### PR TITLE
fix: prefix classes with ONVIF

### DIFF
--- a/docs/classes/_api_advancedsecurity_.onvifadvancedsecurity.md
+++ b/docs/classes/_api_advancedsecurity_.onvifadvancedsecurity.md
@@ -1,119 +1,119 @@
-[onvif-rx](../README.md) > ["api/advancedsecurity"](../modules/_api_advancedsecurity_.md) > [AdvancedSecurity](../classes/_api_advancedsecurity_.advancedsecurity.md)
+[onvif-rx](../README.md) > ["api/advancedsecurity"](../modules/_api_advancedsecurity_.md) > [ONVIFAdvancedSecurity](../classes/_api_advancedsecurity_.onvifadvancedsecurity.md)
 
-# Class: AdvancedSecurity
+# Class: ONVIFAdvancedSecurity
 
 ## Hierarchy
 
-**AdvancedSecurity**
+**ONVIFAdvancedSecurity**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_advancedsecurity_.advancedsecurity.md#constructor)
+* [constructor](_api_advancedsecurity_.onvifadvancedsecurity.md#constructor)
 
 ### Properties
 
-* [config](_api_advancedsecurity_.advancedsecurity.md#config)
+* [config](_api_advancedsecurity_.onvifadvancedsecurity.md#config)
 
 ### Methods
 
-* [AddCertPathValidationPolicyAssignment](_api_advancedsecurity_.advancedsecurity.md#addcertpathvalidationpolicyassignment)
-* [AddDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#adddot1xconfiguration)
-* [AddServerCertificateAssignment](_api_advancedsecurity_.advancedsecurity.md#addservercertificateassignment)
-* [CreateCertPathValidationPolicy](_api_advancedsecurity_.advancedsecurity.md#createcertpathvalidationpolicy)
-* [CreateCertificationPath](_api_advancedsecurity_.advancedsecurity.md#createcertificationpath)
-* [CreatePKCS10CSR](_api_advancedsecurity_.advancedsecurity.md#createpkcs10csr)
-* [CreateRSAKeyPair](_api_advancedsecurity_.advancedsecurity.md#creatersakeypair)
-* [CreateSelfSignedCertificate](_api_advancedsecurity_.advancedsecurity.md#createselfsignedcertificate)
-* [DeleteCRL](_api_advancedsecurity_.advancedsecurity.md#deletecrl)
-* [DeleteCertPathValidationPolicy](_api_advancedsecurity_.advancedsecurity.md#deletecertpathvalidationpolicy)
-* [DeleteCertificate](_api_advancedsecurity_.advancedsecurity.md#deletecertificate)
-* [DeleteCertificationPath](_api_advancedsecurity_.advancedsecurity.md#deletecertificationpath)
-* [DeleteDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#deletedot1xconfiguration)
-* [DeleteKey](_api_advancedsecurity_.advancedsecurity.md#deletekey)
-* [DeleteNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#deletenetworkinterfacedot1xconfiguration)
-* [DeletePassphrase](_api_advancedsecurity_.advancedsecurity.md#deletepassphrase)
-* [GetAllCRLs](_api_advancedsecurity_.advancedsecurity.md#getallcrls)
-* [GetAllCertPathValidationPolicies](_api_advancedsecurity_.advancedsecurity.md#getallcertpathvalidationpolicies)
-* [GetAllCertificates](_api_advancedsecurity_.advancedsecurity.md#getallcertificates)
-* [GetAllCertificationPaths](_api_advancedsecurity_.advancedsecurity.md#getallcertificationpaths)
-* [GetAllDot1XConfigurations](_api_advancedsecurity_.advancedsecurity.md#getalldot1xconfigurations)
-* [GetAllKeys](_api_advancedsecurity_.advancedsecurity.md#getallkeys)
-* [GetAllPassphrases](_api_advancedsecurity_.advancedsecurity.md#getallpassphrases)
-* [GetAssignedCertPathValidationPolicies](_api_advancedsecurity_.advancedsecurity.md#getassignedcertpathvalidationpolicies)
-* [GetAssignedServerCertificates](_api_advancedsecurity_.advancedsecurity.md#getassignedservercertificates)
-* [GetCRL](_api_advancedsecurity_.advancedsecurity.md#getcrl)
-* [GetCertPathValidationPolicy](_api_advancedsecurity_.advancedsecurity.md#getcertpathvalidationpolicy)
-* [GetCertificate](_api_advancedsecurity_.advancedsecurity.md#getcertificate)
-* [GetCertificationPath](_api_advancedsecurity_.advancedsecurity.md#getcertificationpath)
-* [GetClientAuthenticationRequired](_api_advancedsecurity_.advancedsecurity.md#getclientauthenticationrequired)
-* [GetDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#getdot1xconfiguration)
-* [GetEnabledTLSVersions](_api_advancedsecurity_.advancedsecurity.md#getenabledtlsversions)
-* [GetKeyStatus](_api_advancedsecurity_.advancedsecurity.md#getkeystatus)
-* [GetNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#getnetworkinterfacedot1xconfiguration)
-* [GetPrivateKeyStatus](_api_advancedsecurity_.advancedsecurity.md#getprivatekeystatus)
-* [GetServiceCapabilities](_api_advancedsecurity_.advancedsecurity.md#getservicecapabilities)
-* [RemoveCertPathValidationPolicyAssignment](_api_advancedsecurity_.advancedsecurity.md#removecertpathvalidationpolicyassignment)
-* [RemoveServerCertificateAssignment](_api_advancedsecurity_.advancedsecurity.md#removeservercertificateassignment)
-* [ReplaceCertPathValidationPolicyAssignment](_api_advancedsecurity_.advancedsecurity.md#replacecertpathvalidationpolicyassignment)
-* [ReplaceServerCertificateAssignment](_api_advancedsecurity_.advancedsecurity.md#replaceservercertificateassignment)
-* [SetClientAuthenticationRequired](_api_advancedsecurity_.advancedsecurity.md#setclientauthenticationrequired)
-* [SetEnabledTLSVersions](_api_advancedsecurity_.advancedsecurity.md#setenabledtlsversions)
-* [SetNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#setnetworkinterfacedot1xconfiguration)
-* [UploadCRL](_api_advancedsecurity_.advancedsecurity.md#uploadcrl)
-* [UploadCertificate](_api_advancedsecurity_.advancedsecurity.md#uploadcertificate)
-* [UploadCertificateWithPrivateKeyInPKCS12](_api_advancedsecurity_.advancedsecurity.md#uploadcertificatewithprivatekeyinpkcs12)
-* [UploadKeyPairInPKCS8](_api_advancedsecurity_.advancedsecurity.md#uploadkeypairinpkcs8)
-* [UploadPassphrase](_api_advancedsecurity_.advancedsecurity.md#uploadpassphrase)
-* [AddCertPathValidationPolicyAssignment](_api_advancedsecurity_.advancedsecurity.md#addcertpathvalidationpolicyassignment-1)
-* [AddDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#adddot1xconfiguration-1)
-* [AddServerCertificateAssignment](_api_advancedsecurity_.advancedsecurity.md#addservercertificateassignment-1)
-* [CreateCertPathValidationPolicy](_api_advancedsecurity_.advancedsecurity.md#createcertpathvalidationpolicy-1)
-* [CreateCertificationPath](_api_advancedsecurity_.advancedsecurity.md#createcertificationpath-1)
-* [CreatePKCS10CSR](_api_advancedsecurity_.advancedsecurity.md#createpkcs10csr-1)
-* [CreateRSAKeyPair](_api_advancedsecurity_.advancedsecurity.md#creatersakeypair-1)
-* [CreateSelfSignedCertificate](_api_advancedsecurity_.advancedsecurity.md#createselfsignedcertificate-1)
-* [DeleteCRL](_api_advancedsecurity_.advancedsecurity.md#deletecrl-1)
-* [DeleteCertPathValidationPolicy](_api_advancedsecurity_.advancedsecurity.md#deletecertpathvalidationpolicy-1)
-* [DeleteCertificate](_api_advancedsecurity_.advancedsecurity.md#deletecertificate-1)
-* [DeleteCertificationPath](_api_advancedsecurity_.advancedsecurity.md#deletecertificationpath-1)
-* [DeleteDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#deletedot1xconfiguration-1)
-* [DeleteKey](_api_advancedsecurity_.advancedsecurity.md#deletekey-1)
-* [DeleteNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#deletenetworkinterfacedot1xconfiguration-1)
-* [DeletePassphrase](_api_advancedsecurity_.advancedsecurity.md#deletepassphrase-1)
-* [GetAllCRLs](_api_advancedsecurity_.advancedsecurity.md#getallcrls-1)
-* [GetAllCertPathValidationPolicies](_api_advancedsecurity_.advancedsecurity.md#getallcertpathvalidationpolicies-1)
-* [GetAllCertificates](_api_advancedsecurity_.advancedsecurity.md#getallcertificates-1)
-* [GetAllCertificationPaths](_api_advancedsecurity_.advancedsecurity.md#getallcertificationpaths-1)
-* [GetAllDot1XConfigurations](_api_advancedsecurity_.advancedsecurity.md#getalldot1xconfigurations-1)
-* [GetAllKeys](_api_advancedsecurity_.advancedsecurity.md#getallkeys-1)
-* [GetAllPassphrases](_api_advancedsecurity_.advancedsecurity.md#getallpassphrases-1)
-* [GetAssignedCertPathValidationPolicies](_api_advancedsecurity_.advancedsecurity.md#getassignedcertpathvalidationpolicies-1)
-* [GetAssignedServerCertificates](_api_advancedsecurity_.advancedsecurity.md#getassignedservercertificates-1)
-* [GetCRL](_api_advancedsecurity_.advancedsecurity.md#getcrl-1)
-* [GetCertPathValidationPolicy](_api_advancedsecurity_.advancedsecurity.md#getcertpathvalidationpolicy-1)
-* [GetCertificate](_api_advancedsecurity_.advancedsecurity.md#getcertificate-1)
-* [GetCertificationPath](_api_advancedsecurity_.advancedsecurity.md#getcertificationpath-1)
-* [GetClientAuthenticationRequired](_api_advancedsecurity_.advancedsecurity.md#getclientauthenticationrequired-1)
-* [GetDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#getdot1xconfiguration-1)
-* [GetEnabledTLSVersions](_api_advancedsecurity_.advancedsecurity.md#getenabledtlsversions-1)
-* [GetKeyStatus](_api_advancedsecurity_.advancedsecurity.md#getkeystatus-1)
-* [GetNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#getnetworkinterfacedot1xconfiguration-1)
-* [GetPrivateKeyStatus](_api_advancedsecurity_.advancedsecurity.md#getprivatekeystatus-1)
-* [GetServiceCapabilities](_api_advancedsecurity_.advancedsecurity.md#getservicecapabilities-1)
-* [RemoveCertPathValidationPolicyAssignment](_api_advancedsecurity_.advancedsecurity.md#removecertpathvalidationpolicyassignment-1)
-* [RemoveServerCertificateAssignment](_api_advancedsecurity_.advancedsecurity.md#removeservercertificateassignment-1)
-* [ReplaceCertPathValidationPolicyAssignment](_api_advancedsecurity_.advancedsecurity.md#replacecertpathvalidationpolicyassignment-1)
-* [ReplaceServerCertificateAssignment](_api_advancedsecurity_.advancedsecurity.md#replaceservercertificateassignment-1)
-* [SetClientAuthenticationRequired](_api_advancedsecurity_.advancedsecurity.md#setclientauthenticationrequired-1)
-* [SetEnabledTLSVersions](_api_advancedsecurity_.advancedsecurity.md#setenabledtlsversions-1)
-* [SetNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.advancedsecurity.md#setnetworkinterfacedot1xconfiguration-1)
-* [UploadCRL](_api_advancedsecurity_.advancedsecurity.md#uploadcrl-1)
-* [UploadCertificate](_api_advancedsecurity_.advancedsecurity.md#uploadcertificate-1)
-* [UploadCertificateWithPrivateKeyInPKCS12](_api_advancedsecurity_.advancedsecurity.md#uploadcertificatewithprivatekeyinpkcs12-1)
-* [UploadKeyPairInPKCS8](_api_advancedsecurity_.advancedsecurity.md#uploadkeypairinpkcs8-1)
-* [UploadPassphrase](_api_advancedsecurity_.advancedsecurity.md#uploadpassphrase-1)
+* [AddCertPathValidationPolicyAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#addcertpathvalidationpolicyassignment)
+* [AddDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#adddot1xconfiguration)
+* [AddServerCertificateAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#addservercertificateassignment)
+* [CreateCertPathValidationPolicy](_api_advancedsecurity_.onvifadvancedsecurity.md#createcertpathvalidationpolicy)
+* [CreateCertificationPath](_api_advancedsecurity_.onvifadvancedsecurity.md#createcertificationpath)
+* [CreatePKCS10CSR](_api_advancedsecurity_.onvifadvancedsecurity.md#createpkcs10csr)
+* [CreateRSAKeyPair](_api_advancedsecurity_.onvifadvancedsecurity.md#creatersakeypair)
+* [CreateSelfSignedCertificate](_api_advancedsecurity_.onvifadvancedsecurity.md#createselfsignedcertificate)
+* [DeleteCRL](_api_advancedsecurity_.onvifadvancedsecurity.md#deletecrl)
+* [DeleteCertPathValidationPolicy](_api_advancedsecurity_.onvifadvancedsecurity.md#deletecertpathvalidationpolicy)
+* [DeleteCertificate](_api_advancedsecurity_.onvifadvancedsecurity.md#deletecertificate)
+* [DeleteCertificationPath](_api_advancedsecurity_.onvifadvancedsecurity.md#deletecertificationpath)
+* [DeleteDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#deletedot1xconfiguration)
+* [DeleteKey](_api_advancedsecurity_.onvifadvancedsecurity.md#deletekey)
+* [DeleteNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#deletenetworkinterfacedot1xconfiguration)
+* [DeletePassphrase](_api_advancedsecurity_.onvifadvancedsecurity.md#deletepassphrase)
+* [GetAllCRLs](_api_advancedsecurity_.onvifadvancedsecurity.md#getallcrls)
+* [GetAllCertPathValidationPolicies](_api_advancedsecurity_.onvifadvancedsecurity.md#getallcertpathvalidationpolicies)
+* [GetAllCertificates](_api_advancedsecurity_.onvifadvancedsecurity.md#getallcertificates)
+* [GetAllCertificationPaths](_api_advancedsecurity_.onvifadvancedsecurity.md#getallcertificationpaths)
+* [GetAllDot1XConfigurations](_api_advancedsecurity_.onvifadvancedsecurity.md#getalldot1xconfigurations)
+* [GetAllKeys](_api_advancedsecurity_.onvifadvancedsecurity.md#getallkeys)
+* [GetAllPassphrases](_api_advancedsecurity_.onvifadvancedsecurity.md#getallpassphrases)
+* [GetAssignedCertPathValidationPolicies](_api_advancedsecurity_.onvifadvancedsecurity.md#getassignedcertpathvalidationpolicies)
+* [GetAssignedServerCertificates](_api_advancedsecurity_.onvifadvancedsecurity.md#getassignedservercertificates)
+* [GetCRL](_api_advancedsecurity_.onvifadvancedsecurity.md#getcrl)
+* [GetCertPathValidationPolicy](_api_advancedsecurity_.onvifadvancedsecurity.md#getcertpathvalidationpolicy)
+* [GetCertificate](_api_advancedsecurity_.onvifadvancedsecurity.md#getcertificate)
+* [GetCertificationPath](_api_advancedsecurity_.onvifadvancedsecurity.md#getcertificationpath)
+* [GetClientAuthenticationRequired](_api_advancedsecurity_.onvifadvancedsecurity.md#getclientauthenticationrequired)
+* [GetDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#getdot1xconfiguration)
+* [GetEnabledTLSVersions](_api_advancedsecurity_.onvifadvancedsecurity.md#getenabledtlsversions)
+* [GetKeyStatus](_api_advancedsecurity_.onvifadvancedsecurity.md#getkeystatus)
+* [GetNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#getnetworkinterfacedot1xconfiguration)
+* [GetPrivateKeyStatus](_api_advancedsecurity_.onvifadvancedsecurity.md#getprivatekeystatus)
+* [GetServiceCapabilities](_api_advancedsecurity_.onvifadvancedsecurity.md#getservicecapabilities)
+* [RemoveCertPathValidationPolicyAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#removecertpathvalidationpolicyassignment)
+* [RemoveServerCertificateAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#removeservercertificateassignment)
+* [ReplaceCertPathValidationPolicyAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#replacecertpathvalidationpolicyassignment)
+* [ReplaceServerCertificateAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#replaceservercertificateassignment)
+* [SetClientAuthenticationRequired](_api_advancedsecurity_.onvifadvancedsecurity.md#setclientauthenticationrequired)
+* [SetEnabledTLSVersions](_api_advancedsecurity_.onvifadvancedsecurity.md#setenabledtlsversions)
+* [SetNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#setnetworkinterfacedot1xconfiguration)
+* [UploadCRL](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadcrl)
+* [UploadCertificate](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadcertificate)
+* [UploadCertificateWithPrivateKeyInPKCS12](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadcertificatewithprivatekeyinpkcs12)
+* [UploadKeyPairInPKCS8](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadkeypairinpkcs8)
+* [UploadPassphrase](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadpassphrase)
+* [AddCertPathValidationPolicyAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#addcertpathvalidationpolicyassignment-1)
+* [AddDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#adddot1xconfiguration-1)
+* [AddServerCertificateAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#addservercertificateassignment-1)
+* [CreateCertPathValidationPolicy](_api_advancedsecurity_.onvifadvancedsecurity.md#createcertpathvalidationpolicy-1)
+* [CreateCertificationPath](_api_advancedsecurity_.onvifadvancedsecurity.md#createcertificationpath-1)
+* [CreatePKCS10CSR](_api_advancedsecurity_.onvifadvancedsecurity.md#createpkcs10csr-1)
+* [CreateRSAKeyPair](_api_advancedsecurity_.onvifadvancedsecurity.md#creatersakeypair-1)
+* [CreateSelfSignedCertificate](_api_advancedsecurity_.onvifadvancedsecurity.md#createselfsignedcertificate-1)
+* [DeleteCRL](_api_advancedsecurity_.onvifadvancedsecurity.md#deletecrl-1)
+* [DeleteCertPathValidationPolicy](_api_advancedsecurity_.onvifadvancedsecurity.md#deletecertpathvalidationpolicy-1)
+* [DeleteCertificate](_api_advancedsecurity_.onvifadvancedsecurity.md#deletecertificate-1)
+* [DeleteCertificationPath](_api_advancedsecurity_.onvifadvancedsecurity.md#deletecertificationpath-1)
+* [DeleteDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#deletedot1xconfiguration-1)
+* [DeleteKey](_api_advancedsecurity_.onvifadvancedsecurity.md#deletekey-1)
+* [DeleteNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#deletenetworkinterfacedot1xconfiguration-1)
+* [DeletePassphrase](_api_advancedsecurity_.onvifadvancedsecurity.md#deletepassphrase-1)
+* [GetAllCRLs](_api_advancedsecurity_.onvifadvancedsecurity.md#getallcrls-1)
+* [GetAllCertPathValidationPolicies](_api_advancedsecurity_.onvifadvancedsecurity.md#getallcertpathvalidationpolicies-1)
+* [GetAllCertificates](_api_advancedsecurity_.onvifadvancedsecurity.md#getallcertificates-1)
+* [GetAllCertificationPaths](_api_advancedsecurity_.onvifadvancedsecurity.md#getallcertificationpaths-1)
+* [GetAllDot1XConfigurations](_api_advancedsecurity_.onvifadvancedsecurity.md#getalldot1xconfigurations-1)
+* [GetAllKeys](_api_advancedsecurity_.onvifadvancedsecurity.md#getallkeys-1)
+* [GetAllPassphrases](_api_advancedsecurity_.onvifadvancedsecurity.md#getallpassphrases-1)
+* [GetAssignedCertPathValidationPolicies](_api_advancedsecurity_.onvifadvancedsecurity.md#getassignedcertpathvalidationpolicies-1)
+* [GetAssignedServerCertificates](_api_advancedsecurity_.onvifadvancedsecurity.md#getassignedservercertificates-1)
+* [GetCRL](_api_advancedsecurity_.onvifadvancedsecurity.md#getcrl-1)
+* [GetCertPathValidationPolicy](_api_advancedsecurity_.onvifadvancedsecurity.md#getcertpathvalidationpolicy-1)
+* [GetCertificate](_api_advancedsecurity_.onvifadvancedsecurity.md#getcertificate-1)
+* [GetCertificationPath](_api_advancedsecurity_.onvifadvancedsecurity.md#getcertificationpath-1)
+* [GetClientAuthenticationRequired](_api_advancedsecurity_.onvifadvancedsecurity.md#getclientauthenticationrequired-1)
+* [GetDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#getdot1xconfiguration-1)
+* [GetEnabledTLSVersions](_api_advancedsecurity_.onvifadvancedsecurity.md#getenabledtlsversions-1)
+* [GetKeyStatus](_api_advancedsecurity_.onvifadvancedsecurity.md#getkeystatus-1)
+* [GetNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#getnetworkinterfacedot1xconfiguration-1)
+* [GetPrivateKeyStatus](_api_advancedsecurity_.onvifadvancedsecurity.md#getprivatekeystatus-1)
+* [GetServiceCapabilities](_api_advancedsecurity_.onvifadvancedsecurity.md#getservicecapabilities-1)
+* [RemoveCertPathValidationPolicyAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#removecertpathvalidationpolicyassignment-1)
+* [RemoveServerCertificateAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#removeservercertificateassignment-1)
+* [ReplaceCertPathValidationPolicyAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#replacecertpathvalidationpolicyassignment-1)
+* [ReplaceServerCertificateAssignment](_api_advancedsecurity_.onvifadvancedsecurity.md#replaceservercertificateassignment-1)
+* [SetClientAuthenticationRequired](_api_advancedsecurity_.onvifadvancedsecurity.md#setclientauthenticationrequired-1)
+* [SetEnabledTLSVersions](_api_advancedsecurity_.onvifadvancedsecurity.md#setenabledtlsversions-1)
+* [SetNetworkInterfaceDot1XConfiguration](_api_advancedsecurity_.onvifadvancedsecurity.md#setnetworkinterfacedot1xconfiguration-1)
+* [UploadCRL](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadcrl-1)
+* [UploadCertificate](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadcertificate-1)
+* [UploadCertificateWithPrivateKeyInPKCS12](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadcertificatewithprivatekeyinpkcs12-1)
+* [UploadKeyPairInPKCS8](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadkeypairinpkcs8-1)
+* [UploadPassphrase](_api_advancedsecurity_.onvifadvancedsecurity.md#uploadpassphrase-1)
 
 ---
 
@@ -123,9 +123,9 @@
 
 ###  constructor
 
-⊕ **new AdvancedSecurity**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [AdvancedSecurity](_api_advancedsecurity_.advancedsecurity.md)
+⊕ **new ONVIFAdvancedSecurity**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFAdvancedSecurity](_api_advancedsecurity_.onvifadvancedsecurity.md)
 
-*Defined in [api/advancedsecurity.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L5)*
+*Defined in [api/advancedsecurity.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L5)*
 
 **Parameters:**
 
@@ -133,7 +133,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [AdvancedSecurity](_api_advancedsecurity_.advancedsecurity.md)
+**Returns:** [ONVIFAdvancedSecurity](_api_advancedsecurity_.onvifadvancedsecurity.md)
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/advancedsecurity.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L6)*
+*Defined in [api/advancedsecurity.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L6)*
 
 ___
 
@@ -157,7 +157,7 @@ ___
 
 ▸ **AddCertPathValidationPolicyAssignment**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1234](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1234)*
+*Defined in [api/advancedsecurity.ts:1234](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1234)*
 
 ```
       This operation assigns a certification path validation policy to the TLS server on the device. The TLS server shall enforce the policy when authenticating TLS clients and consider a client authentic if and only if the algorithm returns valid.
@@ -174,7 +174,7 @@ ___
 
 ▸ **AddDot1XConfiguration**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1273](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1273)*
+*Defined in [api/advancedsecurity.ts:1273](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1273)*
 
 (to be written)
 
@@ -187,7 +187,7 @@ ___
 
 ▸ **AddServerCertificateAssignment**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1135](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1135)*
+*Defined in [api/advancedsecurity.ts:1135](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1135)*
 
 This operation assigns a key pair and certificate along with a certification path (certificate chain) to the TLS server on the device. The TLS server shall use this information for key exchange during the TLS handshake, particularly for constructing server certificate messages as specified in RFC 4346 and RFC 2246.
 
@@ -202,7 +202,7 @@ ___
 
 ▸ **CreateCertPathValidationPolicy**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1080](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1080)*
+*Defined in [api/advancedsecurity.ts:1080](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1080)*
 
 ```
       This operation creates a certification path validation policy.
@@ -222,7 +222,7 @@ ___
 
 ▸ **CreateCertificationPath**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:955](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L955)*
+*Defined in [api/advancedsecurity.ts:955](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L955)*
 
 This operation creates a sequence of certificates that may be used, e.g., for certification path validation or for TLS server authentication. Certification paths are uniquely identified using certification path IDs. Certificates are uniquely identified using certificate IDs. A certification path contains a sequence of certificate IDs. If there is a certificate ID in the sequence of supplied certificate IDs for which no certificate exists in the device’s keystore, the corresponding fault shall be produced and no certification path shall be created.
 
@@ -237,7 +237,7 @@ ___
 
 ▸ **CreatePKCS10CSR**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:842](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L842)*
+*Defined in [api/advancedsecurity.ts:842](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L842)*
 
 This operation generates a DER-encoded PKCS#10 v1.7 certification request (sometimes also called certificate signing request or CSR) as specified in RFC 2986 for a public key on the device. The key pair that contains the public key for which a certification request shall be produced is specified by its key ID. If no key is stored under the requested KeyID or the key specified by the requested KeyID is not an asymmetric key pair, an invalid key ID fault shall be produced and no CSR shall be generated.
 
@@ -254,7 +254,7 @@ ___
 
 ▸ **CreateRSAKeyPair**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:739](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L739)*
+*Defined in [api/advancedsecurity.ts:739](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L739)*
 
 This operation triggers the asynchronous generation of an RSA key pair of a particular key length (specified as the number of bits) as specified in \[RFC 3447\], with a suitable key generation mechanism on the device. Keys, especially RSA key pairs, are uniquely identified using key IDs. If the device does not have not enough storage capacity for storing the key pair to be created, the maximum number of keys reached fault shall be produced and no key pair shall be generated. Otherwise, the operation generates a keyID for the new key and associates the generating status to it. Immediately after key generation has started, the device shall return the keyID to the client and continue to generate the key pair. The client may query the device with the GetKeyStatus operation whether the generation has finished. The client may also subscribe to Key Status events to be notified about key status changes. The device also returns a best-effort estimate of how much time it requires to create the key pair. A client may use this information as an indication how long to wait before querying the device whether key generation is completed. After the key has been successfully created, the device shall assign it the ok status. If the key generation fails, the device shall assign the key the corrupt status.
 
@@ -267,7 +267,7 @@ ___
 
 ▸ **CreateSelfSignedCertificate**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:865](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L865)*
+*Defined in [api/advancedsecurity.ts:865](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L865)*
 
 This operation generates for a public key on the device a self-signed X.509 certificate that complies to RFC 5280. The X509Version parameter specifies the version of X.509 that the generated certificate shall comply to. A device that supports this command shall support the generation of X.509v3 certificates as specified in RFC 5280 and may additionally be able to handle other X.509 certificate formats as indicated by the X.509Versions capability. The key pair that contains the public key for which a self-signed certificate shall be produced is specified by its key pair ID. The subject parameter describes the entity that the public key belongs to. If the key pair does not have status ok, a device shall produce an InvalidKeyStatus fault and no certificate shall be generated.
 
@@ -284,7 +284,7 @@ ___
 
 ▸ **DeleteCRL**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1066](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1066)*
+*Defined in [api/advancedsecurity.ts:1066](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1066)*
 
 ```
       This operation deletes a certificate revocation list (CRL) from the keystore on the device.
@@ -302,7 +302,7 @@ ___
 
 ▸ **DeleteCertPathValidationPolicy**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1112](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1112)*
+*Defined in [api/advancedsecurity.ts:1112](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1112)*
 
 ```
       This operation deletes a certification path validation policy from the keystore on the device.
@@ -320,7 +320,7 @@ ___
 
 ▸ **DeleteCertificate**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:938](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L938)*
+*Defined in [api/advancedsecurity.ts:938](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L938)*
 
 This operation deletes a certificate from the device’s keystore. The operation shall not delete the public key that is contained in the certificate from the keystore. Certificates are uniquely identified using certificate IDs. If no certificate is stored under the requested certificate ID in the keystore, an InvalidArgVal fault is produced. If there is a certificate under the requested certificate ID stored in the keystore and the certificate could not be deleted, a CertificateDeletion fault is produced. If a reference exists for the specified certificate, the certificate shall not be deleted and the corresponding fault shall be produced. After a certificate has been successfully deleted, the device may assign its former ID to other certificates.
 
@@ -333,7 +333,7 @@ ___
 
 ▸ **DeleteCertificationPath**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:993](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L993)*
+*Defined in [api/advancedsecurity.ts:993](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L993)*
 
 This operation deletes a certification path from the device’s keystore. This operation shall not delete the certificates that are referenced by the certification path. Certification paths are uniquely identified using certification path IDs. If no certification path is stored under the requested certification path ID in the keystore, an InvalidArgVal fault is produced. If there is a certification path under the requested certification path ID stored in the keystore and the certification path could not be deleted, a CertificationPathDeletion fault is produced. If a reference exists for the specified certification path, the certification path shall not be deleted and the corresponding fault shall be produced. After a certification path is successfully deleted, the device may assign its former ID to other certification paths.
 
@@ -346,7 +346,7 @@ ___
 
 ▸ **DeleteDot1XConfiguration**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1300](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1300)*
+*Defined in [api/advancedsecurity.ts:1300](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1300)*
 
 (to be written)
 
@@ -359,7 +359,7 @@ ___
 
 ▸ **DeleteKey**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:822](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L822)*
+*Defined in [api/advancedsecurity.ts:822](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L822)*
 
 This operation deletes a key from the device’s keystore. Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, a device shall produce an InvalidArgVal fault. If a reference exists for the specified key, a device shall produce the corresponding fault and shall not delete the key. If there is a key under the requested key ID stored in the keystore and the key could not be deleted, a device shall produce a KeyDeletion fault. If the key has the status generating, a device shall abort the generation of the key and delete from the keystore all data generated for this key. After a key is successfully deleted, the device may assign its former ID to other keys.
 
@@ -372,7 +372,7 @@ ___
 
 ▸ **DeleteNetworkInterfaceDot1XConfiguration**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1327](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1327)*
+*Defined in [api/advancedsecurity.ts:1327](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1327)*
 
 (to be written)
 
@@ -385,7 +385,7 @@ ___
 
 ▸ **DeletePassphrase**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1022](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1022)*
+*Defined in [api/advancedsecurity.ts:1022](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1022)*
 
 ```
       This operation deletes a passphrase from the keystore of the device.
@@ -400,7 +400,7 @@ ___
 
 ▸ **GetAllCRLs**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1054](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1054)*
+*Defined in [api/advancedsecurity.ts:1054](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1054)*
 
 ```
       This operation returns all certificate revocation lists (CRLs) that are stored in the keystore on the device.
@@ -416,7 +416,7 @@ ___
 
 ▸ **GetAllCertPathValidationPolicies**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1100](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1100)*
+*Defined in [api/advancedsecurity.ts:1100](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1100)*
 
 ```
       This operation returns all certification path validation policies that are stored in the keystore on the device.
@@ -432,7 +432,7 @@ ___
 
 ▸ **GetAllCertificates**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:924](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L924)*
+*Defined in [api/advancedsecurity.ts:924](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L924)*
 
 This operation returns the IDs of all certificates that are stored in the device’s keystore. This operation may be used, e.g., if a client lost track of which certificates are present on the device. If no certificate is stored in the device’s keystore, an empty list is returned.
 
@@ -445,7 +445,7 @@ ___
 
 ▸ **GetAllCertificationPaths**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:977](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L977)*
+*Defined in [api/advancedsecurity.ts:977](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L977)*
 
 This operation returns the IDs of all certification paths that are stored in the device’s keystore. This operation may be used, e.g., if a client lost track of which certificates are present on the device. If no certification path is stored on the device, an empty list is returned.
 
@@ -458,7 +458,7 @@ ___
 
 ▸ **GetAllDot1XConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1282](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1282)*
+*Defined in [api/advancedsecurity.ts:1282](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1282)*
 
 (to be written)
 
@@ -471,7 +471,7 @@ ___
 
 ▸ **GetAllKeys**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:808](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L808)*
+*Defined in [api/advancedsecurity.ts:808](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L808)*
 
 This operation returns information about all keys that are stored in the device’s keystore. This operation may be used, e.g., if a client lost track of which keys are present on the device. If no key is stored on the device, an empty list is returned.
 
@@ -484,7 +484,7 @@ ___
 
 ▸ **GetAllPassphrases**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1013](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1013)*
+*Defined in [api/advancedsecurity.ts:1013](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1013)*
 
 ```
       This operation returns information about all passphrases that are stored in the keystore of the device.
@@ -501,7 +501,7 @@ ___
 
 ▸ **GetAssignedCertPathValidationPolicies**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1264](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1264)*
+*Defined in [api/advancedsecurity.ts:1264](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1264)*
 
 ```
       This operation returns the IDs of all certification path validation policies that are assigned to the TLS server on the device.
@@ -516,7 +516,7 @@ ___
 
 ▸ **GetAssignedServerCertificates**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1202](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1202)*
+*Defined in [api/advancedsecurity.ts:1202](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1202)*
 
 This operation returns the IDs of all key pairs and certificates (including certification paths) that are assigned to the TLS server on the device. This operation may be used, e.g., if a client lost track of the certification path assignments on the device. If no certification path is assigned to the TLS server, an empty list is returned.
 
@@ -529,7 +529,7 @@ ___
 
 ▸ **GetCRL**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1044](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1044)*
+*Defined in [api/advancedsecurity.ts:1044](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1044)*
 
 ```
       This operation returns a specific certificate revocation list (CRL) from the keystore on the device.
@@ -545,7 +545,7 @@ ___
 
 ▸ **GetCertPathValidationPolicy**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1090](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1090)*
+*Defined in [api/advancedsecurity.ts:1090](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1090)*
 
 ```
       This operation returns a certification path validation policy from the keystore on the device.
@@ -561,7 +561,7 @@ ___
 
 ▸ **GetCertificate**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:913](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L913)*
+*Defined in [api/advancedsecurity.ts:913](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L913)*
 
 This operation returns a specific certificate from the device’s keystore. Certificates are uniquely identified using certificate IDs. If no certificate is stored under the requested certificate ID in the keystore, an InvalidArgVal fault is produced. It shall be noted that this command does not return the private key that is associated to the public key in the certificate.
 
@@ -574,7 +574,7 @@ ___
 
 ▸ **GetCertificationPath**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:966](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L966)*
+*Defined in [api/advancedsecurity.ts:966](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L966)*
 
 This operation returns a specific certification path from the device’s keystore. Certification paths are uniquely identified using certification path IDs. If no certification path is stored under the requested ID in the keystore, an InvalidArgVal fault is produced.
 
@@ -587,7 +587,7 @@ ___
 
 ▸ **GetClientAuthenticationRequired**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1223](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1223)*
+*Defined in [api/advancedsecurity.ts:1223](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1223)*
 
 ```
       This operation returns whether TLS client authentication is active.
@@ -602,7 +602,7 @@ ___
 
 ▸ **GetDot1XConfiguration**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1291](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1291)*
+*Defined in [api/advancedsecurity.ts:1291](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1291)*
 
 (to be written)
 
@@ -615,7 +615,7 @@ ___
 
 ▸ **GetEnabledTLSVersions**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1191](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1191)*
+*Defined in [api/advancedsecurity.ts:1191](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1191)*
 
 This operation retrieves the version(s) of TLS which are currently enabled on the device.
 
@@ -628,7 +628,7 @@ ___
 
 ▸ **GetKeyStatus**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:785](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L785)*
+*Defined in [api/advancedsecurity.ts:785](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L785)*
 
 This operation returns the status of a key. Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, an InvalidKeyID fault is produced. Otherwise, the status of the key is returned.
 
@@ -641,7 +641,7 @@ ___
 
 ▸ **GetNetworkInterfaceDot1XConfiguration**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1318](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1318)*
+*Defined in [api/advancedsecurity.ts:1318](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1318)*
 
 (to be written)
 
@@ -654,7 +654,7 @@ ___
 
 ▸ **GetPrivateKeyStatus**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:797](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L797)*
+*Defined in [api/advancedsecurity.ts:797](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L797)*
 
 This operation returns whether a key pair contains a private key. Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore or the key identified by the requested key ID does not identify a key pair, the device shall produce an InvalidKeyID fault. Otherwise, this operation returns true if the key pair identified by the key ID contains a private key, and false otherwise.
 
@@ -667,7 +667,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:721](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L721)*
+*Defined in [api/advancedsecurity.ts:721](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L721)*
 
 Returns the capabilities of the security configuraiton service. The result is returned in a typed answer.
 
@@ -680,7 +680,7 @@ ___
 
 ▸ **RemoveCertPathValidationPolicyAssignment**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1244](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1244)*
+*Defined in [api/advancedsecurity.ts:1244](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1244)*
 
 ```
       This operation removes a certification path validation policy assignment from the TLS server on the device.
@@ -696,7 +696,7 @@ ___
 
 ▸ **RemoveServerCertificateAssignment**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1145](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1145)*
+*Defined in [api/advancedsecurity.ts:1145](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1145)*
 
 This operation removes a key pair and certificate assignment (including certification path) to the TLS server on the device. Certification paths are identified using certification path IDs. If the supplied certification path ID is not associated to the TLS server, an InvalidArgVal fault is produced.
 
@@ -709,7 +709,7 @@ ___
 
 ▸ **ReplaceCertPathValidationPolicyAssignment**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1255](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1255)*
+*Defined in [api/advancedsecurity.ts:1255](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1255)*
 
 ```
       This operation replaces a certification path validation policy assignment to the TLS server on the device with another certification path validation policy assignment.
@@ -726,7 +726,7 @@ ___
 
 ▸ **ReplaceServerCertificateAssignment**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1169](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1169)*
+*Defined in [api/advancedsecurity.ts:1169](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1169)*
 
 This operation replaces an existing key pair and certificate assignment to the TLS server on the device by a new key pair and certificate assignment (including certification paths).
 
@@ -743,7 +743,7 @@ ___
 
 ▸ **SetClientAuthenticationRequired**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1214](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1214)*
+*Defined in [api/advancedsecurity.ts:1214](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1214)*
 
 ```
       This operation activates or deactivates TLS client authentication for the TLS server on the device.
@@ -761,7 +761,7 @@ ___
 
 ▸ **SetEnabledTLSVersions**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1182](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1182)*
+*Defined in [api/advancedsecurity.ts:1182](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1182)*
 
 This operation sets the version(s) of TLS which the device shall use. Valid values are taken from the TLSServerSupported capability. A client initiates a TLS session by sending a ClientHello with the hightest TLS version it supports. This suggests to the server that the client can accept any TLS version up to and including that version. The server then chooses the TLS version to use. This is generally the highest TLS version the server supports that is within the range of the client. For example, if a ClientHello indicates TLS version 1.1, the server can proceed with TLS 1.0 or TLS 1.1. In the event that an ONVIF installation wishes to disable certain version(s) of TLS, it may do so with this operation. For example, to disable TLS 1.0 on a device signaling support for TLS versions 1.0, 1.1, and 1.2, the enabled version list may be set to "1.1 1.2", omitting 1.0. If a client then attempts to connect with a ClientHello containing TLS 1.0, the server shall send a "protocol\_version" alert message and close the connection. This handshake indicates to the client that TLS 1.0 is not supported by the server. The client must try again with a higher TLS version suggestion. An empty list is not permitted. Disabling all versions of TLS is not the intent of this operation. See AddServerCertificateAssignment and RemoveServerCertificateAssignment.
 
@@ -774,7 +774,7 @@ ___
 
 ▸ **SetNetworkInterfaceDot1XConfiguration**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1309](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1309)*
+*Defined in [api/advancedsecurity.ts:1309](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1309)*
 
 (to be written)
 
@@ -787,7 +787,7 @@ ___
 
 ▸ **UploadCRL**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1034](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1034)*
+*Defined in [api/advancedsecurity.ts:1034](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1034)*
 
 ```
       This operation uploads a certificate revocation list (CRL) as specified in [RFC 5280] to the keystore on the device.
@@ -805,7 +805,7 @@ ___
 
 ▸ **UploadCertificate**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:902](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L902)*
+*Defined in [api/advancedsecurity.ts:902](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L902)*
 
 This operation uploads an X.509 certificate as specified by \[RFC 5280\] in DER encoding and the public key in the certificate to a device’s keystore. A device that supports this command shall be able to handle X.509v3 certificates as specified in RFC 5280 and may additionally be able to handle other X.509 certificate formats as indicated by the X.509Versions capability. A device that supports this command shall support sha1-WithRSAEncryption as certificate signature algorithm.
 
@@ -824,7 +824,7 @@ ___
 
 ▸ **UploadCertificateWithPrivateKeyInPKCS12**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:774](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L774)*
+*Defined in [api/advancedsecurity.ts:774](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L774)*
 
 ```
       This operation uploads a certification path consisting of X.509 certificates as specified by [RFC 5280] in DER encoding along with a private key to a device’s keystore.
@@ -852,7 +852,7 @@ ___
 
 ▸ **UploadKeyPairInPKCS8**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:752](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L752)*
+*Defined in [api/advancedsecurity.ts:752](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L752)*
 
 ```
       This operation uploads a key pair in a PKCS#8 data structure as specified in [RFC 5958, RFC 5959].
@@ -871,7 +871,7 @@ ___
 
 ▸ **UploadPassphrase**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/advancedsecurity.ts:1002](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L1002)*
+*Defined in [api/advancedsecurity.ts:1002](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L1002)*
 
 ```
       This operation uploads a passphrase to the keystore of the device.
@@ -886,7 +886,7 @@ ___
 
 ▸ **AddCertPathValidationPolicyAssignment**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:599](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L599)*
+*Defined in [api/advancedsecurity.ts:599](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L599)*
 
 ```
       This operation assigns a certification path validation policy to the TLS server on the device. The TLS server shall enforce the policy when authenticating TLS clients and consider a client authentic if and only if the algorithm returns valid.
@@ -903,7 +903,7 @@ ___
 
 ▸ **AddDot1XConfiguration**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:646](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L646)*
+*Defined in [api/advancedsecurity.ts:646](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L646)*
 
 (to be written)
 
@@ -916,7 +916,7 @@ ___
 
 ▸ **AddServerCertificateAssignment**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:484](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L484)*
+*Defined in [api/advancedsecurity.ts:484](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L484)*
 
 This operation assigns a key pair and certificate along with a certification path (certificate chain) to the TLS server on the device. The TLS server shall use this information for key exchange during the TLS handshake, particularly for constructing server certificate messages as specified in RFC 4346 and RFC 2246.
 
@@ -931,7 +931,7 @@ ___
 
 ▸ **CreateCertPathValidationPolicy**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:421](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L421)*
+*Defined in [api/advancedsecurity.ts:421](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L421)*
 
 ```
       This operation creates a certification path validation policy.
@@ -951,7 +951,7 @@ ___
 
 ▸ **CreateCertificationPath**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:274](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L274)*
+*Defined in [api/advancedsecurity.ts:274](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L274)*
 
 This operation creates a sequence of certificates that may be used, e.g., for certification path validation or for TLS server authentication. Certification paths are uniquely identified using certification path IDs. Certificates are uniquely identified using certificate IDs. A certification path contains a sequence of certificate IDs. If there is a certificate ID in the sequence of supplied certificate IDs for which no certificate exists in the device’s keystore, the corresponding fault shall be produced and no certification path shall be created.
 
@@ -966,7 +966,7 @@ ___
 
 ▸ **CreatePKCS10CSR**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:149](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L149)*
+*Defined in [api/advancedsecurity.ts:149](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L149)*
 
 This operation generates a DER-encoded PKCS#10 v1.7 certification request (sometimes also called certificate signing request or CSR) as specified in RFC 2986 for a public key on the device. The key pair that contains the public key for which a certification request shall be produced is specified by its key ID. If no key is stored under the requested KeyID or the key specified by the requested KeyID is not an asymmetric key pair, an invalid key ID fault shall be produced and no CSR shall be generated.
 
@@ -983,7 +983,7 @@ ___
 
 ▸ **CreateRSAKeyPair**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:32](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L32)*
+*Defined in [api/advancedsecurity.ts:32](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L32)*
 
 This operation triggers the asynchronous generation of an RSA key pair of a particular key length (specified as the number of bits) as specified in \[RFC 3447\], with a suitable key generation mechanism on the device. Keys, especially RSA key pairs, are uniquely identified using key IDs. If the device does not have not enough storage capacity for storing the key pair to be created, the maximum number of keys reached fault shall be produced and no key pair shall be generated. Otherwise, the operation generates a keyID for the new key and associates the generating status to it. Immediately after key generation has started, the device shall return the keyID to the client and continue to generate the key pair. The client may query the device with the GetKeyStatus operation whether the generation has finished. The client may also subscribe to Key Status events to be notified about key status changes. The device also returns a best-effort estimate of how much time it requires to create the key pair. A client may use this information as an indication how long to wait before querying the device whether key generation is completed. After the key has been successfully created, the device shall assign it the ok status. If the key generation fails, the device shall assign the key the corrupt status.
 
@@ -996,7 +996,7 @@ ___
 
 ▸ **CreateSelfSignedCertificate**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:174](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L174)*
+*Defined in [api/advancedsecurity.ts:174](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L174)*
 
 This operation generates for a public key on the device a self-signed X.509 certificate that complies to RFC 5280. The X509Version parameter specifies the version of X.509 that the generated certificate shall comply to. A device that supports this command shall support the generation of X.509v3 certificates as specified in RFC 5280 and may additionally be able to handle other X.509 certificate formats as indicated by the X.509Versions capability. The key pair that contains the public key for which a self-signed certificate shall be produced is specified by its key pair ID. The subject parameter describes the entity that the public key belongs to. If the key pair does not have status ok, a device shall produce an InvalidKeyStatus fault and no certificate shall be generated.
 
@@ -1013,7 +1013,7 @@ ___
 
 ▸ **DeleteCRL**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:405](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L405)*
+*Defined in [api/advancedsecurity.ts:405](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L405)*
 
 ```
       This operation deletes a certificate revocation list (CRL) from the keystore on the device.
@@ -1031,7 +1031,7 @@ ___
 
 ▸ **DeleteCertPathValidationPolicy**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:459](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L459)*
+*Defined in [api/advancedsecurity.ts:459](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L459)*
 
 ```
       This operation deletes a certification path validation policy from the keystore on the device.
@@ -1049,7 +1049,7 @@ ___
 
 ▸ **DeleteCertificate**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:255](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L255)*
+*Defined in [api/advancedsecurity.ts:255](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L255)*
 
 This operation deletes a certificate from the device’s keystore. The operation shall not delete the public key that is contained in the certificate from the keystore. Certificates are uniquely identified using certificate IDs. If no certificate is stored under the requested certificate ID in the keystore, an InvalidArgVal fault is produced. If there is a certificate under the requested certificate ID stored in the keystore and the certificate could not be deleted, a CertificateDeletion fault is produced. If a reference exists for the specified certificate, the certificate shall not be deleted and the corresponding fault shall be produced. After a certificate has been successfully deleted, the device may assign its former ID to other certificates.
 
@@ -1062,7 +1062,7 @@ ___
 
 ▸ **DeleteCertificationPath**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:318](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L318)*
+*Defined in [api/advancedsecurity.ts:318](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L318)*
 
 This operation deletes a certification path from the device’s keystore. This operation shall not delete the certificates that are referenced by the certification path. Certification paths are uniquely identified using certification path IDs. If no certification path is stored under the requested certification path ID in the keystore, an InvalidArgVal fault is produced. If there is a certification path under the requested certification path ID stored in the keystore and the certification path could not be deleted, a CertificationPathDeletion fault is produced. If a reference exists for the specified certification path, the certification path shall not be deleted and the corresponding fault shall be produced. After a certification path is successfully deleted, the device may assign its former ID to other certification paths.
 
@@ -1075,7 +1075,7 @@ ___
 
 ▸ **DeleteDot1XConfiguration**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:679](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L679)*
+*Defined in [api/advancedsecurity.ts:679](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L679)*
 
 (to be written)
 
@@ -1088,7 +1088,7 @@ ___
 
 ▸ **DeleteKey**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:127](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L127)*
+*Defined in [api/advancedsecurity.ts:127](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L127)*
 
 This operation deletes a key from the device’s keystore. Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, a device shall produce an InvalidArgVal fault. If a reference exists for the specified key, a device shall produce the corresponding fault and shall not delete the key. If there is a key under the requested key ID stored in the keystore and the key could not be deleted, a device shall produce a KeyDeletion fault. If the key has the status generating, a device shall abort the generation of the key and delete from the keystore all data generated for this key. After a key is successfully deleted, the device may assign its former ID to other keys.
 
@@ -1101,7 +1101,7 @@ ___
 
 ▸ **DeleteNetworkInterfaceDot1XConfiguration**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:712](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L712)*
+*Defined in [api/advancedsecurity.ts:712](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L712)*
 
 (to be written)
 
@@ -1114,7 +1114,7 @@ ___
 
 ▸ **DeletePassphrase**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:353](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L353)*
+*Defined in [api/advancedsecurity.ts:353](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L353)*
 
 ```
       This operation deletes a passphrase from the keystore of the device.
@@ -1129,7 +1129,7 @@ ___
 
 ▸ **GetAllCRLs**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:391](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L391)*
+*Defined in [api/advancedsecurity.ts:391](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L391)*
 
 ```
       This operation returns all certificate revocation lists (CRLs) that are stored in the keystore on the device.
@@ -1145,7 +1145,7 @@ ___
 
 ▸ **GetAllCertPathValidationPolicies**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:445](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L445)*
+*Defined in [api/advancedsecurity.ts:445](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L445)*
 
 ```
       This operation returns all certification path validation policies that are stored in the keystore on the device.
@@ -1161,7 +1161,7 @@ ___
 
 ▸ **GetAllCertificates**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:239](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L239)*
+*Defined in [api/advancedsecurity.ts:239](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L239)*
 
 This operation returns the IDs of all certificates that are stored in the device’s keystore. This operation may be used, e.g., if a client lost track of which certificates are present on the device. If no certificate is stored in the device’s keystore, an empty list is returned.
 
@@ -1174,7 +1174,7 @@ ___
 
 ▸ **GetAllCertificationPaths**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:300](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L300)*
+*Defined in [api/advancedsecurity.ts:300](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L300)*
 
 This operation returns the IDs of all certification paths that are stored in the device’s keystore. This operation may be used, e.g., if a client lost track of which certificates are present on the device. If no certification path is stored on the device, an empty list is returned.
 
@@ -1187,7 +1187,7 @@ ___
 
 ▸ **GetAllDot1XConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:657](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L657)*
+*Defined in [api/advancedsecurity.ts:657](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L657)*
 
 (to be written)
 
@@ -1200,7 +1200,7 @@ ___
 
 ▸ **GetAllKeys**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:111](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L111)*
+*Defined in [api/advancedsecurity.ts:111](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L111)*
 
 This operation returns information about all keys that are stored in the device’s keystore. This operation may be used, e.g., if a client lost track of which keys are present on the device. If no key is stored on the device, an empty list is returned.
 
@@ -1213,7 +1213,7 @@ ___
 
 ▸ **GetAllPassphrases**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:342](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L342)*
+*Defined in [api/advancedsecurity.ts:342](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L342)*
 
 ```
       This operation returns information about all passphrases that are stored in the keystore of the device.
@@ -1230,7 +1230,7 @@ ___
 
 ▸ **GetAssignedCertPathValidationPolicies**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:635](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L635)*
+*Defined in [api/advancedsecurity.ts:635](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L635)*
 
 ```
       This operation returns the IDs of all certification path validation policies that are assigned to the TLS server on the device.
@@ -1245,7 +1245,7 @@ ___
 
 ▸ **GetAssignedServerCertificates**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:561](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L561)*
+*Defined in [api/advancedsecurity.ts:561](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L561)*
 
 This operation returns the IDs of all key pairs and certificates (including certification paths) that are assigned to the TLS server on the device. This operation may be used, e.g., if a client lost track of the certification path assignments on the device. If no certification path is assigned to the TLS server, an empty list is returned.
 
@@ -1258,7 +1258,7 @@ ___
 
 ▸ **GetCRL**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:379](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L379)*
+*Defined in [api/advancedsecurity.ts:379](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L379)*
 
 ```
       This operation returns a specific certificate revocation list (CRL) from the keystore on the device.
@@ -1274,7 +1274,7 @@ ___
 
 ▸ **GetCertPathValidationPolicy**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:433](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L433)*
+*Defined in [api/advancedsecurity.ts:433](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L433)*
 
 ```
       This operation returns a certification path validation policy from the keystore on the device.
@@ -1290,7 +1290,7 @@ ___
 
 ▸ **GetCertificate**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:226](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L226)*
+*Defined in [api/advancedsecurity.ts:226](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L226)*
 
 This operation returns a specific certificate from the device’s keystore. Certificates are uniquely identified using certificate IDs. If no certificate is stored under the requested certificate ID in the keystore, an InvalidArgVal fault is produced. It shall be noted that this command does not return the private key that is associated to the public key in the certificate.
 
@@ -1303,7 +1303,7 @@ ___
 
 ▸ **GetCertificationPath**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:287](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L287)*
+*Defined in [api/advancedsecurity.ts:287](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L287)*
 
 This operation returns a specific certification path from the device’s keystore. Certification paths are uniquely identified using certification path IDs. If no certification path is stored under the requested ID in the keystore, an InvalidArgVal fault is produced.
 
@@ -1316,7 +1316,7 @@ ___
 
 ▸ **GetClientAuthenticationRequired**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:586](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L586)*
+*Defined in [api/advancedsecurity.ts:586](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L586)*
 
 ```
       This operation returns whether TLS client authentication is active.
@@ -1331,7 +1331,7 @@ ___
 
 ▸ **GetDot1XConfiguration**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:668](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L668)*
+*Defined in [api/advancedsecurity.ts:668](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L668)*
 
 (to be written)
 
@@ -1344,7 +1344,7 @@ ___
 
 ▸ **GetEnabledTLSVersions**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:548](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L548)*
+*Defined in [api/advancedsecurity.ts:548](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L548)*
 
 This operation retrieves the version(s) of TLS which are currently enabled on the device.
 
@@ -1357,7 +1357,7 @@ ___
 
 ▸ **GetKeyStatus**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:84](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L84)*
+*Defined in [api/advancedsecurity.ts:84](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L84)*
 
 This operation returns the status of a key. Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore, an InvalidKeyID fault is produced. Otherwise, the status of the key is returned.
 
@@ -1370,7 +1370,7 @@ ___
 
 ▸ **GetNetworkInterfaceDot1XConfiguration**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:701](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L701)*
+*Defined in [api/advancedsecurity.ts:701](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L701)*
 
 (to be written)
 
@@ -1383,7 +1383,7 @@ ___
 
 ▸ **GetPrivateKeyStatus**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:98](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L98)*
+*Defined in [api/advancedsecurity.ts:98](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L98)*
 
 This operation returns whether a key pair contains a private key. Keys are uniquely identified using key IDs. If no key is stored under the requested key ID in the keystore or the key identified by the requested key ID does not identify a key pair, the device shall produce an InvalidKeyID fault. Otherwise, this operation returns true if the key pair identified by the key ID contains a private key, and false otherwise.
 
@@ -1396,7 +1396,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L12)*
+*Defined in [api/advancedsecurity.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L12)*
 
 Returns the capabilities of the security configuraiton service. The result is returned in a typed answer.
 
@@ -1409,7 +1409,7 @@ ___
 
 ▸ **RemoveCertPathValidationPolicyAssignment**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:611](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L611)*
+*Defined in [api/advancedsecurity.ts:611](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L611)*
 
 ```
       This operation removes a certification path validation policy assignment from the TLS server on the device.
@@ -1425,7 +1425,7 @@ ___
 
 ▸ **RemoveServerCertificateAssignment**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:496](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L496)*
+*Defined in [api/advancedsecurity.ts:496](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L496)*
 
 This operation removes a key pair and certificate assignment (including certification path) to the TLS server on the device. Certification paths are identified using certification path IDs. If the supplied certification path ID is not associated to the TLS server, an InvalidArgVal fault is produced.
 
@@ -1438,7 +1438,7 @@ ___
 
 ▸ **ReplaceCertPathValidationPolicyAssignment**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:624](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L624)*
+*Defined in [api/advancedsecurity.ts:624](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L624)*
 
 ```
       This operation replaces a certification path validation policy assignment to the TLS server on the device with another certification path validation policy assignment.
@@ -1455,7 +1455,7 @@ ___
 
 ▸ **ReplaceServerCertificateAssignment**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:522](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L522)*
+*Defined in [api/advancedsecurity.ts:522](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L522)*
 
 This operation replaces an existing key pair and certificate assignment to the TLS server on the device by a new key pair and certificate assignment (including certification paths).
 
@@ -1472,7 +1472,7 @@ ___
 
 ▸ **SetClientAuthenticationRequired**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:575](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L575)*
+*Defined in [api/advancedsecurity.ts:575](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L575)*
 
 ```
       This operation activates or deactivates TLS client authentication for the TLS server on the device.
@@ -1490,7 +1490,7 @@ ___
 
 ▸ **SetEnabledTLSVersions**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:537](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L537)*
+*Defined in [api/advancedsecurity.ts:537](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L537)*
 
 This operation sets the version(s) of TLS which the device shall use. Valid values are taken from the TLSServerSupported capability. A client initiates a TLS session by sending a ClientHello with the hightest TLS version it supports. This suggests to the server that the client can accept any TLS version up to and including that version. The server then chooses the TLS version to use. This is generally the highest TLS version the server supports that is within the range of the client. For example, if a ClientHello indicates TLS version 1.1, the server can proceed with TLS 1.0 or TLS 1.1. In the event that an ONVIF installation wishes to disable certain version(s) of TLS, it may do so with this operation. For example, to disable TLS 1.0 on a device signaling support for TLS versions 1.0, 1.1, and 1.2, the enabled version list may be set to "1.1 1.2", omitting 1.0. If a client then attempts to connect with a ClientHello containing TLS 1.0, the server shall send a "protocol\_version" alert message and close the connection. This handshake indicates to the client that TLS 1.0 is not supported by the server. The client must try again with a higher TLS version suggestion. An empty list is not permitted. Disabling all versions of TLS is not the intent of this operation. See AddServerCertificateAssignment and RemoveServerCertificateAssignment.
 
@@ -1503,7 +1503,7 @@ ___
 
 ▸ **SetNetworkInterfaceDot1XConfiguration**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:690](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L690)*
+*Defined in [api/advancedsecurity.ts:690](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L690)*
 
 (to be written)
 
@@ -1516,7 +1516,7 @@ ___
 
 ▸ **UploadCRL**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:367](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L367)*
+*Defined in [api/advancedsecurity.ts:367](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L367)*
 
 ```
       This operation uploads a certificate revocation list (CRL) as specified in [RFC 5280] to the keystore on the device.
@@ -1534,7 +1534,7 @@ ___
 
 ▸ **UploadCertificate**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:213](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L213)*
+*Defined in [api/advancedsecurity.ts:213](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L213)*
 
 This operation uploads an X.509 certificate as specified by \[RFC 5280\] in DER encoding and the public key in the certificate to a device’s keystore. A device that supports this command shall be able to handle X.509v3 certificates as specified in RFC 5280 and may additionally be able to handle other X.509 certificate formats as indicated by the X.509Versions capability. A device that supports this command shall support sha1-WithRSAEncryption as certificate signature algorithm.
 
@@ -1553,7 +1553,7 @@ ___
 
 ▸ **UploadCertificateWithPrivateKeyInPKCS12**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:71](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L71)*
+*Defined in [api/advancedsecurity.ts:71](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L71)*
 
 ```
       This operation uploads a certification path consisting of X.509 certificates as specified by [RFC 5280] in DER encoding along with a private key to a device’s keystore.
@@ -1581,7 +1581,7 @@ ___
 
 ▸ **UploadKeyPairInPKCS8**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:47](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L47)*
+*Defined in [api/advancedsecurity.ts:47](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L47)*
 
 ```
       This operation uploads a key pair in a PKCS#8 data structure as specified in [RFC 5958, RFC 5959].
@@ -1600,7 +1600,7 @@ ___
 
 ▸ **UploadPassphrase**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/advancedsecurity.ts:329](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/advancedsecurity.ts#L329)*
+*Defined in [api/advancedsecurity.ts:329](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/advancedsecurity.ts#L329)*
 
 ```
       This operation uploads a passphrase to the keystore of the device.

--- a/docs/classes/_api_analytics_.onvifanalytics.md
+++ b/docs/classes/_api_analytics_.onvifanalytics.md
@@ -1,49 +1,49 @@
-[onvif-rx](../README.md) > ["api/analytics"](../modules/_api_analytics_.md) > [Analytics](../classes/_api_analytics_.analytics.md)
+[onvif-rx](../README.md) > ["api/analytics"](../modules/_api_analytics_.md) > [ONVIFAnalytics](../classes/_api_analytics_.onvifanalytics.md)
 
-# Class: Analytics
+# Class: ONVIFAnalytics
 
 ## Hierarchy
 
-**Analytics**
+**ONVIFAnalytics**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_analytics_.analytics.md#constructor)
+* [constructor](_api_analytics_.onvifanalytics.md#constructor)
 
 ### Properties
 
-* [config](_api_analytics_.analytics.md#config)
+* [config](_api_analytics_.onvifanalytics.md#config)
 
 ### Methods
 
-* [CreateAnalyticsModules](_api_analytics_.analytics.md#createanalyticsmodules)
-* [CreateRules](_api_analytics_.analytics.md#createrules)
-* [DeleteAnalyticsModules](_api_analytics_.analytics.md#deleteanalyticsmodules)
-* [DeleteRules](_api_analytics_.analytics.md#deleterules)
-* [GetAnalyticsModuleOptions](_api_analytics_.analytics.md#getanalyticsmoduleoptions)
-* [GetAnalyticsModules](_api_analytics_.analytics.md#getanalyticsmodules)
-* [GetRuleOptions](_api_analytics_.analytics.md#getruleoptions)
-* [GetRules](_api_analytics_.analytics.md#getrules)
-* [GetServiceCapabilities](_api_analytics_.analytics.md#getservicecapabilities)
-* [GetSupportedAnalyticsModules](_api_analytics_.analytics.md#getsupportedanalyticsmodules)
-* [GetSupportedRules](_api_analytics_.analytics.md#getsupportedrules)
-* [ModifyAnalyticsModules](_api_analytics_.analytics.md#modifyanalyticsmodules)
-* [ModifyRules](_api_analytics_.analytics.md#modifyrules)
-* [CreateAnalyticsModules](_api_analytics_.analytics.md#createanalyticsmodules-1)
-* [CreateRules](_api_analytics_.analytics.md#createrules-1)
-* [DeleteAnalyticsModules](_api_analytics_.analytics.md#deleteanalyticsmodules-1)
-* [DeleteRules](_api_analytics_.analytics.md#deleterules-1)
-* [GetAnalyticsModuleOptions](_api_analytics_.analytics.md#getanalyticsmoduleoptions-1)
-* [GetAnalyticsModules](_api_analytics_.analytics.md#getanalyticsmodules-1)
-* [GetRuleOptions](_api_analytics_.analytics.md#getruleoptions-1)
-* [GetRules](_api_analytics_.analytics.md#getrules-1)
-* [GetServiceCapabilities](_api_analytics_.analytics.md#getservicecapabilities-1)
-* [GetSupportedAnalyticsModules](_api_analytics_.analytics.md#getsupportedanalyticsmodules-1)
-* [GetSupportedRules](_api_analytics_.analytics.md#getsupportedrules-1)
-* [ModifyAnalyticsModules](_api_analytics_.analytics.md#modifyanalyticsmodules-1)
-* [ModifyRules](_api_analytics_.analytics.md#modifyrules-1)
+* [CreateAnalyticsModules](_api_analytics_.onvifanalytics.md#createanalyticsmodules)
+* [CreateRules](_api_analytics_.onvifanalytics.md#createrules)
+* [DeleteAnalyticsModules](_api_analytics_.onvifanalytics.md#deleteanalyticsmodules)
+* [DeleteRules](_api_analytics_.onvifanalytics.md#deleterules)
+* [GetAnalyticsModuleOptions](_api_analytics_.onvifanalytics.md#getanalyticsmoduleoptions)
+* [GetAnalyticsModules](_api_analytics_.onvifanalytics.md#getanalyticsmodules)
+* [GetRuleOptions](_api_analytics_.onvifanalytics.md#getruleoptions)
+* [GetRules](_api_analytics_.onvifanalytics.md#getrules)
+* [GetServiceCapabilities](_api_analytics_.onvifanalytics.md#getservicecapabilities)
+* [GetSupportedAnalyticsModules](_api_analytics_.onvifanalytics.md#getsupportedanalyticsmodules)
+* [GetSupportedRules](_api_analytics_.onvifanalytics.md#getsupportedrules)
+* [ModifyAnalyticsModules](_api_analytics_.onvifanalytics.md#modifyanalyticsmodules)
+* [ModifyRules](_api_analytics_.onvifanalytics.md#modifyrules)
+* [CreateAnalyticsModules](_api_analytics_.onvifanalytics.md#createanalyticsmodules-1)
+* [CreateRules](_api_analytics_.onvifanalytics.md#createrules-1)
+* [DeleteAnalyticsModules](_api_analytics_.onvifanalytics.md#deleteanalyticsmodules-1)
+* [DeleteRules](_api_analytics_.onvifanalytics.md#deleterules-1)
+* [GetAnalyticsModuleOptions](_api_analytics_.onvifanalytics.md#getanalyticsmoduleoptions-1)
+* [GetAnalyticsModules](_api_analytics_.onvifanalytics.md#getanalyticsmodules-1)
+* [GetRuleOptions](_api_analytics_.onvifanalytics.md#getruleoptions-1)
+* [GetRules](_api_analytics_.onvifanalytics.md#getrules-1)
+* [GetServiceCapabilities](_api_analytics_.onvifanalytics.md#getservicecapabilities-1)
+* [GetSupportedAnalyticsModules](_api_analytics_.onvifanalytics.md#getsupportedanalyticsmodules-1)
+* [GetSupportedRules](_api_analytics_.onvifanalytics.md#getsupportedrules-1)
+* [ModifyAnalyticsModules](_api_analytics_.onvifanalytics.md#modifyanalyticsmodules-1)
+* [ModifyRules](_api_analytics_.onvifanalytics.md#modifyrules-1)
 
 ---
 
@@ -53,9 +53,9 @@
 
 ###  constructor
 
-⊕ **new Analytics**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Analytics](_api_analytics_.analytics.md)
+⊕ **new ONVIFAnalytics**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFAnalytics](_api_analytics_.onvifanalytics.md)
 
-*Defined in [api/analytics.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L5)*
+*Defined in [api/analytics.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L5)*
 
 **Parameters:**
 
@@ -63,7 +63,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Analytics](_api_analytics_.analytics.md)
+**Returns:** [ONVIFAnalytics](_api_analytics_.onvifanalytics.md)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/analytics.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L6)*
+*Defined in [api/analytics.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L6)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 ▸ **CreateAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, AnalyticsModule: *[Config](../interfaces/_api_types_.config.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:289](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L289)*
+*Defined in [api/analytics.ts:289](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L289)*
 
 Add one or more analytics modules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via GetSupportedAnalyticsModules, where the Name of the supported AnalyticsModules correspond to the type of an AnalyticsModule instance. Pass unique module names which can be later used as reference. The Parameters of the analytics module must match those of the corresponding AnalyticsModuleDescription.
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **CreateRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Rule: *[Config](../interfaces/_api_types_.config.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:202](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L202)*
+*Defined in [api/analytics.ts:202](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L202)*
 
 Add one or more rules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via GetSupportedRules, where the Name of the supported rule correspond to the type of an rule instance. Pass unique module names which can be later used as reference. The Parameters of the rules must match those of the corresponding description.
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **DeleteAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, AnalyticsModuleName: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:298](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L298)*
+*Defined in [api/analytics.ts:298](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L298)*
 
 Remove one or more analytics modules from a VideoAnalyticsConfiguration referenced by their names.
 
@@ -153,7 +153,7 @@ ___
 
 ▸ **DeleteRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, RuleName: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:211](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L211)*
+*Defined in [api/analytics.ts:211](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L211)*
 
 Remove one or more rules from a VideoAnalyticsConfiguration.
 
@@ -173,7 +173,7 @@ ___
 
 ▸ **GetAnalyticsModuleOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Type: *`any`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:265](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L265)*
+*Defined in [api/analytics.ts:265](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L265)*
 
 Return the options for the supported analytics modules that specify an Option attribute.
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **GetAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:307](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L307)*
+*Defined in [api/analytics.ts:307](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L307)*
 
 List the currently assigned set of analytics modules of a VideoAnalyticsConfiguration.
 
@@ -212,7 +212,7 @@ ___
 
 ▸ **GetRuleOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, RuleType: *`any`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:229](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L229)*
+*Defined in [api/analytics.ts:229](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L229)*
 
 Return the options for the supported rules that specify an Option attribute.
 
@@ -232,7 +232,7 @@ ___
 
 ▸ **GetRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:220](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L220)*
+*Defined in [api/analytics.ts:220](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L220)*
 
 List the currently assigned set of rules of a VideoAnalyticsConfiguration.
 
@@ -251,7 +251,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:245](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L245)*
+*Defined in [api/analytics.ts:245](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L245)*
 
 Returns the capabilities of the analytics service. The result is returned in a typed answer.
 
@@ -264,7 +264,7 @@ ___
 
 ▸ **GetSupportedAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:256](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L256)*
+*Defined in [api/analytics.ts:256](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L256)*
 
 List all analytics modules that are supported by the given VideoAnalyticsConfiguration. The result of this method may depend on the overall Video analytics configuration of the device, which is available via the current set of profiles.
 
@@ -283,7 +283,7 @@ ___
 
 ▸ **GetSupportedRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:185](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L185)*
+*Defined in [api/analytics.ts:185](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L185)*
 
 List all rules that are supported by the given VideoAnalyticsConfiguration. The result of this method may depend on the overall Video analytics configuration of the device, which is available via the current set of profiles.
 
@@ -302,7 +302,7 @@ ___
 
 ▸ **ModifyAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, AnalyticsModule: *[Config](../interfaces/_api_types_.config.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:317](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L317)*
+*Defined in [api/analytics.ts:317](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L317)*
 
 Modify the settings of one or more analytics modules of a VideoAnalyticsConfiguration. The modules are referenced by their names. It is allowed to pass only a subset to be modified.
 
@@ -322,7 +322,7 @@ ___
 
 ▸ **ModifyRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Rule: *[Config](../interfaces/_api_types_.config.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/analytics.ts:238](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L238)*
+*Defined in [api/analytics.ts:238](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L238)*
 
 Modify one or more rules of a VideoAnalyticsConfiguration. The rules are referenced by their names.
 
@@ -342,7 +342,7 @@ ___
 
 ▸ **CreateAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, AnalyticsModule: *[Config](../interfaces/_api_types_.config.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:138](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L138)*
+*Defined in [api/analytics.ts:138](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L138)*
 
 Add one or more analytics modules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via GetSupportedAnalyticsModules, where the Name of the supported AnalyticsModules correspond to the type of an AnalyticsModule instance. Pass unique module names which can be later used as reference. The Parameters of the analytics module must match those of the corresponding AnalyticsModuleDescription.
 
@@ -366,7 +366,7 @@ ___
 
 ▸ **CreateRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Rule: *[Config](../interfaces/_api_types_.config.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:35](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L35)*
+*Defined in [api/analytics.ts:35](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L35)*
 
 Add one or more rules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via GetSupportedRules, where the Name of the supported rule correspond to the type of an rule instance. Pass unique module names which can be later used as reference. The Parameters of the rules must match those of the corresponding description.
 
@@ -388,7 +388,7 @@ ___
 
 ▸ **DeleteAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, AnalyticsModuleName: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:149](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L149)*
+*Defined in [api/analytics.ts:149](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L149)*
 
 Remove one or more analytics modules from a VideoAnalyticsConfiguration referenced by their names.
 
@@ -408,7 +408,7 @@ ___
 
 ▸ **DeleteRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, RuleName: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L46)*
+*Defined in [api/analytics.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L46)*
 
 Remove one or more rules from a VideoAnalyticsConfiguration.
 
@@ -428,7 +428,7 @@ ___
 
 ▸ **GetAnalyticsModuleOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Type?: *`any`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:112](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L112)*
+*Defined in [api/analytics.ts:112](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L112)*
 
 Return the options for the supported analytics modules that specify an Option attribute.
 
@@ -448,7 +448,7 @@ ___
 
 ▸ **GetAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:160](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L160)*
+*Defined in [api/analytics.ts:160](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L160)*
 
 List the currently assigned set of analytics modules of a VideoAnalyticsConfiguration.
 
@@ -467,7 +467,7 @@ ___
 
 ▸ **GetRuleOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, RuleType?: *`any`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:68](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L68)*
+*Defined in [api/analytics.ts:68](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L68)*
 
 Return the options for the supported rules that specify an Option attribute.
 
@@ -487,7 +487,7 @@ ___
 
 ▸ **GetRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:57](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L57)*
+*Defined in [api/analytics.ts:57](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L57)*
 
 List the currently assigned set of rules of a VideoAnalyticsConfiguration.
 
@@ -506,7 +506,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:88](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L88)*
+*Defined in [api/analytics.ts:88](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L88)*
 
 Returns the capabilities of the analytics service. The result is returned in a typed answer.
 
@@ -519,7 +519,7 @@ ___
 
 ▸ **GetSupportedAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:101](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L101)*
+*Defined in [api/analytics.ts:101](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L101)*
 
 List all analytics modules that are supported by the given VideoAnalyticsConfiguration. The result of this method may depend on the overall Video analytics configuration of the device, which is available via the current set of profiles.
 
@@ -538,7 +538,7 @@ ___
 
 ▸ **GetSupportedRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L16)*
+*Defined in [api/analytics.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L16)*
 
 List all rules that are supported by the given VideoAnalyticsConfiguration. The result of this method may depend on the overall Video analytics configuration of the device, which is available via the current set of profiles.
 
@@ -557,7 +557,7 @@ ___
 
 ▸ **ModifyAnalyticsModules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, AnalyticsModule: *[Config](../interfaces/_api_types_.config.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:172](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L172)*
+*Defined in [api/analytics.ts:172](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L172)*
 
 Modify the settings of one or more analytics modules of a VideoAnalyticsConfiguration. The modules are referenced by their names. It is allowed to pass only a subset to be modified.
 
@@ -577,7 +577,7 @@ ___
 
 ▸ **ModifyRules**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Rule: *[Config](../interfaces/_api_types_.config.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/analytics.ts:79](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/analytics.ts#L79)*
+*Defined in [api/analytics.ts:79](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/analytics.ts#L79)*
 
 Modify one or more rules of a VideoAnalyticsConfiguration. The rules are referenced by their names.
 

--- a/docs/classes/_api_device_.onvifdevice.md
+++ b/docs/classes/_api_device_.onvifdevice.md
@@ -1,203 +1,203 @@
-[onvif-rx](../README.md) > ["api/device"](../modules/_api_device_.md) > [Device](../classes/_api_device_.device.md)
+[onvif-rx](../README.md) > ["api/device"](../modules/_api_device_.md) > [ONVIFDevice](../classes/_api_device_.onvifdevice.md)
 
-# Class: Device
+# Class: ONVIFDevice
 
 ## Hierarchy
 
-**Device**
+**ONVIFDevice**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_device_.device.md#constructor)
+* [constructor](_api_device_.onvifdevice.md#constructor)
 
 ### Properties
 
-* [config](_api_device_.device.md#config)
+* [config](_api_device_.onvifdevice.md#config)
 
 ### Methods
 
-* [AddIPAddressFilter](_api_device_.device.md#addipaddressfilter)
-* [AddScopes](_api_device_.device.md#addscopes)
-* [CreateCertificate](_api_device_.device.md#createcertificate)
-* [CreateDot1XConfiguration](_api_device_.device.md#createdot1xconfiguration)
-* [CreateStorageConfiguration](_api_device_.device.md#createstorageconfiguration)
-* [CreateUsers](_api_device_.device.md#createusers)
-* [DeleteCertificates](_api_device_.device.md#deletecertificates)
-* [DeleteDot1XConfiguration](_api_device_.device.md#deletedot1xconfiguration)
-* [DeleteGeoLocation](_api_device_.device.md#deletegeolocation)
-* [DeleteStorageConfiguration](_api_device_.device.md#deletestorageconfiguration)
-* [DeleteUsers](_api_device_.device.md#deleteusers)
-* [GetAccessPolicy](_api_device_.device.md#getaccesspolicy)
-* [GetCACertificates](_api_device_.device.md#getcacertificates)
-* [GetCapabilities](_api_device_.device.md#getcapabilities)
-* [GetCertificateInformation](_api_device_.device.md#getcertificateinformation)
-* [GetCertificates](_api_device_.device.md#getcertificates)
-* [GetCertificatesStatus](_api_device_.device.md#getcertificatesstatus)
-* [GetClientCertificateMode](_api_device_.device.md#getclientcertificatemode)
-* [GetDNS](_api_device_.device.md#getdns)
-* [GetDPAddresses](_api_device_.device.md#getdpaddresses)
-* [GetDeviceInformation](_api_device_.device.md#getdeviceinformation)
-* [GetDiscoveryMode](_api_device_.device.md#getdiscoverymode)
-* [GetDot11Capabilities](_api_device_.device.md#getdot11capabilities)
-* [GetDot11Status](_api_device_.device.md#getdot11status)
-* [GetDot1XConfiguration](_api_device_.device.md#getdot1xconfiguration)
-* [GetDot1XConfigurations](_api_device_.device.md#getdot1xconfigurations)
-* [GetDynamicDNS](_api_device_.device.md#getdynamicdns)
-* [GetEndpointReference](_api_device_.device.md#getendpointreference)
-* [GetGeoLocation](_api_device_.device.md#getgeolocation)
-* [GetHostname](_api_device_.device.md#gethostname)
-* [GetIPAddressFilter](_api_device_.device.md#getipaddressfilter)
-* [GetNTP](_api_device_.device.md#getntp)
-* [GetNetworkDefaultGateway](_api_device_.device.md#getnetworkdefaultgateway)
-* [GetNetworkInterfaces](_api_device_.device.md#getnetworkinterfaces)
-* [GetNetworkProtocols](_api_device_.device.md#getnetworkprotocols)
-* [GetPkcs10Request](_api_device_.device.md#getpkcs10request)
-* [GetRelayOutputs](_api_device_.device.md#getrelayoutputs)
-* [GetRemoteDiscoveryMode](_api_device_.device.md#getremotediscoverymode)
-* [GetRemoteUser](_api_device_.device.md#getremoteuser)
-* [GetScopes](_api_device_.device.md#getscopes)
-* [GetServiceCapabilities](_api_device_.device.md#getservicecapabilities)
-* [GetServices](_api_device_.device.md#getservices)
-* [GetStorageConfiguration](_api_device_.device.md#getstorageconfiguration)
-* [GetStorageConfigurations](_api_device_.device.md#getstorageconfigurations)
-* [GetSystemBackup](_api_device_.device.md#getsystembackup)
-* [GetSystemDateAndTime](_api_device_.device.md#getsystemdateandtime)
-* [GetSystemLog](_api_device_.device.md#getsystemlog)
-* [GetSystemSupportInformation](_api_device_.device.md#getsystemsupportinformation)
-* [GetSystemUris](_api_device_.device.md#getsystemuris)
-* [GetUsers](_api_device_.device.md#getusers)
-* [GetWsdlUrl](_api_device_.device.md#getwsdlurl)
-* [GetZeroConfiguration](_api_device_.device.md#getzeroconfiguration)
-* [LoadCACertificates](_api_device_.device.md#loadcacertificates)
-* [LoadCertificateWithPrivateKey](_api_device_.device.md#loadcertificatewithprivatekey)
-* [LoadCertificates](_api_device_.device.md#loadcertificates)
-* [RemoveIPAddressFilter](_api_device_.device.md#removeipaddressfilter)
-* [RemoveScopes](_api_device_.device.md#removescopes)
-* [RestoreSystem](_api_device_.device.md#restoresystem)
-* [ScanAvailableDot11Networks](_api_device_.device.md#scanavailabledot11networks)
-* [SendAuxiliaryCommand](_api_device_.device.md#sendauxiliarycommand)
-* [SetAccessPolicy](_api_device_.device.md#setaccesspolicy)
-* [SetCertificatesStatus](_api_device_.device.md#setcertificatesstatus)
-* [SetClientCertificateMode](_api_device_.device.md#setclientcertificatemode)
-* [SetDNS](_api_device_.device.md#setdns)
-* [SetDPAddresses](_api_device_.device.md#setdpaddresses)
-* [SetDiscoveryMode](_api_device_.device.md#setdiscoverymode)
-* [SetDot1XConfiguration](_api_device_.device.md#setdot1xconfiguration)
-* [SetDynamicDNS](_api_device_.device.md#setdynamicdns)
-* [SetGeoLocation](_api_device_.device.md#setgeolocation)
-* [SetHostname](_api_device_.device.md#sethostname)
-* [SetHostnameFromDHCP](_api_device_.device.md#sethostnamefromdhcp)
-* [SetIPAddressFilter](_api_device_.device.md#setipaddressfilter)
-* [SetNTP](_api_device_.device.md#setntp)
-* [SetNetworkDefaultGateway](_api_device_.device.md#setnetworkdefaultgateway)
-* [SetNetworkInterfaces](_api_device_.device.md#setnetworkinterfaces)
-* [SetNetworkProtocols](_api_device_.device.md#setnetworkprotocols)
-* [SetRelayOutputSettings](_api_device_.device.md#setrelayoutputsettings)
-* [SetRelayOutputState](_api_device_.device.md#setrelayoutputstate)
-* [SetRemoteDiscoveryMode](_api_device_.device.md#setremotediscoverymode)
-* [SetRemoteUser](_api_device_.device.md#setremoteuser)
-* [SetScopes](_api_device_.device.md#setscopes)
-* [SetStorageConfiguration](_api_device_.device.md#setstorageconfiguration)
-* [SetSystemDateAndTime](_api_device_.device.md#setsystemdateandtime)
-* [SetSystemFactoryDefault](_api_device_.device.md#setsystemfactorydefault)
-* [SetUser](_api_device_.device.md#setuser)
-* [SetZeroConfiguration](_api_device_.device.md#setzeroconfiguration)
-* [StartFirmwareUpgrade](_api_device_.device.md#startfirmwareupgrade)
-* [StartSystemRestore](_api_device_.device.md#startsystemrestore)
-* [SystemReboot](_api_device_.device.md#systemreboot)
-* [UpgradeSystemFirmware](_api_device_.device.md#upgradesystemfirmware)
-* [AddIPAddressFilter](_api_device_.device.md#addipaddressfilter-1)
-* [AddScopes](_api_device_.device.md#addscopes-1)
-* [CreateCertificate](_api_device_.device.md#createcertificate-1)
-* [CreateDot1XConfiguration](_api_device_.device.md#createdot1xconfiguration-1)
-* [CreateStorageConfiguration](_api_device_.device.md#createstorageconfiguration-1)
-* [CreateUsers](_api_device_.device.md#createusers-1)
-* [DeleteCertificates](_api_device_.device.md#deletecertificates-1)
-* [DeleteDot1XConfiguration](_api_device_.device.md#deletedot1xconfiguration-1)
-* [DeleteGeoLocation](_api_device_.device.md#deletegeolocation-1)
-* [DeleteStorageConfiguration](_api_device_.device.md#deletestorageconfiguration-1)
-* [DeleteUsers](_api_device_.device.md#deleteusers-1)
-* [GetAccessPolicy](_api_device_.device.md#getaccesspolicy-1)
-* [GetCACertificates](_api_device_.device.md#getcacertificates-1)
-* [GetCapabilities](_api_device_.device.md#getcapabilities-1)
-* [GetCertificateInformation](_api_device_.device.md#getcertificateinformation-1)
-* [GetCertificates](_api_device_.device.md#getcertificates-1)
-* [GetCertificatesStatus](_api_device_.device.md#getcertificatesstatus-1)
-* [GetClientCertificateMode](_api_device_.device.md#getclientcertificatemode-1)
-* [GetDNS](_api_device_.device.md#getdns-1)
-* [GetDPAddresses](_api_device_.device.md#getdpaddresses-1)
-* [GetDeviceInformation](_api_device_.device.md#getdeviceinformation-1)
-* [GetDiscoveryMode](_api_device_.device.md#getdiscoverymode-1)
-* [GetDot11Capabilities](_api_device_.device.md#getdot11capabilities-1)
-* [GetDot11Status](_api_device_.device.md#getdot11status-1)
-* [GetDot1XConfiguration](_api_device_.device.md#getdot1xconfiguration-1)
-* [GetDot1XConfigurations](_api_device_.device.md#getdot1xconfigurations-1)
-* [GetDynamicDNS](_api_device_.device.md#getdynamicdns-1)
-* [GetEndpointReference](_api_device_.device.md#getendpointreference-1)
-* [GetGeoLocation](_api_device_.device.md#getgeolocation-1)
-* [GetHostname](_api_device_.device.md#gethostname-1)
-* [GetIPAddressFilter](_api_device_.device.md#getipaddressfilter-1)
-* [GetNTP](_api_device_.device.md#getntp-1)
-* [GetNetworkDefaultGateway](_api_device_.device.md#getnetworkdefaultgateway-1)
-* [GetNetworkInterfaces](_api_device_.device.md#getnetworkinterfaces-1)
-* [GetNetworkProtocols](_api_device_.device.md#getnetworkprotocols-1)
-* [GetPkcs10Request](_api_device_.device.md#getpkcs10request-1)
-* [GetRelayOutputs](_api_device_.device.md#getrelayoutputs-1)
-* [GetRemoteDiscoveryMode](_api_device_.device.md#getremotediscoverymode-1)
-* [GetRemoteUser](_api_device_.device.md#getremoteuser-1)
-* [GetScopes](_api_device_.device.md#getscopes-1)
-* [GetServiceCapabilities](_api_device_.device.md#getservicecapabilities-1)
-* [GetServices](_api_device_.device.md#getservices-1)
-* [GetStorageConfiguration](_api_device_.device.md#getstorageconfiguration-1)
-* [GetStorageConfigurations](_api_device_.device.md#getstorageconfigurations-1)
-* [GetSystemBackup](_api_device_.device.md#getsystembackup-1)
-* [GetSystemDateAndTime](_api_device_.device.md#getsystemdateandtime-1)
-* [GetSystemLog](_api_device_.device.md#getsystemlog-1)
-* [GetSystemSupportInformation](_api_device_.device.md#getsystemsupportinformation-1)
-* [GetSystemUris](_api_device_.device.md#getsystemuris-1)
-* [GetUsers](_api_device_.device.md#getusers-1)
-* [GetWsdlUrl](_api_device_.device.md#getwsdlurl-1)
-* [GetZeroConfiguration](_api_device_.device.md#getzeroconfiguration-1)
-* [LoadCACertificates](_api_device_.device.md#loadcacertificates-1)
-* [LoadCertificateWithPrivateKey](_api_device_.device.md#loadcertificatewithprivatekey-1)
-* [LoadCertificates](_api_device_.device.md#loadcertificates-1)
-* [RemoveIPAddressFilter](_api_device_.device.md#removeipaddressfilter-1)
-* [RemoveScopes](_api_device_.device.md#removescopes-1)
-* [RestoreSystem](_api_device_.device.md#restoresystem-1)
-* [ScanAvailableDot11Networks](_api_device_.device.md#scanavailabledot11networks-1)
-* [SendAuxiliaryCommand](_api_device_.device.md#sendauxiliarycommand-1)
-* [SetAccessPolicy](_api_device_.device.md#setaccesspolicy-1)
-* [SetCertificatesStatus](_api_device_.device.md#setcertificatesstatus-1)
-* [SetClientCertificateMode](_api_device_.device.md#setclientcertificatemode-1)
-* [SetDNS](_api_device_.device.md#setdns-1)
-* [SetDPAddresses](_api_device_.device.md#setdpaddresses-1)
-* [SetDiscoveryMode](_api_device_.device.md#setdiscoverymode-1)
-* [SetDot1XConfiguration](_api_device_.device.md#setdot1xconfiguration-1)
-* [SetDynamicDNS](_api_device_.device.md#setdynamicdns-1)
-* [SetGeoLocation](_api_device_.device.md#setgeolocation-1)
-* [SetHostname](_api_device_.device.md#sethostname-1)
-* [SetHostnameFromDHCP](_api_device_.device.md#sethostnamefromdhcp-1)
-* [SetIPAddressFilter](_api_device_.device.md#setipaddressfilter-1)
-* [SetNTP](_api_device_.device.md#setntp-1)
-* [SetNetworkDefaultGateway](_api_device_.device.md#setnetworkdefaultgateway-1)
-* [SetNetworkInterfaces](_api_device_.device.md#setnetworkinterfaces-1)
-* [SetNetworkProtocols](_api_device_.device.md#setnetworkprotocols-1)
-* [SetRelayOutputSettings](_api_device_.device.md#setrelayoutputsettings-1)
-* [SetRelayOutputState](_api_device_.device.md#setrelayoutputstate-1)
-* [SetRemoteDiscoveryMode](_api_device_.device.md#setremotediscoverymode-1)
-* [SetRemoteUser](_api_device_.device.md#setremoteuser-1)
-* [SetScopes](_api_device_.device.md#setscopes-1)
-* [SetStorageConfiguration](_api_device_.device.md#setstorageconfiguration-1)
-* [SetSystemDateAndTime](_api_device_.device.md#setsystemdateandtime-1)
-* [SetSystemFactoryDefault](_api_device_.device.md#setsystemfactorydefault-1)
-* [SetUser](_api_device_.device.md#setuser-1)
-* [SetZeroConfiguration](_api_device_.device.md#setzeroconfiguration-1)
-* [StartFirmwareUpgrade](_api_device_.device.md#startfirmwareupgrade-1)
-* [StartSystemRestore](_api_device_.device.md#startsystemrestore-1)
-* [SystemReboot](_api_device_.device.md#systemreboot-1)
-* [UpgradeSystemFirmware](_api_device_.device.md#upgradesystemfirmware-1)
+* [AddIPAddressFilter](_api_device_.onvifdevice.md#addipaddressfilter)
+* [AddScopes](_api_device_.onvifdevice.md#addscopes)
+* [CreateCertificate](_api_device_.onvifdevice.md#createcertificate)
+* [CreateDot1XConfiguration](_api_device_.onvifdevice.md#createdot1xconfiguration)
+* [CreateStorageConfiguration](_api_device_.onvifdevice.md#createstorageconfiguration)
+* [CreateUsers](_api_device_.onvifdevice.md#createusers)
+* [DeleteCertificates](_api_device_.onvifdevice.md#deletecertificates)
+* [DeleteDot1XConfiguration](_api_device_.onvifdevice.md#deletedot1xconfiguration)
+* [DeleteGeoLocation](_api_device_.onvifdevice.md#deletegeolocation)
+* [DeleteStorageConfiguration](_api_device_.onvifdevice.md#deletestorageconfiguration)
+* [DeleteUsers](_api_device_.onvifdevice.md#deleteusers)
+* [GetAccessPolicy](_api_device_.onvifdevice.md#getaccesspolicy)
+* [GetCACertificates](_api_device_.onvifdevice.md#getcacertificates)
+* [GetCapabilities](_api_device_.onvifdevice.md#getcapabilities)
+* [GetCertificateInformation](_api_device_.onvifdevice.md#getcertificateinformation)
+* [GetCertificates](_api_device_.onvifdevice.md#getcertificates)
+* [GetCertificatesStatus](_api_device_.onvifdevice.md#getcertificatesstatus)
+* [GetClientCertificateMode](_api_device_.onvifdevice.md#getclientcertificatemode)
+* [GetDNS](_api_device_.onvifdevice.md#getdns)
+* [GetDPAddresses](_api_device_.onvifdevice.md#getdpaddresses)
+* [GetDeviceInformation](_api_device_.onvifdevice.md#getdeviceinformation)
+* [GetDiscoveryMode](_api_device_.onvifdevice.md#getdiscoverymode)
+* [GetDot11Capabilities](_api_device_.onvifdevice.md#getdot11capabilities)
+* [GetDot11Status](_api_device_.onvifdevice.md#getdot11status)
+* [GetDot1XConfiguration](_api_device_.onvifdevice.md#getdot1xconfiguration)
+* [GetDot1XConfigurations](_api_device_.onvifdevice.md#getdot1xconfigurations)
+* [GetDynamicDNS](_api_device_.onvifdevice.md#getdynamicdns)
+* [GetEndpointReference](_api_device_.onvifdevice.md#getendpointreference)
+* [GetGeoLocation](_api_device_.onvifdevice.md#getgeolocation)
+* [GetHostname](_api_device_.onvifdevice.md#gethostname)
+* [GetIPAddressFilter](_api_device_.onvifdevice.md#getipaddressfilter)
+* [GetNTP](_api_device_.onvifdevice.md#getntp)
+* [GetNetworkDefaultGateway](_api_device_.onvifdevice.md#getnetworkdefaultgateway)
+* [GetNetworkInterfaces](_api_device_.onvifdevice.md#getnetworkinterfaces)
+* [GetNetworkProtocols](_api_device_.onvifdevice.md#getnetworkprotocols)
+* [GetPkcs10Request](_api_device_.onvifdevice.md#getpkcs10request)
+* [GetRelayOutputs](_api_device_.onvifdevice.md#getrelayoutputs)
+* [GetRemoteDiscoveryMode](_api_device_.onvifdevice.md#getremotediscoverymode)
+* [GetRemoteUser](_api_device_.onvifdevice.md#getremoteuser)
+* [GetScopes](_api_device_.onvifdevice.md#getscopes)
+* [GetServiceCapabilities](_api_device_.onvifdevice.md#getservicecapabilities)
+* [GetServices](_api_device_.onvifdevice.md#getservices)
+* [GetStorageConfiguration](_api_device_.onvifdevice.md#getstorageconfiguration)
+* [GetStorageConfigurations](_api_device_.onvifdevice.md#getstorageconfigurations)
+* [GetSystemBackup](_api_device_.onvifdevice.md#getsystembackup)
+* [GetSystemDateAndTime](_api_device_.onvifdevice.md#getsystemdateandtime)
+* [GetSystemLog](_api_device_.onvifdevice.md#getsystemlog)
+* [GetSystemSupportInformation](_api_device_.onvifdevice.md#getsystemsupportinformation)
+* [GetSystemUris](_api_device_.onvifdevice.md#getsystemuris)
+* [GetUsers](_api_device_.onvifdevice.md#getusers)
+* [GetWsdlUrl](_api_device_.onvifdevice.md#getwsdlurl)
+* [GetZeroConfiguration](_api_device_.onvifdevice.md#getzeroconfiguration)
+* [LoadCACertificates](_api_device_.onvifdevice.md#loadcacertificates)
+* [LoadCertificateWithPrivateKey](_api_device_.onvifdevice.md#loadcertificatewithprivatekey)
+* [LoadCertificates](_api_device_.onvifdevice.md#loadcertificates)
+* [RemoveIPAddressFilter](_api_device_.onvifdevice.md#removeipaddressfilter)
+* [RemoveScopes](_api_device_.onvifdevice.md#removescopes)
+* [RestoreSystem](_api_device_.onvifdevice.md#restoresystem)
+* [ScanAvailableDot11Networks](_api_device_.onvifdevice.md#scanavailabledot11networks)
+* [SendAuxiliaryCommand](_api_device_.onvifdevice.md#sendauxiliarycommand)
+* [SetAccessPolicy](_api_device_.onvifdevice.md#setaccesspolicy)
+* [SetCertificatesStatus](_api_device_.onvifdevice.md#setcertificatesstatus)
+* [SetClientCertificateMode](_api_device_.onvifdevice.md#setclientcertificatemode)
+* [SetDNS](_api_device_.onvifdevice.md#setdns)
+* [SetDPAddresses](_api_device_.onvifdevice.md#setdpaddresses)
+* [SetDiscoveryMode](_api_device_.onvifdevice.md#setdiscoverymode)
+* [SetDot1XConfiguration](_api_device_.onvifdevice.md#setdot1xconfiguration)
+* [SetDynamicDNS](_api_device_.onvifdevice.md#setdynamicdns)
+* [SetGeoLocation](_api_device_.onvifdevice.md#setgeolocation)
+* [SetHostname](_api_device_.onvifdevice.md#sethostname)
+* [SetHostnameFromDHCP](_api_device_.onvifdevice.md#sethostnamefromdhcp)
+* [SetIPAddressFilter](_api_device_.onvifdevice.md#setipaddressfilter)
+* [SetNTP](_api_device_.onvifdevice.md#setntp)
+* [SetNetworkDefaultGateway](_api_device_.onvifdevice.md#setnetworkdefaultgateway)
+* [SetNetworkInterfaces](_api_device_.onvifdevice.md#setnetworkinterfaces)
+* [SetNetworkProtocols](_api_device_.onvifdevice.md#setnetworkprotocols)
+* [SetRelayOutputSettings](_api_device_.onvifdevice.md#setrelayoutputsettings)
+* [SetRelayOutputState](_api_device_.onvifdevice.md#setrelayoutputstate)
+* [SetRemoteDiscoveryMode](_api_device_.onvifdevice.md#setremotediscoverymode)
+* [SetRemoteUser](_api_device_.onvifdevice.md#setremoteuser)
+* [SetScopes](_api_device_.onvifdevice.md#setscopes)
+* [SetStorageConfiguration](_api_device_.onvifdevice.md#setstorageconfiguration)
+* [SetSystemDateAndTime](_api_device_.onvifdevice.md#setsystemdateandtime)
+* [SetSystemFactoryDefault](_api_device_.onvifdevice.md#setsystemfactorydefault)
+* [SetUser](_api_device_.onvifdevice.md#setuser)
+* [SetZeroConfiguration](_api_device_.onvifdevice.md#setzeroconfiguration)
+* [StartFirmwareUpgrade](_api_device_.onvifdevice.md#startfirmwareupgrade)
+* [StartSystemRestore](_api_device_.onvifdevice.md#startsystemrestore)
+* [SystemReboot](_api_device_.onvifdevice.md#systemreboot)
+* [UpgradeSystemFirmware](_api_device_.onvifdevice.md#upgradesystemfirmware)
+* [AddIPAddressFilter](_api_device_.onvifdevice.md#addipaddressfilter-1)
+* [AddScopes](_api_device_.onvifdevice.md#addscopes-1)
+* [CreateCertificate](_api_device_.onvifdevice.md#createcertificate-1)
+* [CreateDot1XConfiguration](_api_device_.onvifdevice.md#createdot1xconfiguration-1)
+* [CreateStorageConfiguration](_api_device_.onvifdevice.md#createstorageconfiguration-1)
+* [CreateUsers](_api_device_.onvifdevice.md#createusers-1)
+* [DeleteCertificates](_api_device_.onvifdevice.md#deletecertificates-1)
+* [DeleteDot1XConfiguration](_api_device_.onvifdevice.md#deletedot1xconfiguration-1)
+* [DeleteGeoLocation](_api_device_.onvifdevice.md#deletegeolocation-1)
+* [DeleteStorageConfiguration](_api_device_.onvifdevice.md#deletestorageconfiguration-1)
+* [DeleteUsers](_api_device_.onvifdevice.md#deleteusers-1)
+* [GetAccessPolicy](_api_device_.onvifdevice.md#getaccesspolicy-1)
+* [GetCACertificates](_api_device_.onvifdevice.md#getcacertificates-1)
+* [GetCapabilities](_api_device_.onvifdevice.md#getcapabilities-1)
+* [GetCertificateInformation](_api_device_.onvifdevice.md#getcertificateinformation-1)
+* [GetCertificates](_api_device_.onvifdevice.md#getcertificates-1)
+* [GetCertificatesStatus](_api_device_.onvifdevice.md#getcertificatesstatus-1)
+* [GetClientCertificateMode](_api_device_.onvifdevice.md#getclientcertificatemode-1)
+* [GetDNS](_api_device_.onvifdevice.md#getdns-1)
+* [GetDPAddresses](_api_device_.onvifdevice.md#getdpaddresses-1)
+* [GetDeviceInformation](_api_device_.onvifdevice.md#getdeviceinformation-1)
+* [GetDiscoveryMode](_api_device_.onvifdevice.md#getdiscoverymode-1)
+* [GetDot11Capabilities](_api_device_.onvifdevice.md#getdot11capabilities-1)
+* [GetDot11Status](_api_device_.onvifdevice.md#getdot11status-1)
+* [GetDot1XConfiguration](_api_device_.onvifdevice.md#getdot1xconfiguration-1)
+* [GetDot1XConfigurations](_api_device_.onvifdevice.md#getdot1xconfigurations-1)
+* [GetDynamicDNS](_api_device_.onvifdevice.md#getdynamicdns-1)
+* [GetEndpointReference](_api_device_.onvifdevice.md#getendpointreference-1)
+* [GetGeoLocation](_api_device_.onvifdevice.md#getgeolocation-1)
+* [GetHostname](_api_device_.onvifdevice.md#gethostname-1)
+* [GetIPAddressFilter](_api_device_.onvifdevice.md#getipaddressfilter-1)
+* [GetNTP](_api_device_.onvifdevice.md#getntp-1)
+* [GetNetworkDefaultGateway](_api_device_.onvifdevice.md#getnetworkdefaultgateway-1)
+* [GetNetworkInterfaces](_api_device_.onvifdevice.md#getnetworkinterfaces-1)
+* [GetNetworkProtocols](_api_device_.onvifdevice.md#getnetworkprotocols-1)
+* [GetPkcs10Request](_api_device_.onvifdevice.md#getpkcs10request-1)
+* [GetRelayOutputs](_api_device_.onvifdevice.md#getrelayoutputs-1)
+* [GetRemoteDiscoveryMode](_api_device_.onvifdevice.md#getremotediscoverymode-1)
+* [GetRemoteUser](_api_device_.onvifdevice.md#getremoteuser-1)
+* [GetScopes](_api_device_.onvifdevice.md#getscopes-1)
+* [GetServiceCapabilities](_api_device_.onvifdevice.md#getservicecapabilities-1)
+* [GetServices](_api_device_.onvifdevice.md#getservices-1)
+* [GetStorageConfiguration](_api_device_.onvifdevice.md#getstorageconfiguration-1)
+* [GetStorageConfigurations](_api_device_.onvifdevice.md#getstorageconfigurations-1)
+* [GetSystemBackup](_api_device_.onvifdevice.md#getsystembackup-1)
+* [GetSystemDateAndTime](_api_device_.onvifdevice.md#getsystemdateandtime-1)
+* [GetSystemLog](_api_device_.onvifdevice.md#getsystemlog-1)
+* [GetSystemSupportInformation](_api_device_.onvifdevice.md#getsystemsupportinformation-1)
+* [GetSystemUris](_api_device_.onvifdevice.md#getsystemuris-1)
+* [GetUsers](_api_device_.onvifdevice.md#getusers-1)
+* [GetWsdlUrl](_api_device_.onvifdevice.md#getwsdlurl-1)
+* [GetZeroConfiguration](_api_device_.onvifdevice.md#getzeroconfiguration-1)
+* [LoadCACertificates](_api_device_.onvifdevice.md#loadcacertificates-1)
+* [LoadCertificateWithPrivateKey](_api_device_.onvifdevice.md#loadcertificatewithprivatekey-1)
+* [LoadCertificates](_api_device_.onvifdevice.md#loadcertificates-1)
+* [RemoveIPAddressFilter](_api_device_.onvifdevice.md#removeipaddressfilter-1)
+* [RemoveScopes](_api_device_.onvifdevice.md#removescopes-1)
+* [RestoreSystem](_api_device_.onvifdevice.md#restoresystem-1)
+* [ScanAvailableDot11Networks](_api_device_.onvifdevice.md#scanavailabledot11networks-1)
+* [SendAuxiliaryCommand](_api_device_.onvifdevice.md#sendauxiliarycommand-1)
+* [SetAccessPolicy](_api_device_.onvifdevice.md#setaccesspolicy-1)
+* [SetCertificatesStatus](_api_device_.onvifdevice.md#setcertificatesstatus-1)
+* [SetClientCertificateMode](_api_device_.onvifdevice.md#setclientcertificatemode-1)
+* [SetDNS](_api_device_.onvifdevice.md#setdns-1)
+* [SetDPAddresses](_api_device_.onvifdevice.md#setdpaddresses-1)
+* [SetDiscoveryMode](_api_device_.onvifdevice.md#setdiscoverymode-1)
+* [SetDot1XConfiguration](_api_device_.onvifdevice.md#setdot1xconfiguration-1)
+* [SetDynamicDNS](_api_device_.onvifdevice.md#setdynamicdns-1)
+* [SetGeoLocation](_api_device_.onvifdevice.md#setgeolocation-1)
+* [SetHostname](_api_device_.onvifdevice.md#sethostname-1)
+* [SetHostnameFromDHCP](_api_device_.onvifdevice.md#sethostnamefromdhcp-1)
+* [SetIPAddressFilter](_api_device_.onvifdevice.md#setipaddressfilter-1)
+* [SetNTP](_api_device_.onvifdevice.md#setntp-1)
+* [SetNetworkDefaultGateway](_api_device_.onvifdevice.md#setnetworkdefaultgateway-1)
+* [SetNetworkInterfaces](_api_device_.onvifdevice.md#setnetworkinterfaces-1)
+* [SetNetworkProtocols](_api_device_.onvifdevice.md#setnetworkprotocols-1)
+* [SetRelayOutputSettings](_api_device_.onvifdevice.md#setrelayoutputsettings-1)
+* [SetRelayOutputState](_api_device_.onvifdevice.md#setrelayoutputstate-1)
+* [SetRemoteDiscoveryMode](_api_device_.onvifdevice.md#setremotediscoverymode-1)
+* [SetRemoteUser](_api_device_.onvifdevice.md#setremoteuser-1)
+* [SetScopes](_api_device_.onvifdevice.md#setscopes-1)
+* [SetStorageConfiguration](_api_device_.onvifdevice.md#setstorageconfiguration-1)
+* [SetSystemDateAndTime](_api_device_.onvifdevice.md#setsystemdateandtime-1)
+* [SetSystemFactoryDefault](_api_device_.onvifdevice.md#setsystemfactorydefault-1)
+* [SetUser](_api_device_.onvifdevice.md#setuser-1)
+* [SetZeroConfiguration](_api_device_.onvifdevice.md#setzeroconfiguration-1)
+* [StartFirmwareUpgrade](_api_device_.onvifdevice.md#startfirmwareupgrade-1)
+* [StartSystemRestore](_api_device_.onvifdevice.md#startsystemrestore-1)
+* [SystemReboot](_api_device_.onvifdevice.md#systemreboot-1)
+* [UpgradeSystemFirmware](_api_device_.onvifdevice.md#upgradesystemfirmware-1)
 
 ---
 
@@ -207,9 +207,9 @@
 
 ###  constructor
 
-⊕ **new Device**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Device](_api_device_.device.md)
+⊕ **new ONVIFDevice**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFDevice](_api_device_.onvifdevice.md)
 
-*Defined in [api/device.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L5)*
+*Defined in [api/device.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L5)*
 
 **Parameters:**
 
@@ -217,7 +217,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Device](_api_device_.device.md)
+**Returns:** [ONVIFDevice](_api_device_.onvifdevice.md)
 
 ___
 
@@ -229,7 +229,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/device.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L6)*
+*Defined in [api/device.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L6)*
 
 ___
 
@@ -241,7 +241,7 @@ ___
 
 ▸ **AddIPAddressFilter**(IPAddressFilter: *[IPAddressFilter](../interfaces/_api_types_.ipaddressfilter.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1596](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1596)*
+*Defined in [api/device.ts:1596](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1596)*
 
 This operation adds an IP filter address to a device. If the device supports device access control based on IP filtering rules (denied or accepted ranges of IP addresses), the device shall support adding of IP filtering addresses through the AddIPAddressFilter command.
 
@@ -260,7 +260,7 @@ ___
 
 ▸ **AddScopes**(ScopeItem: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1260](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1260)*
+*Defined in [api/device.ts:1260](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1260)*
 
 This operation adds new configurable scope parameters to a device. The scope parameters are used in the device discovery to match a probe message. The device shall support addition of discovery scope parameters through the AddScopes command.
 
@@ -279,7 +279,7 @@ ___
 
 ▸ **CreateCertificate**(CertificateID: *`string`*, Subject: *`string`*, ValidNotBefore: *`string`*, ValidNotAfter: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1643](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1643)*
+*Defined in [api/device.ts:1643](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1643)*
 
 This operation generates a private/public key pair and also can create a self-signed device certificate as a result of key pair generation. The certificate is created using a suitable onboard key pair generation mechanism. If a device supports onboard key pair generation, the device that supports TLS shall support this certificate creation command. And also, if a device supports onboard key pair generation, the device that support IEEE 802.1X shall support this command for the purpose of key pair generation. Certificates and key pairs are identified using certificate IDs. These IDs are either chosen by the certificate generation requester or by the device (in case that no ID value is given).
 
@@ -301,7 +301,7 @@ ___
 
 ▸ **CreateDot1XConfiguration**(Dot1XConfiguration: *[Dot1XConfiguration](../interfaces/_api_types_.dot1xconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1853](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1853)*
+*Defined in [api/device.ts:1853](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1853)*
 
 This operation newly creates IEEE 802.1X configuration parameter set of the device. The device shall support this command if it supports IEEE 802.1X. If the device receives this request with already existing configuration token (Dot1XConfigurationToken) specification, the device should respond with 'ter:ReferenceToken ' error to indicate there is some configuration conflict.
 
@@ -320,7 +320,7 @@ ___
 
 ▸ **CreateStorageConfiguration**(StorageConfiguration: *`any`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1999](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1999)*
+*Defined in [api/device.ts:1999](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1999)*
 
 This operation creates a new storage configuration. The configuration data shall be created in the device and shall be persistent (remain after reboot).
 
@@ -339,7 +339,7 @@ ___
 
 ▸ **CreateUsers**(User: *[User](../interfaces/_api_types_.user.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1381](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1381)*
+*Defined in [api/device.ts:1381](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1381)*
 
 This operation creates new device users and corresponding credentials on a device for authentication purposes. The device shall support creation of device users and their credentials through the CreateUsers command. Either all users are created successfully or a fault message shall be returned without creating any user. ONVIF compliant devices are recommended to support password length of at least 28 bytes, as clients may follow the password derivation mechanism which results in 'password equivalent' of length 28 bytes, as described in section 3.1.2 of the ONVIF security white paper.
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **DeleteCertificates**(CertificateID: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1685](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1685)*
+*Defined in [api/device.ts:1685](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1685)*
 
 This operation deletes a certificate or multiple certificates. The device MAY also delete a private/public key pair which is coupled with the certificate to be deleted. The device that support either TLS or IEEE 802.1X shall support the deletion of a certificate or multiple certificates through this command. Either all certificates are deleted successfully or a fault message shall be returned without deleting any certificate.
 
@@ -377,7 +377,7 @@ ___
 
 ▸ **DeleteDot1XConfiguration**(Dot1XConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1894](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1894)*
+*Defined in [api/device.ts:1894](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1894)*
 
 This operation deletes an IEEE 802.1X configuration parameter set from the device. Which configuration should be deleted is specified by the 'Dot1XConfigurationToken' in the request. A device that support IEEE 802.1X shall support this command.
 
@@ -396,7 +396,7 @@ ___
 
 ▸ **DeleteGeoLocation**(Location: *[LocationEntity](../interfaces/_api_types_.locationentity.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:2053](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L2053)*
+*Defined in [api/device.ts:2053](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L2053)*
 
 This operation deletes the given geo location entries.
 
@@ -415,7 +415,7 @@ ___
 
 ▸ **DeleteStorageConfiguration**(Token: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:2026](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L2026)*
+*Defined in [api/device.ts:2026](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L2026)*
 
 This operation deletes the given storage configuration and configuration change shall always be persistent.
 
@@ -434,7 +434,7 @@ ___
 
 ▸ **DeleteUsers**(Username: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1391](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1391)*
+*Defined in [api/device.ts:1391](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1391)*
 
 This operation deletes users on a device. The device shall support deletion of device users and their credentials through the DeleteUsers command. A device may have one or more fixed users that cannot be deleted to ensure access to the unit. Either all users are deleted successfully or a fault message shall be returned and no users be deleted.
 
@@ -453,7 +453,7 @@ ___
 
 ▸ **GetAccessPolicy**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1619](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1619)*
+*Defined in [api/device.ts:1619](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1619)*
 
 Access to different services and sub-sets of services should be subject to access control. The WS-Security framework gives the prerequisite for end-point authentication. Authorization decisions can then be taken using an access security policy. This standard does not mandate any particular policy description format or security policy but this is up to the device manufacturer or system provider to choose policy and policy description format of choice. However, an access policy (in arbitrary format) can be requested using this command. If the device supports access policy settings based on WS-Security authentication, then the device shall support this command.
 
@@ -466,7 +466,7 @@ ___
 
 ▸ **GetCACertificates**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1796](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1796)*
+*Defined in [api/device.ts:1796](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1796)*
 
 CA certificates will be loaded into a device and be used for the sake of following two cases. The one is for the purpose of TLS client authentication in TLS server function. The other one is for the purpose of Authentication Server authentication in IEEE 802.1X function. This operation gets all CA certificates loaded into a device. A device that supports either TLS client authentication or IEEE 802.1X shall support this command and the returned certificates shall be encoded using ASN.1 \[X.681\], \[X.682\], \[X.683\] DER \[X.690\] encoding rules.
 
@@ -479,7 +479,7 @@ ___
 
 ▸ **GetCapabilities**(Category: *[CapabilityCategory](../enums/_api_types_.capabilitycategory.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1418](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1418)*
+*Defined in [api/device.ts:1418](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1418)*
 
 This method has been replaced by the more generic GetServices method. For capabilities of individual services refer to the GetServiceCapabilities methods.
 
@@ -498,7 +498,7 @@ ___
 
 ▸ **GetCertificateInformation**(CertificateID: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1827](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1827)*
+*Defined in [api/device.ts:1827](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1827)*
 
 This operation requests the information of a certificate specified by certificate ID. The device should respond with its “Issuer DN”, “Subject DN”, “Key usage”, "Extended key usage”, “Key Length”, “Version”, “Serial Number”, “Signature Algorithm” and “Validity” data as the information of the certificate, as long as the device can retrieve such information from the specified certificate. A device that supports either TLS or IEEE 802.1X should support this command.
 
@@ -517,7 +517,7 @@ ___
 
 ▸ **GetCertificates**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1656](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1656)*
+*Defined in [api/device.ts:1656](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1656)*
 
 This operation gets all device server certificates (including self-signed) for the purpose of TLS authentication and all device client certificates for the purpose of IEEE 802.1X authentication. This command lists only the TLS server certificates and IEEE 802.1X client certificates for the device (neither trusted CA certificates nor trusted root certificates). The certificates are returned as binary data. A device that supports TLS shall support this command and the certificates shall be encoded using ASN.1 \[X.681\], \[X.682\], \[X.683\] DER \[X.690\] encoding rules.
 
@@ -530,7 +530,7 @@ ___
 
 ▸ **GetCertificatesStatus**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1665](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1665)*
+*Defined in [api/device.ts:1665](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1665)*
 
 This operation is specific to TLS functionality. This operation gets the status (enabled/disabled) of the device TLS server certificates. A device that supports TLS shall support this command.
 
@@ -543,7 +543,7 @@ ___
 
 ▸ **GetClientCertificateMode**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1728](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1728)*
+*Defined in [api/device.ts:1728](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1728)*
 
 This operation is specific to TLS functionality. This operation gets the status (enabled/disabled) of the device TLS client authentication. A device that supports TLS shall support this command.
 
@@ -556,7 +556,7 @@ ___
 
 ▸ **GetDNS**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1452](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1452)*
+*Defined in [api/device.ts:1452](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1452)*
 
 This operation gets the DNS settings from a device. The device shall return its DNS configurations through the GetDNS command.
 
@@ -569,7 +569,7 @@ ___
 
 ▸ **GetDPAddresses**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1318](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1318)*
+*Defined in [api/device.ts:1318](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1318)*
 
 This operation gets the remote DP address or addresses from a device. If the device supports remote discovery, as specified in Section 7.4, the device shall support retrieval of the remote DP address(es) through the GetDPAddresses command.
 
@@ -582,7 +582,7 @@ ___
 
 ▸ **GetDeviceInformation**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1140](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1140)*
+*Defined in [api/device.ts:1140](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1140)*
 
 This operation gets basic device information from the device.
 
@@ -595,7 +595,7 @@ ___
 
 ▸ **GetDiscoveryMode**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1280](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1280)*
+*Defined in [api/device.ts:1280](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1280)*
 
 This operation gets the discovery mode of a device. See Section 7.2 for the definition of the different device discovery modes. The device shall support retrieval of the discovery mode setting through the GetDiscoveryMode command.
 
@@ -608,7 +608,7 @@ ___
 
 ▸ **GetDot11Capabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1902](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1902)*
+*Defined in [api/device.ts:1902](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1902)*
 
 This operation returns the IEEE802.11 capabilities. The device shall support this operation.
 
@@ -621,7 +621,7 @@ ___
 
 ▸ **GetDot11Status**(InterfaceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1910](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1910)*
+*Defined in [api/device.ts:1910](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1910)*
 
 This operation returns the status of a wireless network interface. The device shall support this command.
 
@@ -640,7 +640,7 @@ ___
 
 ▸ **GetDot1XConfiguration**(Dot1XConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1873](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1873)*
+*Defined in [api/device.ts:1873](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1873)*
 
 This operation gets one IEEE 802.1X configuration parameter set from the device by specifying the configuration token (Dot1XConfigurationToken). A device that supports IEEE 802.1X shall support this command. Regardless of whether the 802.1X method in the retrieved configuration has a password or not, the device shall not include the Password element in the response.
 
@@ -659,7 +659,7 @@ ___
 
 ▸ **GetDot1XConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1885](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1885)*
+*Defined in [api/device.ts:1885](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1885)*
 
 This operation gets all the existing IEEE 802.1X configuration parameter sets from the device. The device shall respond with all the IEEE 802.1X configurations so that the client can get to know how many IEEE 802.1X configurations are existing and how they are configured. A device that support IEEE 802.1X shall support this command. Regardless of whether the 802.1X method in the retrieved configuration has a password or not, the device shall not include the Password element in the response.
 
@@ -672,7 +672,7 @@ ___
 
 ▸ **GetDynamicDNS**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1489](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1489)*
+*Defined in [api/device.ts:1489](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1489)*
 
 This operation gets the dynamic DNS settings from a device. If the device supports dynamic DNS as specified in \[RFC 2136\] and \[RFC 4702\], it shall be possible to get the type, name and TTL through the GetDynamicDNS command.
 
@@ -685,7 +685,7 @@ ___
 
 ▸ **GetEndpointReference**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1337](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1337)*
+*Defined in [api/device.ts:1337](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1337)*
 
 A client can ask for the device service endpoint reference address property that can be used to derive the password equivalent for remote user operation. The device shall support the GetEndpointReference command returning the address property of the device service endpoint reference.
 
@@ -698,7 +698,7 @@ ___
 
 ▸ **GetGeoLocation**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:2035](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L2035)*
+*Defined in [api/device.ts:2035](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L2035)*
 
 This operation lists all existing geo location configurations for the device.
 
@@ -711,7 +711,7 @@ ___
 
 ▸ **GetHostname**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1426](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1426)*
+*Defined in [api/device.ts:1426](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1426)*
 
 This operation is used by an endpoint to get the hostname from a device. The device shall return its hostname configurations through the GetHostname command.
 
@@ -724,7 +724,7 @@ ___
 
 ▸ **GetIPAddressFilter**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1577](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1577)*
+*Defined in [api/device.ts:1577](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1577)*
 
 This operation gets the IP address filter settings from a device. If the device supports device access control based on IP filtering rules (denied or accepted ranges of IP addresses), the device shall support the GetIPAddressFilter command.
 
@@ -737,7 +737,7 @@ ___
 
 ▸ **GetNTP**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1468](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1468)*
+*Defined in [api/device.ts:1468](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1468)*
 
 This operation gets the NTP settings from a device. If the device supports NTP, it shall be possible to get the NTP server settings through the GetNTP command.
 
@@ -750,7 +750,7 @@ ___
 
 ▸ **GetNetworkDefaultGateway**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1543](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1543)*
+*Defined in [api/device.ts:1543](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1543)*
 
 This operation gets the default gateway settings from a device. The device shall support the GetNetworkDefaultGateway command returning configured default gateway address(es).
 
@@ -763,7 +763,7 @@ ___
 
 ▸ **GetNetworkInterfaces**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1507](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1507)*
+*Defined in [api/device.ts:1507](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1507)*
 
 This operation gets the network interface configuration from a device. The device shall support return of network interface configuration settings as defined by the NetworkInterface type through the GetNetworkInterfaces command.
 
@@ -776,7 +776,7 @@ ___
 
 ▸ **GetNetworkProtocols**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1527](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1527)*
+*Defined in [api/device.ts:1527](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1527)*
 
 This operation gets defined network protocols from a device. The device shall support the GetNetworkProtocols command returning configured network protocols.
 
@@ -789,7 +789,7 @@ ___
 
 ▸ **GetPkcs10Request**(CertificateID: *`string`*, Subject: *`string`*, Attributes: *[BinaryData](../interfaces/_api_types_.binarydata.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1699](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1699)*
+*Defined in [api/device.ts:1699](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1699)*
 
 This operation requests a PKCS #10 certificate signature request from the device. The returned information field shall be either formatted exactly as specified in \[PKCS#10\] or PEM encoded \[PKCS#10\] format. In order for this command to work, the device must already have a private/public key pair. This key pair should be referred by CertificateID as specified in the input parameter description. This CertificateID refers to the key pair generated using CreateCertificate command. A device that support onboard key pair generation that supports either TLS or IEEE 802.1X using client certificate shall support this command.
 
@@ -810,7 +810,7 @@ ___
 
 ▸ **GetRelayOutputs**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1745](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1745)*
+*Defined in [api/device.ts:1745](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1745)*
 
 This operation gets a list of all available relay outputs and their settings. This method has been depricated with version 2.0. Refer to the DeviceIO service.
 
@@ -823,7 +823,7 @@ ___
 
 ▸ **GetRemoteDiscoveryMode**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1299](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1299)*
+*Defined in [api/device.ts:1299](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1299)*
 
 This operation gets the remote discovery mode of a device. See Section 7.4 for the definition of remote discovery extensions. A device that supports remote discovery shall support retrieval of the remote discovery mode setting through the GetRemoteDiscoveryMode command.
 
@@ -836,7 +836,7 @@ ___
 
 ▸ **GetRemoteUser**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1347](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1347)*
+*Defined in [api/device.ts:1347](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1347)*
 
 This operation returns the configured remote user (if any). A device supporting remote user handling shall support this operation. The user is only valid for the WS-UserToken profile or as a HTTP / RTSP user. The algorithm to use for deriving the password is described in section 5.12.2.1 of the core specification.
 
@@ -849,7 +849,7 @@ ___
 
 ▸ **GetScopes**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1240](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1240)*
+*Defined in [api/device.ts:1240](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1240)*
 
 This operation requests the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The Scope parameters are of two different types: Fixed Configurable
 
@@ -864,7 +864,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1133](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1133)*
+*Defined in [api/device.ts:1133](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1133)*
 
 Returns the capabilities of the device service. The result is returned in a typed answer.
 
@@ -877,7 +877,7 @@ ___
 
 ▸ **GetServices**(IncludeCapability: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1126](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1126)*
+*Defined in [api/device.ts:1126](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1126)*
 
 Returns information about services on the device.
 
@@ -896,7 +896,7 @@ ___
 
 ▸ **GetStorageConfiguration**(Token: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:2008](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L2008)*
+*Defined in [api/device.ts:2008](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L2008)*
 
 This operation retrieves the Storage configuration associated with the given storage configuration token.
 
@@ -915,7 +915,7 @@ ___
 
 ▸ **GetStorageConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1989](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1989)*
+*Defined in [api/device.ts:1989](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1989)*
 
 This operation lists all existing storage configurations for the device.
 
@@ -928,7 +928,7 @@ ___
 
 ▸ **GetSystemBackup**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1210](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1210)*
+*Defined in [api/device.ts:1210](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1210)*
 
 This operation is retrieves system backup configuration file(s) from a device. The device should support return of back up configuration file(s) through the GetSystemBackup command. The backup is returned with reference to a name and mime-type together with binary data. The exact format of the backup configuration files is outside the scope of this standard.
 
@@ -941,7 +941,7 @@ ___
 
 ▸ **GetSystemDateAndTime**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1165](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1165)*
+*Defined in [api/device.ts:1165](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1165)*
 
 This operation gets the device system date and time. The device shall support the return of the daylight saving setting and of the manual system date and time (if applicable) or indication of NTP time (if applicable) through the GetSystemDateAndTime command. A device shall provide the UTCDateTime information.
 
@@ -954,7 +954,7 @@ ___
 
 ▸ **GetSystemLog**(LogType: *[SystemLogType](../enums/_api_types_.systemlogtype.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1217](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1217)*
+*Defined in [api/device.ts:1217](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1217)*
 
 This operation gets a system log from the device. The exact format of the system logs is outside the scope of this standard.
 
@@ -973,7 +973,7 @@ ___
 
 ▸ **GetSystemSupportInformation**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1224](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1224)*
+*Defined in [api/device.ts:1224](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1224)*
 
 This operation gets arbitary device diagnostics information from the device.
 
@@ -986,7 +986,7 @@ ___
 
 ▸ **GetSystemUris**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1936](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1936)*
+*Defined in [api/device.ts:1936](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1936)*
 
 This operation is used to retrieve URIs from which system information may be downloaded using HTTP. URIs may be returned for the following system information: System Logs. Multiple system logs may be returned, of different types. The exact format of the system logs is outside the scope of this specification. Support Information. This consists of arbitrary device diagnostics information from a device. The exact format of the diagnostic information is outside the scope of this specification. System Backup. The received file is a backup file that can be used to restore the current device configuration at a later date. The exact format of the backup configuration file is outside the scope of this specification. If the device allows retrieval of system logs, support information or system backup data, it should make them available via HTTP GET. If it does, it shall support the GetSystemUris command.
 
@@ -999,7 +999,7 @@ ___
 
 ▸ **GetUsers**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1368](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1368)*
+*Defined in [api/device.ts:1368](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1368)*
 
 This operation lists the registered users and corresponding credentials on a device. The device shall support retrieval of registered device users and their credentials for the user token through the GetUsers command.
 
@@ -1012,7 +1012,7 @@ ___
 
 ▸ **GetWsdlUrl**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1410](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1410)*
+*Defined in [api/device.ts:1410](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1410)*
 
 It is possible for an endpoint to request a URL that can be used to retrieve the complete schema and WSDL definitions of a device. The command gives in return a URL entry point where all the necessary product specific WSDL and schema definitions can be retrieved. The device shall provide a URL for WSDL and schema download through the GetWsdlUrl command.
 
@@ -1025,7 +1025,7 @@ ___
 
 ▸ **GetZeroConfiguration**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1561](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1561)*
+*Defined in [api/device.ts:1561](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1561)*
 
 This operation gets the zero-configuration from a device. If the device supports dynamic IP configuration according to \[RFC3927\], it shall support the return of IPv4 zero configuration address and status through the GetZeroConfiguration command. Devices supporting zero configuration on more than one interface shall use the extension to list the additional interface settings.
 
@@ -1038,7 +1038,7 @@ ___
 
 ▸ **LoadCACertificates**(CACertificate: *[Certificate](../interfaces/_api_types_.certificate.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1842](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1842)*
+*Defined in [api/device.ts:1842](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1842)*
 
 This command is used when it is necessary to load trusted CA certificates or trusted root certificates for the purpose of verification for its counterpart i.e. client certificate verification in TLS function or server certificate verification in IEEE 802.1X function. A device that support either TLS or IEEE 802.1X shall support this command. As for the supported certificate format, either DER format or PEM format is possible to be used. But a device that support this command shall support at least DER format as supported format type. The device may sort the received certificate(s) based on the public key and subject information in the certificate(s). Either all CA certificates are loaded successfully or a fault message shall be returned without loading any CA certificate.
 
@@ -1057,7 +1057,7 @@ ___
 
 ▸ **LoadCertificateWithPrivateKey**(CertificateWithPrivateKey: *[CertificateWithPrivateKey](../interfaces/_api_types_.certificatewithprivatekey.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1815](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1815)*
+*Defined in [api/device.ts:1815](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1815)*
 
 There might be some cases that a Certificate Authority or some other equivalent creates a certificate without having PKCS#10 certificate signing request. In such cases, the certificate will be bundled in conjunction with its private key. This command will be used for such use case scenarios. The certificate ID in the request is optionally set to the ID value the client wish to have. If the certificate ID is not specified in the request, device can choose the ID accordingly. This operation imports a private/public key pair into the device. The certificates shall be encoded using ASN.1 \[X.681\], \[X.682\], \[X.683\] DER \[X.690\] encoding rules. A device that does not support onboard key pair generation and support either TLS or IEEE 802.1X using client certificate shall support this command. A device that support onboard key pair generation MAY support this command. The security policy of a device that supports this operation should make sure that the private key is sufficiently protected.
 
@@ -1076,7 +1076,7 @@ ___
 
 ▸ **LoadCertificates**(NVTCertificate: *[Certificate](../interfaces/_api_types_.certificate.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1719](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1719)*
+*Defined in [api/device.ts:1719](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1719)*
 
 TLS server certificate(s) or IEEE 802.1X client certificate(s) created using the PKCS#10 certificate request command can be loaded into the device using this command (see Section 8.4.13). The certificate ID in the request shall be present. The device may sort the received certificate(s) based on the public key and subject information in the certificate(s). The certificate ID in the request will be the ID value the client wish to have. The device is supposed to scan the generated key pairs present in the device to identify which is the correspondent key pair with the loaded certificate and then make the link between the certificate and the key pair. A device that supports onboard key pair generation that support either TLS or IEEE 802.1X shall support this command. The certificates shall be encoded using ASN.1 \[X.681\], \[X.682\], \[X.683\] DER \[X.690\] encoding rules. This command is applicable to any device type, although the parameter name is called for historical reasons NVTCertificate.
 
@@ -1095,7 +1095,7 @@ ___
 
 ▸ **RemoveIPAddressFilter**(IPAddressFilter: *[IPAddressFilter](../interfaces/_api_types_.ipaddressfilter.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1605](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1605)*
+*Defined in [api/device.ts:1605](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1605)*
 
 This operation deletes an IP filter address from a device. If the device supports device access control based on IP filtering rules (denied or accepted ranges of IP addresses), the device shall support deletion of IP filtering addresses through the RemoveIPAddressFilter command.
 
@@ -1114,7 +1114,7 @@ ___
 
 ▸ **RemoveScopes**(ScopeItem: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1271](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1271)*
+*Defined in [api/device.ts:1271](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1271)*
 
 This operation deletes scope-configurable scope parameters from a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The device shall support deletion of discovery scope parameters through the RemoveScopes command. Table
 
@@ -1133,7 +1133,7 @@ ___
 
 ▸ **RestoreSystem**(BackupFiles: *[BackupFile](../interfaces/_api_types_.backupfile.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1200](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1200)*
+*Defined in [api/device.ts:1200](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1200)*
 
 This operation restores the system backup configuration files(s) previously retrieved from a device. The device should support restore of backup configuration file(s) through the RestoreSystem command. The exact format of the backup configuration file(s) is outside the scope of this standard. If the command is supported, it shall accept backup files returned by the GetSystemBackup command.
 
@@ -1152,7 +1152,7 @@ ___
 
 ▸ **ScanAvailableDot11Networks**(InterfaceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1918](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1918)*
+*Defined in [api/device.ts:1918](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1918)*
 
 This operation returns a lists of the wireless networks in range of the device. A device should support this operation.
 
@@ -1171,7 +1171,7 @@ ___
 
 ▸ **SendAuxiliaryCommand**(AuxiliaryCommand: *[AuxiliaryData](../modules/_api_types_.md#auxiliarydata)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1784](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1784)*
+*Defined in [api/device.ts:1784](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1784)*
 
 Manage auxiliary commands supported by a device, such as controlling an Infrared (IR) lamp, a heater or a wiper or a thermometer that is connected to the device. The supported commands can be retrieved via the AuxiliaryCommands capability. Although the name of the auxiliary commands can be freely defined, commands starting with the prefix tt: are reserved to define frequently used commands and these reserved commands shall all share the "tt:command\|parameter" syntax.
 
@@ -1194,7 +1194,7 @@ ___
 
 ▸ **SetAccessPolicy**(PolicyFile: *[BinaryData](../interfaces/_api_types_.binarydata.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1628](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1628)*
+*Defined in [api/device.ts:1628](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1628)*
 
 This command sets the device access security policy (for more details on the access security policy see the Get command). If the device supports access policy settings based on WS-Security authentication, then the device shall support this command.
 
@@ -1213,7 +1213,7 @@ ___
 
 ▸ **SetCertificatesStatus**(CertificateStatus: *[CertificateStatus](../interfaces/_api_types_.certificatestatus.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1674](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1674)*
+*Defined in [api/device.ts:1674](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1674)*
 
 This operation is specific to TLS functionality. This operation sets the status (enable/disable) of the device TLS server certificates. A device that supports TLS shall support this command. Typically only one device server certificate is allowed to be enabled at a time.
 
@@ -1232,7 +1232,7 @@ ___
 
 ▸ **SetClientCertificateMode**(Enabled: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1737](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1737)*
+*Defined in [api/device.ts:1737](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1737)*
 
 This operation is specific to TLS functionality. This operation sets the status (enabled/disabled) of the device TLS client authentication. A device that supports TLS shall support this command.
 
@@ -1251,7 +1251,7 @@ ___
 
 ▸ **SetDNS**(FromDHCP: *`boolean`*, SearchDomain: *`string`*, DNSManual: *[IPAddress](../interfaces/_api_types_.ipaddress.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1460](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1460)*
+*Defined in [api/device.ts:1460](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1460)*
 
 This operation sets the DNS settings on a device. It shall be possible to set the device DNS configurations through the SetDNS command.
 
@@ -1272,7 +1272,7 @@ ___
 
 ▸ **SetDPAddresses**(DPAddress: *[NetworkHost](../interfaces/_api_types_.networkhost.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1327](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1327)*
+*Defined in [api/device.ts:1327](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1327)*
 
 This operation sets the remote DP address or addresses on a device. If the device supports remote discovery, as specified in Section 7.4, the device shall support configuration of the remote DP address(es) through the SetDPAddresses command.
 
@@ -1291,7 +1291,7 @@ ___
 
 ▸ **SetDiscoveryMode**(DiscoveryMode: *[DiscoveryMode](../enums/_api_types_.discoverymode.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1289](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1289)*
+*Defined in [api/device.ts:1289](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1289)*
 
 This operation sets the discovery mode operation of a device. See Section 7.2 for the definition of the different device discovery modes. The device shall support configuration of the discovery mode setting through the SetDiscoveryMode command.
 
@@ -1310,7 +1310,7 @@ ___
 
 ▸ **SetDot1XConfiguration**(Dot1XConfiguration: *[Dot1XConfiguration](../interfaces/_api_types_.dot1xconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1862](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1862)*
+*Defined in [api/device.ts:1862](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1862)*
 
 While the CreateDot1XConfiguration command is trying to create a new configuration parameter set, this operation modifies existing IEEE 802.1X configuration parameter set of the device. A device that support IEEE 802.1X shall support this command.
 
@@ -1329,7 +1329,7 @@ ___
 
 ▸ **SetDynamicDNS**(Type: *[DynamicDNSType](../enums/_api_types_.dynamicdnstype.md)*, Name: *[DNSName](../modules/_api_types_.md#dnsname)*, TTL: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1498](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1498)*
+*Defined in [api/device.ts:1498](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1498)*
 
 This operation sets the dynamic DNS settings on a device. If the device supports dynamic DNS as specified in \[RFC 2136\] and \[RFC 4702\], it shall be possible to set the type, name and TTL through the SetDynamicDNS command.
 
@@ -1350,7 +1350,7 @@ ___
 
 ▸ **SetGeoLocation**(Location: *[LocationEntity](../interfaces/_api_types_.locationentity.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:2044](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L2044)*
+*Defined in [api/device.ts:2044](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L2044)*
 
 This operation allows to modify one or more geo configuration entries.
 
@@ -1369,7 +1369,7 @@ ___
 
 ▸ **SetHostname**(Name: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1437](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1437)*
+*Defined in [api/device.ts:1437](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1437)*
 
 This operation sets the hostname on a device. It shall be possible to set the device hostname configurations through the SetHostname command. A device shall accept string formated according to RFC 1123 section 2.1 or alternatively to RFC 952, other string shall be considered as invalid strings.
 
@@ -1388,7 +1388,7 @@ ___
 
 ▸ **SetHostnameFromDHCP**(FromDHCP: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1444](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1444)*
+*Defined in [api/device.ts:1444](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1444)*
 
 This operation controls whether the hostname is set manually or retrieved via DHCP.
 
@@ -1407,7 +1407,7 @@ ___
 
 ▸ **SetIPAddressFilter**(IPAddressFilter: *[IPAddressFilter](../interfaces/_api_types_.ipaddressfilter.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1587](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1587)*
+*Defined in [api/device.ts:1587](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1587)*
 
 This operation sets the IP address filter settings on a device. If the device supports device access control based on IP filtering rules (denied or accepted ranges of IP addresses), the device shall support configuration of IP filtering rules through the SetIPAddressFilter command.
 
@@ -1426,7 +1426,7 @@ ___
 
 ▸ **SetNTP**(FromDHCP: *`boolean`*, NTPManual: *[NetworkHost](../interfaces/_api_types_.networkhost.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1480](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1480)*
+*Defined in [api/device.ts:1480](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1480)*
 
 This operation sets the NTP settings on a device. If the device supports NTP, it shall be possible to set the NTP server settings through the SetNTP command. A device shall accept string formated according to RFC 1123 section 2.1 or alternatively to RFC 952, other string shall be considered as invalid strings. Changes to the NTP server list will not affect the clock mode DateTimeType. Use SetSystemDateAndTime to activate NTP operation.
 
@@ -1446,7 +1446,7 @@ ___
 
 ▸ **SetNetworkDefaultGateway**(IPv4Address: *[IPv4Address]()*, IPv6Address: *[IPv6Address]()*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1551](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1551)*
+*Defined in [api/device.ts:1551](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1551)*
 
 This operation sets the default gateway settings on a device. The device shall support configuration of default gateway through the SetNetworkDefaultGateway command.
 
@@ -1466,7 +1466,7 @@ ___
 
 ▸ **SetNetworkInterfaces**(InterfaceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, NetworkInterface: *[NetworkInterfaceSetConfiguration](../interfaces/_api_types_.networkinterfacesetconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1519](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1519)*
+*Defined in [api/device.ts:1519](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1519)*
 
 This operation sets the network interface configuration on a device. The device shall support network configuration of supported network interfaces through the SetNetworkInterfaces command. For interoperability with a client unaware of the IEEE 802.11 extension a device shall retain its IEEE 802.11 configuration if the IEEE 802.11 configuration element isn’t present in the request.
 
@@ -1486,7 +1486,7 @@ ___
 
 ▸ **SetNetworkProtocols**(NetworkProtocols: *[NetworkProtocol](../interfaces/_api_types_.networkprotocol.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1535](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1535)*
+*Defined in [api/device.ts:1535](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1535)*
 
 This operation configures defined network protocols on a device. The device shall support configuration of defined network protocols through the SetNetworkProtocols command.
 
@@ -1505,7 +1505,7 @@ ___
 
 ▸ **SetRelayOutputSettings**(RelayOutputToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Properties: *[RelayOutputSettings](../interfaces/_api_types_.relayoutputsettings.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1753](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1753)*
+*Defined in [api/device.ts:1753](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1753)*
 
 This operation sets the settings of a relay output. This method has been depricated with version 2.0. Refer to the DeviceIO service.
 
@@ -1525,7 +1525,7 @@ ___
 
 ▸ **SetRelayOutputState**(RelayOutputToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, LogicalState: *[RelayLogicalState](../enums/_api_types_.relaylogicalstate.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1761](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1761)*
+*Defined in [api/device.ts:1761](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1761)*
 
 This operation sets the state of a relay output. This method has been depricated with version 2.0. Refer to the DeviceIO service.
 
@@ -1545,7 +1545,7 @@ ___
 
 ▸ **SetRemoteDiscoveryMode**(RemoteDiscoveryMode: *[DiscoveryMode](../enums/_api_types_.discoverymode.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1309](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1309)*
+*Defined in [api/device.ts:1309](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1309)*
 
 This operation sets the remote discovery mode of operation of a device. See Section 7.4 for the definition of remote discovery remote extensions. A device that supports remote discovery shall support configuration of the discovery mode setting through the SetRemoteDiscoveryMode command.
 
@@ -1564,7 +1564,7 @@ ___
 
 ▸ **SetRemoteUser**(RemoteUser: *[RemoteUser](../interfaces/_api_types_.remoteuser.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1359](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1359)*
+*Defined in [api/device.ts:1359](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1359)*
 
 This operation sets the remote user. A device supporting remote user handling shall support this operation. The user is only valid for the WS-UserToken profile or as a HTTP / RTSP user. The password that is set shall always be the original (not derived) password. If UseDerivedPassword is set password derivation shall be done by the device when connecting to a remote device.The algorithm to use for deriving the password is described in section 5.12.2.1 of the core specification. To remove the remote user SetRemoteUser should be called without the RemoteUser parameter.
 
@@ -1583,7 +1583,7 @@ ___
 
 ▸ **SetScopes**(Scopes: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1251](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1251)*
+*Defined in [api/device.ts:1251](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1251)*
 
 This operation sets the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message. This operation replaces all existing configurable scope parameters (not fixed parameters). If this shall be avoided, one should use the scope add command instead. The device shall support configuration of discovery scope parameters through the SetScopes command.
 
@@ -1602,7 +1602,7 @@ ___
 
 ▸ **SetStorageConfiguration**(StorageConfiguration: *`any`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:2017](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L2017)*
+*Defined in [api/device.ts:2017](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L2017)*
 
 This operation modifies an existing Storage configuration.
 
@@ -1621,7 +1621,7 @@ ___
 
 ▸ **SetSystemDateAndTime**(DateTimeType: *[SetDateTimeType](../enums/_api_types_.setdatetimetype.md)*, DaylightSavings: *`boolean`*, TimeZone: *[TimeZone](../interfaces/_api_types_.timezone.md)*, UTCDateTime: *[DateTime](../interfaces/_api_types_.datetime.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1155](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1155)*
+*Defined in [api/device.ts:1155](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1155)*
 
 This operation sets the device system date and time. The device shall support the configuration of the daylight saving setting and of the manual system date and time (if applicable) or indication of NTP time (if applicable) through the SetSystemDateAndTime command. If system time and date are set manually, the client shall include UTCDateTime in the request. A TimeZone token which is not formed according to the rules of IEEE 1003.1 section 8.3 is considered as invalid timezone. The DayLightSavings flag should be set to true to activate any DST settings of the TimeZone string. Clear the DayLightSavings flag if the DST portion of the TimeZone settings should be ignored.
 
@@ -1643,7 +1643,7 @@ ___
 
 ▸ **SetSystemFactoryDefault**(FactoryDefault: *[FactoryDefaultType](../enums/_api_types_.factorydefaulttype.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1172](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1172)*
+*Defined in [api/device.ts:1172](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1172)*
 
 This operation reloads the parameters on the device to their factory default values.
 
@@ -1662,7 +1662,7 @@ ___
 
 ▸ **SetUser**(User: *[User](../interfaces/_api_types_.user.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1400](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1400)*
+*Defined in [api/device.ts:1400](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1400)*
 
 This operation updates the settings for one or several users on a device for authentication purposes. The device shall support update of device users and their credentials through the SetUser command. Either all change requests are processed successfully or a fault message shall be returned and no change requests be processed.
 
@@ -1681,7 +1681,7 @@ ___
 
 ▸ **SetZeroConfiguration**(InterfaceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Enabled: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1568](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1568)*
+*Defined in [api/device.ts:1568](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1568)*
 
 This operation sets the zero-configuration. Use GetCapalities to get if zero-zero-configuration is supported or not.
 
@@ -1701,7 +1701,7 @@ ___
 
 ▸ **StartFirmwareUpgrade**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1958](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1958)*
+*Defined in [api/device.ts:1958](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1958)*
 
 This operation initiates a firmware upgrade using the HTTP POST mechanism. The response to the command includes an HTTP URL to which the upgrade file may be uploaded. The actual upgrade takes place as soon as the HTTP POST operation has completed. The device should support firmware upgrade through the StartFirmwareUpgrade command. The exact format of the firmware data is outside the scope of this specification. Firmware upgrade over HTTP may be achieved using the following steps: Client calls StartFirmwareUpgrade. Server responds with upload URI and optional delay value. Client waits for delay duration if specified by server. Client transmits the firmware image to the upload URI using HTTP POST. Server reprograms itself using the uploaded image, then reboots.
 
@@ -1716,7 +1716,7 @@ ___
 
 ▸ **StartSystemRestore**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1980](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1980)*
+*Defined in [api/device.ts:1980](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1980)*
 
 This operation initiates a system restore from backed up configuration data using the HTTP POST mechanism. The response to the command includes an HTTP URL to which the backup file may be uploaded. The actual restore takes place as soon as the HTTP POST operation has completed. Devices should support system restore through the StartSystemRestore command. The exact format of the backup configuration data is outside the scope of this specification. System restore over HTTP may be achieved using the following steps: Client calls StartSystemRestore. Server responds with upload URI. Client transmits the configuration data to the upload URI using HTTP POST. Server applies the uploaded configuration, then reboots if necessary.
 
@@ -1731,7 +1731,7 @@ ___
 
 ▸ **SystemReboot**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1189](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1189)*
+*Defined in [api/device.ts:1189](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1189)*
 
 This operation reboots the device.
 
@@ -1744,7 +1744,7 @@ ___
 
 ▸ **UpgradeSystemFirmware**(Firmware: *[AttachmentData](../interfaces/_api_types_.attachmentdata.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/device.ts:1182](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1182)*
+*Defined in [api/device.ts:1182](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1182)*
 
 This operation upgrades a device firmware version. After a successful upgrade the response message is sent before the device reboots. The device should support firmware upgrade through the UpgradeSystemFirmware command. The exact format of the firmware data is outside the scope of this standard.
 
@@ -1763,7 +1763,7 @@ ___
 
 ▸ **AddIPAddressFilter**(IPAddressFilter: *[IPAddressFilter](../interfaces/_api_types_.ipaddressfilter.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:582](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L582)*
+*Defined in [api/device.ts:582](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L582)*
 
 This operation adds an IP filter address to a device. If the device supports device access control based on IP filtering rules (denied or accepted ranges of IP addresses), the device shall support adding of IP filtering addresses through the AddIPAddressFilter command.
 
@@ -1782,7 +1782,7 @@ ___
 
 ▸ **AddScopes**(ScopeItem: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:174](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L174)*
+*Defined in [api/device.ts:174](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L174)*
 
 This operation adds new configurable scope parameters to a device. The scope parameters are used in the device discovery to match a probe message. The device shall support addition of discovery scope parameters through the AddScopes command.
 
@@ -1801,7 +1801,7 @@ ___
 
 ▸ **CreateCertificate**(CertificateID?: *`undefined` \| `string`*, Subject?: *`undefined` \| `string`*, ValidNotBefore?: *`undefined` \| `string`*, ValidNotAfter?: *`undefined` \| `string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:637](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L637)*
+*Defined in [api/device.ts:637](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L637)*
 
 This operation generates a private/public key pair and also can create a self-signed device certificate as a result of key pair generation. The certificate is created using a suitable onboard key pair generation mechanism. If a device supports onboard key pair generation, the device that supports TLS shall support this certificate creation command. And also, if a device supports onboard key pair generation, the device that support IEEE 802.1X shall support this command for the purpose of key pair generation. Certificates and key pairs are identified using certificate IDs. These IDs are either chosen by the certificate generation requester or by the device (in case that no ID value is given).
 
@@ -1823,7 +1823,7 @@ ___
 
 ▸ **CreateDot1XConfiguration**(Dot1XConfiguration: *[Dot1XConfiguration](../interfaces/_api_types_.dot1xconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:881](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L881)*
+*Defined in [api/device.ts:881](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L881)*
 
 This operation newly creates IEEE 802.1X configuration parameter set of the device. The device shall support this command if it supports IEEE 802.1X. If the device receives this request with already existing configuration token (Dot1XConfigurationToken) specification, the device should respond with 'ter:ReferenceToken ' error to indicate there is some configuration conflict.
 
@@ -1842,7 +1842,7 @@ ___
 
 ▸ **CreateStorageConfiguration**(StorageConfiguration: *`any`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1051](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1051)*
+*Defined in [api/device.ts:1051](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1051)*
 
 This operation creates a new storage configuration. The configuration data shall be created in the device and shall be persistent (remain after reboot).
 
@@ -1861,7 +1861,7 @@ ___
 
 ▸ **CreateUsers**(User: *[User](../interfaces/_api_types_.user.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:319](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L319)*
+*Defined in [api/device.ts:319](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L319)*
 
 This operation creates new device users and corresponding credentials on a device for authentication purposes. The device shall support creation of device users and their credentials through the CreateUsers command. Either all users are created successfully or a fault message shall be returned without creating any user. ONVIF compliant devices are recommended to support password length of at least 28 bytes, as clients may follow the password derivation mechanism which results in 'password equivalent' of length 28 bytes, as described in section 3.1.2 of the ONVIF security white paper.
 
@@ -1880,7 +1880,7 @@ ___
 
 ▸ **DeleteCertificates**(CertificateID: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:687](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L687)*
+*Defined in [api/device.ts:687](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L687)*
 
 This operation deletes a certificate or multiple certificates. The device MAY also delete a private/public key pair which is coupled with the certificate to be deleted. The device that support either TLS or IEEE 802.1X shall support the deletion of a certificate or multiple certificates through this command. Either all certificates are deleted successfully or a fault message shall be returned without deleting any certificate.
 
@@ -1899,7 +1899,7 @@ ___
 
 ▸ **DeleteDot1XConfiguration**(Dot1XConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:930](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L930)*
+*Defined in [api/device.ts:930](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L930)*
 
 This operation deletes an IEEE 802.1X configuration parameter set from the device. Which configuration should be deleted is specified by the 'Dot1XConfigurationToken' in the request. A device that support IEEE 802.1X shall support this command.
 
@@ -1918,7 +1918,7 @@ ___
 
 ▸ **DeleteGeoLocation**(Location: *[LocationEntity](../interfaces/_api_types_.locationentity.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1117](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1117)*
+*Defined in [api/device.ts:1117](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1117)*
 
 This operation deletes the given geo location entries.
 
@@ -1937,7 +1937,7 @@ ___
 
 ▸ **DeleteStorageConfiguration**(Token: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1084](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1084)*
+*Defined in [api/device.ts:1084](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1084)*
 
 This operation deletes the given storage configuration and configuration change shall always be persistent.
 
@@ -1956,7 +1956,7 @@ ___
 
 ▸ **DeleteUsers**(Username: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:331](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L331)*
+*Defined in [api/device.ts:331](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L331)*
 
 This operation deletes users on a device. The device shall support deletion of device users and their credentials through the DeleteUsers command. A device may have one or more fixed users that cannot be deleted to ensure access to the unit. Either all users are deleted successfully or a fault message shall be returned and no users be deleted.
 
@@ -1975,7 +1975,7 @@ ___
 
 ▸ **GetAccessPolicy**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:609](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L609)*
+*Defined in [api/device.ts:609](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L609)*
 
 Access to different services and sub-sets of services should be subject to access control. The WS-Security framework gives the prerequisite for end-point authentication. Authorization decisions can then be taken using an access security policy. This standard does not mandate any particular policy description format or security policy but this is up to the device manufacturer or system provider to choose policy and policy description format of choice. However, an access policy (in arbitrary format) can be requested using this command. If the device supports access policy settings based on WS-Security authentication, then the device shall support this command.
 
@@ -1988,7 +1988,7 @@ ___
 
 ▸ **GetCACertificates**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:816](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L816)*
+*Defined in [api/device.ts:816](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L816)*
 
 CA certificates will be loaded into a device and be used for the sake of following two cases. The one is for the purpose of TLS client authentication in TLS server function. The other one is for the purpose of Authentication Server authentication in IEEE 802.1X function. This operation gets all CA certificates loaded into a device. A device that supports either TLS client authentication or IEEE 802.1X shall support this command and the returned certificates shall be encoded using ASN.1 \[X.681\], \[X.682\], \[X.683\] DER \[X.690\] encoding rules.
 
@@ -2001,7 +2001,7 @@ ___
 
 ▸ **GetCapabilities**(Category?: *[CapabilityCategory](../enums/_api_types_.capabilitycategory.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:364](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L364)*
+*Defined in [api/device.ts:364](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L364)*
 
 This method has been replaced by the more generic GetServices method. For capabilities of individual services refer to the GetServiceCapabilities methods.
 
@@ -2020,7 +2020,7 @@ ___
 
 ▸ **GetCertificateInformation**(CertificateID: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:851](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L851)*
+*Defined in [api/device.ts:851](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L851)*
 
 This operation requests the information of a certificate specified by certificate ID. The device should respond with its “Issuer DN”, “Subject DN”, “Key usage”, "Extended key usage”, “Key Length”, “Version”, “Serial Number”, “Signature Algorithm” and “Validity” data as the information of the certificate, as long as the device can retrieve such information from the specified certificate. A device that supports either TLS or IEEE 802.1X should support this command.
 
@@ -2039,7 +2039,7 @@ ___
 
 ▸ **GetCertificates**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:652](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L652)*
+*Defined in [api/device.ts:652](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L652)*
 
 This operation gets all device server certificates (including self-signed) for the purpose of TLS authentication and all device client certificates for the purpose of IEEE 802.1X authentication. This command lists only the TLS server certificates and IEEE 802.1X client certificates for the device (neither trusted CA certificates nor trusted root certificates). The certificates are returned as binary data. A device that supports TLS shall support this command and the certificates shall be encoded using ASN.1 \[X.681\], \[X.682\], \[X.683\] DER \[X.690\] encoding rules.
 
@@ -2052,7 +2052,7 @@ ___
 
 ▸ **GetCertificatesStatus**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:663](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L663)*
+*Defined in [api/device.ts:663](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L663)*
 
 This operation is specific to TLS functionality. This operation gets the status (enabled/disabled) of the device TLS server certificates. A device that supports TLS shall support this command.
 
@@ -2065,7 +2065,7 @@ ___
 
 ▸ **GetClientCertificateMode**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:736](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L736)*
+*Defined in [api/device.ts:736](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L736)*
 
 This operation is specific to TLS functionality. This operation gets the status (enabled/disabled) of the device TLS client authentication. A device that supports TLS shall support this command.
 
@@ -2078,7 +2078,7 @@ ___
 
 ▸ **GetDNS**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:406](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L406)*
+*Defined in [api/device.ts:406](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L406)*
 
 This operation gets the DNS settings from a device. The device shall return its DNS configurations through the GetDNS command.
 
@@ -2091,7 +2091,7 @@ ___
 
 ▸ **GetDPAddresses**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:244](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L244)*
+*Defined in [api/device.ts:244](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L244)*
 
 This operation gets the remote DP address or addresses from a device. If the device supports remote discovery, as specified in Section 7.4, the device shall support retrieval of the remote DP address(es) through the GetDPAddresses command.
 
@@ -2104,7 +2104,7 @@ ___
 
 ▸ **GetDeviceInformation**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L30)*
+*Defined in [api/device.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L30)*
 
 This operation gets basic device information from the device.
 
@@ -2117,7 +2117,7 @@ ___
 
 ▸ **GetDiscoveryMode**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:198](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L198)*
+*Defined in [api/device.ts:198](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L198)*
 
 This operation gets the discovery mode of a device. See Section 7.2 for the definition of the different device discovery modes. The device shall support retrieval of the discovery mode setting through the GetDiscoveryMode command.
 
@@ -2130,7 +2130,7 @@ ___
 
 ▸ **GetDot11Capabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:940](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L940)*
+*Defined in [api/device.ts:940](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L940)*
 
 This operation returns the IEEE802.11 capabilities. The device shall support this operation.
 
@@ -2143,7 +2143,7 @@ ___
 
 ▸ **GetDot11Status**(InterfaceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:950](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L950)*
+*Defined in [api/device.ts:950](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L950)*
 
 This operation returns the status of a wireless network interface. The device shall support this command.
 
@@ -2162,7 +2162,7 @@ ___
 
 ▸ **GetDot1XConfiguration**(Dot1XConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:905](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L905)*
+*Defined in [api/device.ts:905](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L905)*
 
 This operation gets one IEEE 802.1X configuration parameter set from the device by specifying the configuration token (Dot1XConfigurationToken). A device that supports IEEE 802.1X shall support this command. Regardless of whether the 802.1X method in the retrieved configuration has a password or not, the device shall not include the Password element in the response.
 
@@ -2181,7 +2181,7 @@ ___
 
 ▸ **GetDot1XConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:919](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L919)*
+*Defined in [api/device.ts:919](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L919)*
 
 This operation gets all the existing IEEE 802.1X configuration parameter sets from the device. The device shall respond with all the IEEE 802.1X configurations so that the client can get to know how many IEEE 802.1X configurations are existing and how they are configured. A device that support IEEE 802.1X shall support this command. Regardless of whether the 802.1X method in the retrieved configuration has a password or not, the device shall not include the Password element in the response.
 
@@ -2194,7 +2194,7 @@ ___
 
 ▸ **GetDynamicDNS**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:451](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L451)*
+*Defined in [api/device.ts:451](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L451)*
 
 This operation gets the dynamic DNS settings from a device. If the device supports dynamic DNS as specified in \[RFC 2136\] and \[RFC 4702\], it shall be possible to get the type, name and TTL through the GetDynamicDNS command.
 
@@ -2207,7 +2207,7 @@ ___
 
 ▸ **GetEndpointReference**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:267](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L267)*
+*Defined in [api/device.ts:267](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L267)*
 
 A client can ask for the device service endpoint reference address property that can be used to derive the password equivalent for remote user operation. The device shall support the GetEndpointReference command returning the address property of the device service endpoint reference.
 
@@ -2220,7 +2220,7 @@ ___
 
 ▸ **GetGeoLocation**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1095](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1095)*
+*Defined in [api/device.ts:1095](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1095)*
 
 This operation lists all existing geo location configurations for the device.
 
@@ -2233,7 +2233,7 @@ ___
 
 ▸ **GetHostname**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:374](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L374)*
+*Defined in [api/device.ts:374](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L374)*
 
 This operation is used by an endpoint to get the hostname from a device. The device shall return its hostname configurations through the GetHostname command.
 
@@ -2246,7 +2246,7 @@ ___
 
 ▸ **GetIPAddressFilter**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:559](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L559)*
+*Defined in [api/device.ts:559](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L559)*
 
 This operation gets the IP address filter settings from a device. If the device supports device access control based on IP filtering rules (denied or accepted ranges of IP addresses), the device shall support the GetIPAddressFilter command.
 
@@ -2259,7 +2259,7 @@ ___
 
 ▸ **GetNTP**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:426](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L426)*
+*Defined in [api/device.ts:426](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L426)*
 
 This operation gets the NTP settings from a device. If the device supports NTP, it shall be possible to get the NTP server settings through the GetNTP command.
 
@@ -2272,7 +2272,7 @@ ___
 
 ▸ **GetNetworkDefaultGateway**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:517](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L517)*
+*Defined in [api/device.ts:517](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L517)*
 
 This operation gets the default gateway settings from a device. The device shall support the GetNetworkDefaultGateway command returning configured default gateway address(es).
 
@@ -2285,7 +2285,7 @@ ___
 
 ▸ **GetNetworkInterfaces**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:473](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L473)*
+*Defined in [api/device.ts:473](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L473)*
 
 This operation gets the network interface configuration from a device. The device shall support return of network interface configuration settings as defined by the NetworkInterface type through the GetNetworkInterfaces command.
 
@@ -2298,7 +2298,7 @@ ___
 
 ▸ **GetNetworkProtocols**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:497](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L497)*
+*Defined in [api/device.ts:497](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L497)*
 
 This operation gets defined network protocols from a device. The device shall support the GetNetworkProtocols command returning configured network protocols.
 
@@ -2311,7 +2311,7 @@ ___
 
 ▸ **GetPkcs10Request**(CertificateID: *`string`*, Subject?: *`undefined` \| `string`*, Attributes?: *[BinaryData](../interfaces/_api_types_.binarydata.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:703](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L703)*
+*Defined in [api/device.ts:703](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L703)*
 
 This operation requests a PKCS #10 certificate signature request from the device. The returned information field shall be either formatted exactly as specified in \[PKCS#10\] or PEM encoded \[PKCS#10\] format. In order for this command to work, the device must already have a private/public key pair. This key pair should be referred by CertificateID as specified in the input parameter description. This CertificateID refers to the key pair generated using CreateCertificate command. A device that support onboard key pair generation that supports either TLS or IEEE 802.1X using client certificate shall support this command.
 
@@ -2332,7 +2332,7 @@ ___
 
 ▸ **GetRelayOutputs**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:757](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L757)*
+*Defined in [api/device.ts:757](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L757)*
 
 This operation gets a list of all available relay outputs and their settings. This method has been depricated with version 2.0. Refer to the DeviceIO service.
 
@@ -2345,7 +2345,7 @@ ___
 
 ▸ **GetRemoteDiscoveryMode**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:221](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L221)*
+*Defined in [api/device.ts:221](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L221)*
 
 This operation gets the remote discovery mode of a device. See Section 7.4 for the definition of remote discovery extensions. A device that supports remote discovery shall support retrieval of the remote discovery mode setting through the GetRemoteDiscoveryMode command.
 
@@ -2358,7 +2358,7 @@ ___
 
 ▸ **GetRemoteUser**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:279](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L279)*
+*Defined in [api/device.ts:279](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L279)*
 
 This operation returns the configured remote user (if any). A device supporting remote user handling shall support this operation. The user is only valid for the WS-UserToken profile or as a HTTP / RTSP user. The algorithm to use for deriving the password is described in section 5.12.2.1 of the core specification.
 
@@ -2371,7 +2371,7 @@ ___
 
 ▸ **GetScopes**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:150](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L150)*
+*Defined in [api/device.ts:150](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L150)*
 
 This operation requests the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The Scope parameters are of two different types: Fixed Configurable
 
@@ -2386,7 +2386,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L21)*
+*Defined in [api/device.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L21)*
 
 Returns the capabilities of the device service. The result is returned in a typed answer.
 
@@ -2399,7 +2399,7 @@ ___
 
 ▸ **GetServices**(IncludeCapability: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L12)*
+*Defined in [api/device.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L12)*
 
 Returns information about services on the device.
 
@@ -2418,7 +2418,7 @@ ___
 
 ▸ **GetStorageConfiguration**(Token: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1062](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1062)*
+*Defined in [api/device.ts:1062](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1062)*
 
 This operation retrieves the Storage configuration associated with the given storage configuration token.
 
@@ -2437,7 +2437,7 @@ ___
 
 ▸ **GetStorageConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1039](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1039)*
+*Defined in [api/device.ts:1039](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1039)*
 
 This operation lists all existing storage configurations for the device.
 
@@ -2450,7 +2450,7 @@ ___
 
 ▸ **GetSystemBackup**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:114](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L114)*
+*Defined in [api/device.ts:114](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L114)*
 
 This operation is retrieves system backup configuration file(s) from a device. The device should support return of back up configuration file(s) through the GetSystemBackup command. The backup is returned with reference to a name and mime-type together with binary data. The exact format of the backup configuration files is outside the scope of this standard.
 
@@ -2463,7 +2463,7 @@ ___
 
 ▸ **GetSystemDateAndTime**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:59](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L59)*
+*Defined in [api/device.ts:59](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L59)*
 
 This operation gets the device system date and time. The device shall support the return of the daylight saving setting and of the manual system date and time (if applicable) or indication of NTP time (if applicable) through the GetSystemDateAndTime command. A device shall provide the UTCDateTime information.
 
@@ -2476,7 +2476,7 @@ ___
 
 ▸ **GetSystemLog**(LogType: *[SystemLogType](../enums/_api_types_.systemlogtype.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:123](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L123)*
+*Defined in [api/device.ts:123](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L123)*
 
 This operation gets a system log from the device. The exact format of the system logs is outside the scope of this standard.
 
@@ -2495,7 +2495,7 @@ ___
 
 ▸ **GetSystemSupportInformation**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:132](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L132)*
+*Defined in [api/device.ts:132](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L132)*
 
 This operation gets arbitary device diagnostics information from the device.
 
@@ -2508,7 +2508,7 @@ ___
 
 ▸ **GetSystemUris**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:980](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L980)*
+*Defined in [api/device.ts:980](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L980)*
 
 This operation is used to retrieve URIs from which system information may be downloaded using HTTP. URIs may be returned for the following system information: System Logs. Multiple system logs may be returned, of different types. The exact format of the system logs is outside the scope of this specification. Support Information. This consists of arbitrary device diagnostics information from a device. The exact format of the diagnostic information is outside the scope of this specification. System Backup. The received file is a backup file that can be used to restore the current device configuration at a later date. The exact format of the backup configuration file is outside the scope of this specification. If the device allows retrieval of system logs, support information or system backup data, it should make them available via HTTP GET. If it does, it shall support the GetSystemUris command.
 
@@ -2521,7 +2521,7 @@ ___
 
 ▸ **GetUsers**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:304](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L304)*
+*Defined in [api/device.ts:304](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L304)*
 
 This operation lists the registered users and corresponding credentials on a device. The device shall support retrieval of registered device users and their credentials for the user token through the GetUsers command.
 
@@ -2534,7 +2534,7 @@ ___
 
 ▸ **GetWsdlUrl**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:354](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L354)*
+*Defined in [api/device.ts:354](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L354)*
 
 It is possible for an endpoint to request a URL that can be used to retrieve the complete schema and WSDL definitions of a device. The command gives in return a URL entry point where all the necessary product specific WSDL and schema definitions can be retrieved. The device shall provide a URL for WSDL and schema download through the GetWsdlUrl command.
 
@@ -2547,7 +2547,7 @@ ___
 
 ▸ **GetZeroConfiguration**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:539](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L539)*
+*Defined in [api/device.ts:539](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L539)*
 
 This operation gets the zero-configuration from a device. If the device supports dynamic IP configuration according to \[RFC3927\], it shall support the return of IPv4 zero configuration address and status through the GetZeroConfiguration command. Devices supporting zero configuration on more than one interface shall use the extension to list the additional interface settings.
 
@@ -2560,7 +2560,7 @@ ___
 
 ▸ **LoadCACertificates**(CACertificate: *[Certificate](../interfaces/_api_types_.certificate.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:868](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L868)*
+*Defined in [api/device.ts:868](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L868)*
 
 This command is used when it is necessary to load trusted CA certificates or trusted root certificates for the purpose of verification for its counterpart i.e. client certificate verification in TLS function or server certificate verification in IEEE 802.1X function. A device that support either TLS or IEEE 802.1X shall support this command. As for the supported certificate format, either DER format or PEM format is possible to be used. But a device that support this command shall support at least DER format as supported format type. The device may sort the received certificate(s) based on the public key and subject information in the certificate(s). Either all CA certificates are loaded successfully or a fault message shall be returned without loading any CA certificate.
 
@@ -2579,7 +2579,7 @@ ___
 
 ▸ **LoadCertificateWithPrivateKey**(CertificateWithPrivateKey: *[CertificateWithPrivateKey](../interfaces/_api_types_.certificatewithprivatekey.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:837](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L837)*
+*Defined in [api/device.ts:837](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L837)*
 
 There might be some cases that a Certificate Authority or some other equivalent creates a certificate without having PKCS#10 certificate signing request. In such cases, the certificate will be bundled in conjunction with its private key. This command will be used for such use case scenarios. The certificate ID in the request is optionally set to the ID value the client wish to have. If the certificate ID is not specified in the request, device can choose the ID accordingly. This operation imports a private/public key pair into the device. The certificates shall be encoded using ASN.1 \[X.681\], \[X.682\], \[X.683\] DER \[X.690\] encoding rules. A device that does not support onboard key pair generation and support either TLS or IEEE 802.1X using client certificate shall support this command. A device that support onboard key pair generation MAY support this command. The security policy of a device that supports this operation should make sure that the private key is sufficiently protected.
 
@@ -2598,7 +2598,7 @@ ___
 
 ▸ **LoadCertificates**(NVTCertificate: *[Certificate](../interfaces/_api_types_.certificate.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:725](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L725)*
+*Defined in [api/device.ts:725](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L725)*
 
 TLS server certificate(s) or IEEE 802.1X client certificate(s) created using the PKCS#10 certificate request command can be loaded into the device using this command (see Section 8.4.13). The certificate ID in the request shall be present. The device may sort the received certificate(s) based on the public key and subject information in the certificate(s). The certificate ID in the request will be the ID value the client wish to have. The device is supposed to scan the generated key pairs present in the device to identify which is the correspondent key pair with the loaded certificate and then make the link between the certificate and the key pair. A device that supports onboard key pair generation that support either TLS or IEEE 802.1X shall support this command. The certificates shall be encoded using ASN.1 \[X.681\], \[X.682\], \[X.683\] DER \[X.690\] encoding rules. This command is applicable to any device type, although the parameter name is called for historical reasons NVTCertificate.
 
@@ -2617,7 +2617,7 @@ ___
 
 ▸ **RemoveIPAddressFilter**(IPAddressFilter: *[IPAddressFilter](../interfaces/_api_types_.ipaddressfilter.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:593](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L593)*
+*Defined in [api/device.ts:593](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L593)*
 
 This operation deletes an IP filter address from a device. If the device supports device access control based on IP filtering rules (denied or accepted ranges of IP addresses), the device shall support deletion of IP filtering addresses through the RemoveIPAddressFilter command.
 
@@ -2636,7 +2636,7 @@ ___
 
 ▸ **RemoveScopes**(ScopeItem: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:187](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L187)*
+*Defined in [api/device.ts:187](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L187)*
 
 This operation deletes scope-configurable scope parameters from a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The device shall support deletion of discovery scope parameters through the RemoveScopes command. Table
 
@@ -2655,7 +2655,7 @@ ___
 
 ▸ **RestoreSystem**(BackupFiles: *[BackupFile](../interfaces/_api_types_.backupfile.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L102)*
+*Defined in [api/device.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L102)*
 
 This operation restores the system backup configuration files(s) previously retrieved from a device. The device should support restore of backup configuration file(s) through the RestoreSystem command. The exact format of the backup configuration file(s) is outside the scope of this standard. If the command is supported, it shall accept backup files returned by the GetSystemBackup command.
 
@@ -2674,7 +2674,7 @@ ___
 
 ▸ **ScanAvailableDot11Networks**(InterfaceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:960](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L960)*
+*Defined in [api/device.ts:960](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L960)*
 
 This operation returns a lists of the wireless networks in range of the device. A device should support this operation.
 
@@ -2693,7 +2693,7 @@ ___
 
 ▸ **SendAuxiliaryCommand**(AuxiliaryCommand: *[AuxiliaryData](../modules/_api_types_.md#auxiliarydata)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:802](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L802)*
+*Defined in [api/device.ts:802](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L802)*
 
 Manage auxiliary commands supported by a device, such as controlling an Infrared (IR) lamp, a heater or a wiper or a thermometer that is connected to the device. The supported commands can be retrieved via the AuxiliaryCommands capability. Although the name of the auxiliary commands can be freely defined, commands starting with the prefix tt: are reserved to define frequently used commands and these reserved commands shall all share the "tt:command\|parameter" syntax.
 
@@ -2716,7 +2716,7 @@ ___
 
 ▸ **SetAccessPolicy**(PolicyFile: *[BinaryData](../interfaces/_api_types_.binarydata.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:620](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L620)*
+*Defined in [api/device.ts:620](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L620)*
 
 This command sets the device access security policy (for more details on the access security policy see the Get command). If the device supports access policy settings based on WS-Security authentication, then the device shall support this command.
 
@@ -2735,7 +2735,7 @@ ___
 
 ▸ **SetCertificatesStatus**(CertificateStatus?: *[CertificateStatus]()*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:674](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L674)*
+*Defined in [api/device.ts:674](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L674)*
 
 This operation is specific to TLS functionality. This operation sets the status (enable/disable) of the device TLS server certificates. A device that supports TLS shall support this command. Typically only one device server certificate is allowed to be enabled at a time.
 
@@ -2754,7 +2754,7 @@ ___
 
 ▸ **SetClientCertificateMode**(Enabled: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:747](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L747)*
+*Defined in [api/device.ts:747](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L747)*
 
 This operation is specific to TLS functionality. This operation sets the status (enabled/disabled) of the device TLS client authentication. A device that supports TLS shall support this command.
 
@@ -2773,7 +2773,7 @@ ___
 
 ▸ **SetDNS**(FromDHCP: *`boolean`*, SearchDomain?: *`undefined` \| `string`*, DNSManual?: *[IPAddress](../interfaces/_api_types_.ipaddress.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:416](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L416)*
+*Defined in [api/device.ts:416](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L416)*
 
 This operation sets the DNS settings on a device. It shall be possible to set the device DNS configurations through the SetDNS command.
 
@@ -2794,7 +2794,7 @@ ___
 
 ▸ **SetDPAddresses**(DPAddress?: *[NetworkHost](../interfaces/_api_types_.networkhost.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:255](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L255)*
+*Defined in [api/device.ts:255](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L255)*
 
 This operation sets the remote DP address or addresses on a device. If the device supports remote discovery, as specified in Section 7.4, the device shall support configuration of the remote DP address(es) through the SetDPAddresses command.
 
@@ -2813,7 +2813,7 @@ ___
 
 ▸ **SetDiscoveryMode**(DiscoveryMode: *[DiscoveryMode](../enums/_api_types_.discoverymode.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:209](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L209)*
+*Defined in [api/device.ts:209](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L209)*
 
 This operation sets the discovery mode operation of a device. See Section 7.2 for the definition of the different device discovery modes. The device shall support configuration of the discovery mode setting through the SetDiscoveryMode command.
 
@@ -2832,7 +2832,7 @@ ___
 
 ▸ **SetDot1XConfiguration**(Dot1XConfiguration: *[Dot1XConfiguration](../interfaces/_api_types_.dot1xconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:892](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L892)*
+*Defined in [api/device.ts:892](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L892)*
 
 While the CreateDot1XConfiguration command is trying to create a new configuration parameter set, this operation modifies existing IEEE 802.1X configuration parameter set of the device. A device that support IEEE 802.1X shall support this command.
 
@@ -2851,7 +2851,7 @@ ___
 
 ▸ **SetDynamicDNS**(Type: *[DynamicDNSType](../enums/_api_types_.dynamicdnstype.md)*, Name?: *[DNSName](../modules/_api_types_.md#dnsname)*, TTL?: *`undefined` \| `string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:462](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L462)*
+*Defined in [api/device.ts:462](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L462)*
 
 This operation sets the dynamic DNS settings on a device. If the device supports dynamic DNS as specified in \[RFC 2136\] and \[RFC 4702\], it shall be possible to set the type, name and TTL through the SetDynamicDNS command.
 
@@ -2872,7 +2872,7 @@ ___
 
 ▸ **SetGeoLocation**(Location: *[LocationEntity](../interfaces/_api_types_.locationentity.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1106](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1106)*
+*Defined in [api/device.ts:1106](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1106)*
 
 This operation allows to modify one or more geo configuration entries.
 
@@ -2891,7 +2891,7 @@ ___
 
 ▸ **SetHostname**(Name: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:387](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L387)*
+*Defined in [api/device.ts:387](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L387)*
 
 This operation sets the hostname on a device. It shall be possible to set the device hostname configurations through the SetHostname command. A device shall accept string formated according to RFC 1123 section 2.1 or alternatively to RFC 952, other string shall be considered as invalid strings.
 
@@ -2910,7 +2910,7 @@ ___
 
 ▸ **SetHostnameFromDHCP**(FromDHCP: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:396](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L396)*
+*Defined in [api/device.ts:396](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L396)*
 
 This operation controls whether the hostname is set manually or retrieved via DHCP.
 
@@ -2929,7 +2929,7 @@ ___
 
 ▸ **SetIPAddressFilter**(IPAddressFilter: *[IPAddressFilter](../interfaces/_api_types_.ipaddressfilter.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:571](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L571)*
+*Defined in [api/device.ts:571](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L571)*
 
 This operation sets the IP address filter settings on a device. If the device supports device access control based on IP filtering rules (denied or accepted ranges of IP addresses), the device shall support configuration of IP filtering rules through the SetIPAddressFilter command.
 
@@ -2948,7 +2948,7 @@ ___
 
 ▸ **SetNTP**(FromDHCP: *`boolean`*, NTPManual?: *[NetworkHost](../interfaces/_api_types_.networkhost.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:440](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L440)*
+*Defined in [api/device.ts:440](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L440)*
 
 This operation sets the NTP settings on a device. If the device supports NTP, it shall be possible to set the NTP server settings through the SetNTP command. A device shall accept string formated according to RFC 1123 section 2.1 or alternatively to RFC 952, other string shall be considered as invalid strings. Changes to the NTP server list will not affect the clock mode DateTimeType. Use SetSystemDateAndTime to activate NTP operation.
 
@@ -2968,7 +2968,7 @@ ___
 
 ▸ **SetNetworkDefaultGateway**(IPv4Address?: *[IPv4Address]()*, IPv6Address?: *[IPv6Address]()*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:527](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L527)*
+*Defined in [api/device.ts:527](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L527)*
 
 This operation sets the default gateway settings on a device. The device shall support configuration of default gateway through the SetNetworkDefaultGateway command.
 
@@ -2988,7 +2988,7 @@ ___
 
 ▸ **SetNetworkInterfaces**(InterfaceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, NetworkInterface: *[NetworkInterfaceSetConfiguration](../interfaces/_api_types_.networkinterfacesetconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:487](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L487)*
+*Defined in [api/device.ts:487](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L487)*
 
 This operation sets the network interface configuration on a device. The device shall support network configuration of supported network interfaces through the SetNetworkInterfaces command. For interoperability with a client unaware of the IEEE 802.11 extension a device shall retain its IEEE 802.11 configuration if the IEEE 802.11 configuration element isn’t present in the request.
 
@@ -3008,7 +3008,7 @@ ___
 
 ▸ **SetNetworkProtocols**(NetworkProtocols: *[NetworkProtocol](../interfaces/_api_types_.networkprotocol.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:507](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L507)*
+*Defined in [api/device.ts:507](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L507)*
 
 This operation configures defined network protocols on a device. The device shall support configuration of defined network protocols through the SetNetworkProtocols command.
 
@@ -3027,7 +3027,7 @@ ___
 
 ▸ **SetRelayOutputSettings**(RelayOutputToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Properties: *[RelayOutputSettings](../interfaces/_api_types_.relayoutputsettings.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:767](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L767)*
+*Defined in [api/device.ts:767](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L767)*
 
 This operation sets the settings of a relay output. This method has been depricated with version 2.0. Refer to the DeviceIO service.
 
@@ -3047,7 +3047,7 @@ ___
 
 ▸ **SetRelayOutputState**(RelayOutputToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, LogicalState: *[RelayLogicalState](../enums/_api_types_.relaylogicalstate.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:777](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L777)*
+*Defined in [api/device.ts:777](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L777)*
 
 This operation sets the state of a relay output. This method has been depricated with version 2.0. Refer to the DeviceIO service.
 
@@ -3067,7 +3067,7 @@ ___
 
 ▸ **SetRemoteDiscoveryMode**(RemoteDiscoveryMode: *[DiscoveryMode](../enums/_api_types_.discoverymode.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:233](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L233)*
+*Defined in [api/device.ts:233](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L233)*
 
 This operation sets the remote discovery mode of operation of a device. See Section 7.4 for the definition of remote discovery remote extensions. A device that supports remote discovery shall support configuration of the discovery mode setting through the SetRemoteDiscoveryMode command.
 
@@ -3086,7 +3086,7 @@ ___
 
 ▸ **SetRemoteUser**(RemoteUser?: *[RemoteUser]()*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:293](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L293)*
+*Defined in [api/device.ts:293](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L293)*
 
 This operation sets the remote user. A device supporting remote user handling shall support this operation. The user is only valid for the WS-UserToken profile or as a HTTP / RTSP user. The password that is set shall always be the original (not derived) password. If UseDerivedPassword is set password derivation shall be done by the device when connecting to a remote device.The algorithm to use for deriving the password is described in section 5.12.2.1 of the core specification. To remove the remote user SetRemoteUser should be called without the RemoteUser parameter.
 
@@ -3105,7 +3105,7 @@ ___
 
 ▸ **SetScopes**(Scopes: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:163](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L163)*
+*Defined in [api/device.ts:163](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L163)*
 
 This operation sets the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message. This operation replaces all existing configurable scope parameters (not fixed parameters). If this shall be avoided, one should use the scope add command instead. The device shall support configuration of discovery scope parameters through the SetScopes command.
 
@@ -3124,7 +3124,7 @@ ___
 
 ▸ **SetStorageConfiguration**(StorageConfiguration: *`any`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1073](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1073)*
+*Defined in [api/device.ts:1073](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1073)*
 
 This operation modifies an existing Storage configuration.
 
@@ -3143,7 +3143,7 @@ ___
 
 ▸ **SetSystemDateAndTime**(DateTimeType: *[SetDateTimeType](../enums/_api_types_.setdatetimetype.md)*, DaylightSavings: *`boolean`*, TimeZone?: *[TimeZone]()*, UTCDateTime?: *[DateTime](../interfaces/_api_types_.datetime.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:47](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L47)*
+*Defined in [api/device.ts:47](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L47)*
 
 This operation sets the device system date and time. The device shall support the configuration of the daylight saving setting and of the manual system date and time (if applicable) or indication of NTP time (if applicable) through the SetSystemDateAndTime command. If system time and date are set manually, the client shall include UTCDateTime in the request. A TimeZone token which is not formed according to the rules of IEEE 1003.1 section 8.3 is considered as invalid timezone. The DayLightSavings flag should be set to true to activate any DST settings of the TimeZone string. Clear the DayLightSavings flag if the DST portion of the TimeZone settings should be ignored.
 
@@ -3165,7 +3165,7 @@ ___
 
 ▸ **SetSystemFactoryDefault**(FactoryDefault: *[FactoryDefaultType](../enums/_api_types_.factorydefaulttype.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:68](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L68)*
+*Defined in [api/device.ts:68](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L68)*
 
 This operation reloads the parameters on the device to their factory default values.
 
@@ -3184,7 +3184,7 @@ ___
 
 ▸ **SetUser**(User: *[User](../interfaces/_api_types_.user.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:342](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L342)*
+*Defined in [api/device.ts:342](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L342)*
 
 This operation updates the settings for one or several users on a device for authentication purposes. The device shall support update of device users and their credentials through the SetUser command. Either all change requests are processed successfully or a fault message shall be returned and no change requests be processed.
 
@@ -3203,7 +3203,7 @@ ___
 
 ▸ **SetZeroConfiguration**(InterfaceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Enabled: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:548](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L548)*
+*Defined in [api/device.ts:548](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L548)*
 
 This operation sets the zero-configuration. Use GetCapalities to get if zero-zero-configuration is supported or not.
 
@@ -3223,7 +3223,7 @@ ___
 
 ▸ **StartFirmwareUpgrade**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1004](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1004)*
+*Defined in [api/device.ts:1004](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1004)*
 
 This operation initiates a firmware upgrade using the HTTP POST mechanism. The response to the command includes an HTTP URL to which the upgrade file may be uploaded. The actual upgrade takes place as soon as the HTTP POST operation has completed. The device should support firmware upgrade through the StartFirmwareUpgrade command. The exact format of the firmware data is outside the scope of this specification. Firmware upgrade over HTTP may be achieved using the following steps: Client calls StartFirmwareUpgrade. Server responds with upload URI and optional delay value. Client waits for delay duration if specified by server. Client transmits the firmware image to the upload URI using HTTP POST. Server reprograms itself using the uploaded image, then reboots.
 
@@ -3238,7 +3238,7 @@ ___
 
 ▸ **StartSystemRestore**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:1028](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L1028)*
+*Defined in [api/device.ts:1028](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L1028)*
 
 This operation initiates a system restore from backed up configuration data using the HTTP POST mechanism. The response to the command includes an HTTP URL to which the backup file may be uploaded. The actual restore takes place as soon as the HTTP POST operation has completed. Devices should support system restore through the StartSystemRestore command. The exact format of the backup configuration data is outside the scope of this specification. System restore over HTTP may be achieved using the following steps: Client calls StartSystemRestore. Server responds with upload URI. Client transmits the configuration data to the upload URI using HTTP POST. Server applies the uploaded configuration, then reboots if necessary.
 
@@ -3253,7 +3253,7 @@ ___
 
 ▸ **SystemReboot**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:89](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L89)*
+*Defined in [api/device.ts:89](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L89)*
 
 This operation reboots the device.
 
@@ -3266,7 +3266,7 @@ ___
 
 ▸ **UpgradeSystemFirmware**(Firmware: *[AttachmentData](../interfaces/_api_types_.attachmentdata.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/device.ts:80](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/device.ts#L80)*
+*Defined in [api/device.ts:80](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/device.ts#L80)*
 
 This operation upgrades a device firmware version. After a successful upgrade the response message is sent before the device reboots. The device should support firmware upgrade through the UpgradeSystemFirmware command. The exact format of the firmware data is outside the scope of this standard.
 

--- a/docs/classes/_api_display_.onvifdisplay.md
+++ b/docs/classes/_api_display_.onvifdisplay.md
@@ -1,43 +1,43 @@
-[onvif-rx](../README.md) > ["api/display"](../modules/_api_display_.md) > [Display](../classes/_api_display_.display.md)
+[onvif-rx](../README.md) > ["api/display"](../modules/_api_display_.md) > [ONVIFDisplay](../classes/_api_display_.onvifdisplay.md)
 
-# Class: Display
+# Class: ONVIFDisplay
 
 ## Hierarchy
 
-**Display**
+**ONVIFDisplay**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_display_.display.md#constructor)
+* [constructor](_api_display_.onvifdisplay.md#constructor)
 
 ### Properties
 
-* [config](_api_display_.display.md#config)
+* [config](_api_display_.onvifdisplay.md#config)
 
 ### Methods
 
-* [CreatePaneConfiguration](_api_display_.display.md#createpaneconfiguration)
-* [DeletePaneConfiguration](_api_display_.display.md#deletepaneconfiguration)
-* [GetDisplayOptions](_api_display_.display.md#getdisplayoptions)
-* [GetLayout](_api_display_.display.md#getlayout)
-* [GetPaneConfiguration](_api_display_.display.md#getpaneconfiguration)
-* [GetPaneConfigurations](_api_display_.display.md#getpaneconfigurations)
-* [GetServiceCapabilities](_api_display_.display.md#getservicecapabilities)
-* [SetLayout](_api_display_.display.md#setlayout)
-* [SetPaneConfiguration](_api_display_.display.md#setpaneconfiguration)
-* [SetPaneConfigurations](_api_display_.display.md#setpaneconfigurations)
-* [CreatePaneConfiguration](_api_display_.display.md#createpaneconfiguration-1)
-* [DeletePaneConfiguration](_api_display_.display.md#deletepaneconfiguration-1)
-* [GetDisplayOptions](_api_display_.display.md#getdisplayoptions-1)
-* [GetLayout](_api_display_.display.md#getlayout-1)
-* [GetPaneConfiguration](_api_display_.display.md#getpaneconfiguration-1)
-* [GetPaneConfigurations](_api_display_.display.md#getpaneconfigurations-1)
-* [GetServiceCapabilities](_api_display_.display.md#getservicecapabilities-1)
-* [SetLayout](_api_display_.display.md#setlayout-1)
-* [SetPaneConfiguration](_api_display_.display.md#setpaneconfiguration-1)
-* [SetPaneConfigurations](_api_display_.display.md#setpaneconfigurations-1)
+* [CreatePaneConfiguration](_api_display_.onvifdisplay.md#createpaneconfiguration)
+* [DeletePaneConfiguration](_api_display_.onvifdisplay.md#deletepaneconfiguration)
+* [GetDisplayOptions](_api_display_.onvifdisplay.md#getdisplayoptions)
+* [GetLayout](_api_display_.onvifdisplay.md#getlayout)
+* [GetPaneConfiguration](_api_display_.onvifdisplay.md#getpaneconfiguration)
+* [GetPaneConfigurations](_api_display_.onvifdisplay.md#getpaneconfigurations)
+* [GetServiceCapabilities](_api_display_.onvifdisplay.md#getservicecapabilities)
+* [SetLayout](_api_display_.onvifdisplay.md#setlayout)
+* [SetPaneConfiguration](_api_display_.onvifdisplay.md#setpaneconfiguration)
+* [SetPaneConfigurations](_api_display_.onvifdisplay.md#setpaneconfigurations)
+* [CreatePaneConfiguration](_api_display_.onvifdisplay.md#createpaneconfiguration-1)
+* [DeletePaneConfiguration](_api_display_.onvifdisplay.md#deletepaneconfiguration-1)
+* [GetDisplayOptions](_api_display_.onvifdisplay.md#getdisplayoptions-1)
+* [GetLayout](_api_display_.onvifdisplay.md#getlayout-1)
+* [GetPaneConfiguration](_api_display_.onvifdisplay.md#getpaneconfiguration-1)
+* [GetPaneConfigurations](_api_display_.onvifdisplay.md#getpaneconfigurations-1)
+* [GetServiceCapabilities](_api_display_.onvifdisplay.md#getservicecapabilities-1)
+* [SetLayout](_api_display_.onvifdisplay.md#setlayout-1)
+* [SetPaneConfiguration](_api_display_.onvifdisplay.md#setpaneconfiguration-1)
+* [SetPaneConfigurations](_api_display_.onvifdisplay.md#setpaneconfigurations-1)
 
 ---
 
@@ -47,9 +47,9 @@
 
 ###  constructor
 
-⊕ **new Display**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Display](_api_display_.display.md)
+⊕ **new ONVIFDisplay**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFDisplay](_api_display_.onvifdisplay.md)
 
-*Defined in [api/display.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L5)*
+*Defined in [api/display.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L5)*
 
 **Parameters:**
 
@@ -57,7 +57,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Display](_api_display_.display.md)
+**Returns:** [ONVIFDisplay](_api_display_.onvifdisplay.md)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/display.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L6)*
+*Defined in [api/display.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L6)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **CreatePaneConfiguration**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PaneConfiguration: *[PaneConfiguration](../interfaces/_api_types_.paneconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:197](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L197)*
+*Defined in [api/display.ts:197](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L197)*
 
 Create a new pane configuration describing the streaming and coding settings for a display area. This optional method is only supported by devices that signal support of dynamic pane creation via their capabilities. The content of the Token field may be ignored by the device.
 
@@ -101,7 +101,7 @@ ___
 
 ▸ **DeletePaneConfiguration**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PaneToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:207](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L207)*
+*Defined in [api/display.ts:207](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L207)*
 
 Delete a pane configuration. A service must respond with an error if the pane configuration is in use by the current layout. This optional method is only supported by devices that signal support of dynamic pane creation via their capabilities.
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **GetDisplayOptions**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:153](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L153)*
+*Defined in [api/display.ts:153](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L153)*
 
 The Display Options contain the supported layouts (LayoutOptions) and the decoding and encoding capabilities (CodingCapabilities) of the device. The GetDisplayOptions command returns both, Layout and Coding Capabilities, of a VideoOutput.
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **GetLayout**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:132](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L132)*
+*Defined in [api/display.ts:132](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L132)*
 
 Return the current layout of a video output. The Layout assigns a pane configuration to a certain area of the display. The layout settings directly affect a specific video output. The layout consists of a list of PaneConfigurations and their associated display areas.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **GetPaneConfiguration**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Pane: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:171](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L171)*
+*Defined in [api/display.ts:171](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L171)*
 
 Retrieve the pane configuration for a pane token.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **GetPaneConfigurations**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:164](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L164)*
+*Defined in [api/display.ts:164](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L164)*
 
 List all currently defined panes of a device for a specified video output (regardless if this pane is visible at a moment). A Pane is a display area on the monitor that is attached to a video output. A pane has a PaneConfiguration that describes which entities are associated with the pane. A client has to configure the pane according to the connection to be established by setting the AudioOutput and/or AudioSourceToken. If a Token is not set, the corresponding session will not be established.
 
@@ -198,7 +198,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:123](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L123)*
+*Defined in [api/display.ts:123](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L123)*
 
 Returns the capabilities of the display service. The result is returned in a typed answer.
 
@@ -211,7 +211,7 @@ ___
 
 ▸ **SetLayout**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Layout: *[Layout](../interfaces/_api_types_.layout.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:144](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L144)*
+*Defined in [api/display.ts:144](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L144)*
 
 Change the layout of a display (e.g. change from single view to split screen view).The Layout assigns a pane configuration to a certain area of the display. The layout settings directly affect a specific video output. The layout consists of a list of PaneConfigurations and their associated display areas. A device implementation shall be tolerant against rounding errors when matching a layout against its fixed set of layouts by accepting differences of at least one percent.
 
@@ -231,7 +231,7 @@ ___
 
 ▸ **SetPaneConfiguration**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PaneConfiguration: *[PaneConfiguration](../interfaces/_api_types_.paneconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:187](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L187)*
+*Defined in [api/display.ts:187](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L187)*
 
 This command changes the configuration of the specified pane (tbd)
 
@@ -251,7 +251,7 @@ ___
 
 ▸ **SetPaneConfigurations**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PaneConfiguration: *[PaneConfiguration](../interfaces/_api_types_.paneconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/display.ts:180](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L180)*
+*Defined in [api/display.ts:180](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L180)*
 
 Modify one or more configurations of the specified video output. This method will only modify the provided configurations and leave the others unchanged. Use DeletePaneConfiguration to remove pane configurations.
 
@@ -271,7 +271,7 @@ ___
 
 ▸ **CreatePaneConfiguration**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PaneConfiguration: *[PaneConfiguration](../interfaces/_api_types_.paneconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L102)*
+*Defined in [api/display.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L102)*
 
 Create a new pane configuration describing the streaming and coding settings for a display area. This optional method is only supported by devices that signal support of dynamic pane creation via their capabilities. The content of the Token field may be ignored by the device.
 
@@ -291,7 +291,7 @@ ___
 
 ▸ **DeletePaneConfiguration**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PaneToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:114](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L114)*
+*Defined in [api/display.ts:114](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L114)*
 
 Delete a pane configuration. A service must respond with an error if the pane configuration is in use by the current layout. This optional method is only supported by devices that signal support of dynamic pane creation via their capabilities.
 
@@ -311,7 +311,7 @@ ___
 
 ▸ **GetDisplayOptions**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:48](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L48)*
+*Defined in [api/display.ts:48](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L48)*
 
 The Display Options contain the supported layouts (LayoutOptions) and the decoding and encoding capabilities (CodingCapabilities) of the device. The GetDisplayOptions command returns both, Layout and Coding Capabilities, of a VideoOutput.
 
@@ -330,7 +330,7 @@ ___
 
 ▸ **GetLayout**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:23](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L23)*
+*Defined in [api/display.ts:23](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L23)*
 
 Return the current layout of a video output. The Layout assigns a pane configuration to a certain area of the display. The layout settings directly affect a specific video output. The layout consists of a list of PaneConfigurations and their associated display areas.
 
@@ -349,7 +349,7 @@ ___
 
 ▸ **GetPaneConfiguration**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Pane: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L70)*
+*Defined in [api/display.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L70)*
 
 Retrieve the pane configuration for a pane token.
 
@@ -369,7 +369,7 @@ ___
 
 ▸ **GetPaneConfigurations**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:61](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L61)*
+*Defined in [api/display.ts:61](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L61)*
 
 List all currently defined panes of a device for a specified video output (regardless if this pane is visible at a moment). A Pane is a display area on the monitor that is attached to a video output. A pane has a PaneConfiguration that describes which entities are associated with the pane. A client has to configure the pane according to the connection to be established by setting the AudioOutput and/or AudioSourceToken. If a Token is not set, the corresponding session will not be established.
 
@@ -388,7 +388,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L12)*
+*Defined in [api/display.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L12)*
 
 Returns the capabilities of the display service. The result is returned in a typed answer.
 
@@ -401,7 +401,7 @@ ___
 
 ▸ **SetLayout**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Layout: *[Layout](../interfaces/_api_types_.layout.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:37](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L37)*
+*Defined in [api/display.ts:37](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L37)*
 
 Change the layout of a display (e.g. change from single view to split screen view).The Layout assigns a pane configuration to a certain area of the display. The layout settings directly affect a specific video output. The layout consists of a list of PaneConfigurations and their associated display areas. A device implementation shall be tolerant against rounding errors when matching a layout against its fixed set of layouts by accepting differences of at least one percent.
 
@@ -421,7 +421,7 @@ ___
 
 ▸ **SetPaneConfiguration**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PaneConfiguration: *[PaneConfiguration](../interfaces/_api_types_.paneconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:90](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L90)*
+*Defined in [api/display.ts:90](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L90)*
 
 This command changes the configuration of the specified pane (tbd)
 
@@ -441,7 +441,7 @@ ___
 
 ▸ **SetPaneConfigurations**(VideoOutput: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PaneConfiguration: *[PaneConfiguration](../interfaces/_api_types_.paneconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/display.ts:81](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/display.ts#L81)*
+*Defined in [api/display.ts:81](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/display.ts#L81)*
 
 Modify one or more configurations of the specified video output. This method will only modify the provided configurations and leave the others unchanged. Use DeletePaneConfiguration to remove pane configurations.
 

--- a/docs/classes/_api_imaging_.onvifimaging.md
+++ b/docs/classes/_api_imaging_.onvifimaging.md
@@ -1,45 +1,45 @@
-[onvif-rx](../README.md) > ["api/imaging"](../modules/_api_imaging_.md) > [Imaging](../classes/_api_imaging_.imaging.md)
+[onvif-rx](../README.md) > ["api/imaging"](../modules/_api_imaging_.md) > [ONVIFImaging](../classes/_api_imaging_.onvifimaging.md)
 
-# Class: Imaging
+# Class: ONVIFImaging
 
 ## Hierarchy
 
-**Imaging**
+**ONVIFImaging**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_imaging_.imaging.md#constructor)
+* [constructor](_api_imaging_.onvifimaging.md#constructor)
 
 ### Properties
 
-* [config](_api_imaging_.imaging.md#config)
+* [config](_api_imaging_.onvifimaging.md#config)
 
 ### Methods
 
-* [GetCurrentPreset](_api_imaging_.imaging.md#getcurrentpreset)
-* [GetImagingSettings](_api_imaging_.imaging.md#getimagingsettings)
-* [GetMoveOptions](_api_imaging_.imaging.md#getmoveoptions)
-* [GetOptions](_api_imaging_.imaging.md#getoptions)
-* [GetPresets](_api_imaging_.imaging.md#getpresets)
-* [GetServiceCapabilities](_api_imaging_.imaging.md#getservicecapabilities)
-* [GetStatus](_api_imaging_.imaging.md#getstatus)
-* [Move](_api_imaging_.imaging.md#move)
-* [SetCurrentPreset](_api_imaging_.imaging.md#setcurrentpreset)
-* [SetImagingSettings](_api_imaging_.imaging.md#setimagingsettings)
-* [Stop](_api_imaging_.imaging.md#stop)
-* [GetCurrentPreset](_api_imaging_.imaging.md#getcurrentpreset-1)
-* [GetImagingSettings](_api_imaging_.imaging.md#getimagingsettings-1)
-* [GetMoveOptions](_api_imaging_.imaging.md#getmoveoptions-1)
-* [GetOptions](_api_imaging_.imaging.md#getoptions-1)
-* [GetPresets](_api_imaging_.imaging.md#getpresets-1)
-* [GetServiceCapabilities](_api_imaging_.imaging.md#getservicecapabilities-1)
-* [GetStatus](_api_imaging_.imaging.md#getstatus-1)
-* [Move](_api_imaging_.imaging.md#move-1)
-* [SetCurrentPreset](_api_imaging_.imaging.md#setcurrentpreset-1)
-* [SetImagingSettings](_api_imaging_.imaging.md#setimagingsettings-1)
-* [Stop](_api_imaging_.imaging.md#stop-1)
+* [GetCurrentPreset](_api_imaging_.onvifimaging.md#getcurrentpreset)
+* [GetImagingSettings](_api_imaging_.onvifimaging.md#getimagingsettings)
+* [GetMoveOptions](_api_imaging_.onvifimaging.md#getmoveoptions)
+* [GetOptions](_api_imaging_.onvifimaging.md#getoptions)
+* [GetPresets](_api_imaging_.onvifimaging.md#getpresets)
+* [GetServiceCapabilities](_api_imaging_.onvifimaging.md#getservicecapabilities)
+* [GetStatus](_api_imaging_.onvifimaging.md#getstatus)
+* [Move](_api_imaging_.onvifimaging.md#move)
+* [SetCurrentPreset](_api_imaging_.onvifimaging.md#setcurrentpreset)
+* [SetImagingSettings](_api_imaging_.onvifimaging.md#setimagingsettings)
+* [Stop](_api_imaging_.onvifimaging.md#stop)
+* [GetCurrentPreset](_api_imaging_.onvifimaging.md#getcurrentpreset-1)
+* [GetImagingSettings](_api_imaging_.onvifimaging.md#getimagingsettings-1)
+* [GetMoveOptions](_api_imaging_.onvifimaging.md#getmoveoptions-1)
+* [GetOptions](_api_imaging_.onvifimaging.md#getoptions-1)
+* [GetPresets](_api_imaging_.onvifimaging.md#getpresets-1)
+* [GetServiceCapabilities](_api_imaging_.onvifimaging.md#getservicecapabilities-1)
+* [GetStatus](_api_imaging_.onvifimaging.md#getstatus-1)
+* [Move](_api_imaging_.onvifimaging.md#move-1)
+* [SetCurrentPreset](_api_imaging_.onvifimaging.md#setcurrentpreset-1)
+* [SetImagingSettings](_api_imaging_.onvifimaging.md#setimagingsettings-1)
+* [Stop](_api_imaging_.onvifimaging.md#stop-1)
 
 ---
 
@@ -49,9 +49,9 @@
 
 ###  constructor
 
-⊕ **new Imaging**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Imaging](_api_imaging_.imaging.md)
+⊕ **new ONVIFImaging**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFImaging](_api_imaging_.onvifimaging.md)
 
-*Defined in [api/imaging.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L5)*
+*Defined in [api/imaging.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L5)*
 
 **Parameters:**
 
@@ -59,7 +59,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Imaging](_api_imaging_.imaging.md)
+**Returns:** [ONVIFImaging](_api_imaging_.onvifimaging.md)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/imaging.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L6)*
+*Defined in [api/imaging.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L6)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 ▸ **GetCurrentPreset**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:209](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L209)*
+*Defined in [api/imaging.ts:209](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L209)*
 
 Via this command the last Imaging Preset applied can be requested. If the camera configuration does not match any of the existing Imaging Presets, the output of GetCurrentPreset shall be Empty. GetCurrentPreset shall return 0 if Imaging Presets are not supported by the Video Source.
 
@@ -102,7 +102,7 @@ ___
 
 ▸ **GetImagingSettings**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:137](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L137)*
+*Defined in [api/imaging.ts:137](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L137)*
 
 Get the ImagingConfiguration for the requested VideoSource.
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **GetMoveOptions**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:178](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L178)*
+*Defined in [api/imaging.ts:178](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L178)*
 
 Imaging move operation options supported for the Video source.
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **GetOptions**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:155](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L155)*
+*Defined in [api/imaging.ts:155](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L155)*
 
 This operation gets the valid ranges for the imaging parameters that have device specific ranges. This command is mandatory for all device implementing the imaging service. The command returns all supported parameters and their ranges such that these can be applied to the SetImagingSettings command. For read-only parameters which cannot be modified via the SetImagingSettings command only a single option or identical Min and Max values is provided.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **GetPresets**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:200](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L200)*
+*Defined in [api/imaging.ts:200](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L200)*
 
 Via this command the list of available Imaging Presets can be requested.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:130](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L130)*
+*Defined in [api/imaging.ts:130](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L130)*
 
 Returns the capabilities of the imaging service. The result is returned in a typed answer.
 
@@ -191,7 +191,7 @@ ___
 
 ▸ **GetStatus**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:193](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L193)*
+*Defined in [api/imaging.ts:193](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L193)*
 
 Via this command the current status of the Move operation can be requested. Supported for this command is available if the support for the Move operation is signalled via GetMoveOptions.
 
@@ -210,7 +210,7 @@ ___
 
 ▸ **Move**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Focus: *[FocusMove](../interfaces/_api_types_.focusmove.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:171](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L171)*
+*Defined in [api/imaging.ts:171](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L171)*
 
 The Move command moves the focus lens in an absolute, a relative or in a continuous manner from its current position. The speed argument is optional for absolute and relative control, but required for continuous. If no speed argument is used, the default speed is used. Focus adjustments through this operation will turn off the autofocus. A device with support for remote focus control should support absolute, relative or continuous control through the Move operation. The supported MoveOpions are signalled via the GetMoveOptions command. At least one focus control capability is required for this operation to be functional. The move operation contains the following commands: Absolute – Requires position parameter and optionally takes a speed argument. A unitless type is used by default for focus positioning and speed. Optionally, if supported, the position may be requested in m-1 units. Relative – Requires distance parameter and optionally takes a speed argument. Negative distance means negative direction. Continuous – Requires a speed argument. Negative speed argument means negative direction.
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **SetCurrentPreset**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:219](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L219)*
+*Defined in [api/imaging.ts:219](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L219)*
 
 The SetCurrentPreset command shall request a given Imaging Preset to be applied to the specified Video Source. SetCurrentPreset shall only be available for Video Sources with Imaging Presets Capability. Imaging Presets are defined by the Manufacturer, and offered as a tool to simplify Imaging Settings adjustments for specific scene content. When the new Imaging Preset is applied by SetCurrentPreset, the Device shall adjust the Video Source settings to match those defined by the specified Imaging Preset.
 
@@ -250,7 +250,7 @@ ___
 
 ▸ **SetImagingSettings**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ImagingSettings: *[ImagingSettings20](../interfaces/_api_types_.imagingsettings20.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:144](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L144)*
+*Defined in [api/imaging.ts:144](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L144)*
 
 Set the ImagingConfiguration for the requested VideoSource.
 
@@ -271,7 +271,7 @@ ___
 
 ▸ **Stop**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/imaging.ts:186](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L186)*
+*Defined in [api/imaging.ts:186](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L186)*
 
 The Stop command stops all ongoing focus movements of the lense. A device with support for remote focus control as signalled via the GetMoveOptions supports this command. The operation will not affect ongoing autofocus operation.
 
@@ -290,7 +290,7 @@ ___
 
 ▸ **GetCurrentPreset**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:109](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L109)*
+*Defined in [api/imaging.ts:109](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L109)*
 
 Via this command the last Imaging Preset applied can be requested. If the camera configuration does not match any of the existing Imaging Presets, the output of GetCurrentPreset shall be Empty. GetCurrentPreset shall return 0 if Imaging Presets are not supported by the Video Source.
 
@@ -309,7 +309,7 @@ ___
 
 ▸ **GetImagingSettings**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L21)*
+*Defined in [api/imaging.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L21)*
 
 Get the ImagingConfiguration for the requested VideoSource.
 
@@ -328,7 +328,7 @@ ___
 
 ▸ **GetMoveOptions**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L70)*
+*Defined in [api/imaging.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L70)*
 
 Imaging move operation options supported for the Video source.
 
@@ -347,7 +347,7 @@ ___
 
 ▸ **GetOptions**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:43](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L43)*
+*Defined in [api/imaging.ts:43](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L43)*
 
 This operation gets the valid ranges for the imaging parameters that have device specific ranges. This command is mandatory for all device implementing the imaging service. The command returns all supported parameters and their ranges such that these can be applied to the SetImagingSettings command. For read-only parameters which cannot be modified via the SetImagingSettings command only a single option or identical Min and Max values is provided.
 
@@ -366,7 +366,7 @@ ___
 
 ▸ **GetPresets**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:98](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L98)*
+*Defined in [api/imaging.ts:98](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L98)*
 
 Via this command the list of available Imaging Presets can be requested.
 
@@ -385,7 +385,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L12)*
+*Defined in [api/imaging.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L12)*
 
 Returns the capabilities of the imaging service. The result is returned in a typed answer.
 
@@ -398,7 +398,7 @@ ___
 
 ▸ **GetStatus**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:89](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L89)*
+*Defined in [api/imaging.ts:89](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L89)*
 
 Via this command the current status of the Move operation can be requested. Supported for this command is available if the support for the Move operation is signalled via GetMoveOptions.
 
@@ -417,7 +417,7 @@ ___
 
 ▸ **Move**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Focus: *[FocusMove](../interfaces/_api_types_.focusmove.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:61](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L61)*
+*Defined in [api/imaging.ts:61](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L61)*
 
 The Move command moves the focus lens in an absolute, a relative or in a continuous manner from its current position. The speed argument is optional for absolute and relative control, but required for continuous. If no speed argument is used, the default speed is used. Focus adjustments through this operation will turn off the autofocus. A device with support for remote focus control should support absolute, relative or continuous control through the Move operation. The supported MoveOpions are signalled via the GetMoveOptions command. At least one focus control capability is required for this operation to be functional. The move operation contains the following commands: Absolute – Requires position parameter and optionally takes a speed argument. A unitless type is used by default for focus positioning and speed. Optionally, if supported, the position may be requested in m-1 units. Relative – Requires distance parameter and optionally takes a speed argument. Negative distance means negative direction. Continuous – Requires a speed argument. Negative speed argument means negative direction.
 
@@ -437,7 +437,7 @@ ___
 
 ▸ **SetCurrentPreset**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:121](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L121)*
+*Defined in [api/imaging.ts:121](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L121)*
 
 The SetCurrentPreset command shall request a given Imaging Preset to be applied to the specified Video Source. SetCurrentPreset shall only be available for Video Sources with Imaging Presets Capability. Imaging Presets are defined by the Manufacturer, and offered as a tool to simplify Imaging Settings adjustments for specific scene content. When the new Imaging Preset is applied by SetCurrentPreset, the Device shall adjust the Video Source settings to match those defined by the specified Imaging Preset.
 
@@ -457,7 +457,7 @@ ___
 
 ▸ **SetImagingSettings**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ImagingSettings: *[ImagingSettings20](../interfaces/_api_types_.imagingsettings20.md)*, ForcePersistence?: *`undefined` \| `false` \| `true`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L30)*
+*Defined in [api/imaging.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L30)*
 
 Set the ImagingConfiguration for the requested VideoSource.
 
@@ -478,7 +478,7 @@ ___
 
 ▸ **Stop**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/imaging.ts:80](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/imaging.ts#L80)*
+*Defined in [api/imaging.ts:80](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/imaging.ts#L80)*
 
 The Stop command stops all ongoing focus movements of the lense. A device with support for remote focus control as signalled via the GetMoveOptions supports this command. The operation will not affect ongoing autofocus operation.
 

--- a/docs/classes/_api_index_.managedonvifapi.md
+++ b/docs/classes/_api_index_.managedonvifapi.md
@@ -38,7 +38,7 @@
 
 ⊕ **new ManagedONVIFApi**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ManagedONVIFApi](_api_index_.managedonvifapi.md)
 
-*Defined in [api/index.ts:27](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L27)*
+*Defined in [api/index.ts:27](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L27)*
 
 **Parameters:**
 
@@ -56,108 +56,108 @@ ___
 
 ###  AdvancedSecurity
 
-**● AdvancedSecurity**: *[AdvancedSecurity](_api_advancedsecurity_.advancedsecurity.md)* =  new AdvancedSecurity(this.config)
+**● AdvancedSecurity**: *[ONVIFAdvancedSecurity](_api_advancedsecurity_.onvifadvancedsecurity.md)* =  new ONVIFAdvancedSecurity(this.config)
 
-*Defined in [api/index.ts:27](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L27)*
+*Defined in [api/index.ts:27](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L27)*
 
 ___
 <a id="analytics"></a>
 
 ###  Analytics
 
-**● Analytics**: *[Analytics](_api_analytics_.analytics.md)* =  new Analytics(this.config)
+**● Analytics**: *[ONVIFAnalytics](_api_analytics_.onvifanalytics.md)* =  new ONVIFAnalytics(this.config)
 
-*Defined in [api/index.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L18)*
+*Defined in [api/index.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L18)*
 
 ___
 <a id="device"></a>
 
 ###  Device
 
-**● Device**: *[Device](_api_device_.device.md)* =  new Device(this.config)
+**● Device**: *[ONVIFDevice](_api_device_.onvifdevice.md)* =  new ONVIFDevice(this.config)
 
-*Defined in [api/index.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L16)*
+*Defined in [api/index.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L16)*
 
 ___
 <a id="display"></a>
 
 ###  Display
 
-**● Display**: *[Display](_api_display_.display.md)* =  new Display(this.config)
+**● Display**: *[ONVIFDisplay](_api_display_.onvifdisplay.md)* =  new ONVIFDisplay(this.config)
 
-*Defined in [api/index.ts:19](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L19)*
+*Defined in [api/index.ts:19](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L19)*
 
 ___
 <a id="imaging"></a>
 
 ###  Imaging
 
-**● Imaging**: *[Imaging](_api_imaging_.imaging.md)* =  new Imaging(this.config)
+**● Imaging**: *[ONVIFImaging](_api_imaging_.onvifimaging.md)* =  new ONVIFImaging(this.config)
 
-*Defined in [api/index.ts:20](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L20)*
+*Defined in [api/index.ts:20](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L20)*
 
 ___
 <a id="media"></a>
 
 ###  Media
 
-**● Media**: *[Media](_api_media_.media.md)* =  new Media(this.config)
+**● Media**: *[ONVIFMedia](_api_media_.onvifmedia.md)* =  new ONVIFMedia(this.config)
 
-*Defined in [api/index.ts:17](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L17)*
+*Defined in [api/index.ts:17](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L17)*
 
 ___
 <a id="ptz"></a>
 
 ###  PTZ
 
-**● PTZ**: *[PTZ](_api_ptz_.ptz.md)* =  new PTZ(this.config)
+**● PTZ**: *[ONVIFPTZ](_api_ptz_.onvifptz.md)* =  new ONVIFPTZ(this.config)
 
-*Defined in [api/index.ts:22](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L22)*
+*Defined in [api/index.ts:22](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L22)*
 
 ___
 <a id="provisioning"></a>
 
 ###  Provisioning
 
-**● Provisioning**: *[Provisioning](_api_provisioning_.provisioning.md)* =  new Provisioning(this.config)
+**● Provisioning**: *[ONVIFProvisioning](_api_provisioning_.onvifprovisioning.md)* =  new ONVIFProvisioning(this.config)
 
-*Defined in [api/index.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L21)*
+*Defined in [api/index.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L21)*
 
 ___
 <a id="receiver"></a>
 
 ###  Receiver
 
-**● Receiver**: *[Receiver](_api_receiver_.receiver.md)* =  new Receiver(this.config)
+**● Receiver**: *[ONVIFReceiver](_api_receiver_.onvifreceiver.md)* =  new ONVIFReceiver(this.config)
 
-*Defined in [api/index.ts:23](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L23)*
+*Defined in [api/index.ts:23](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L23)*
 
 ___
 <a id="recording"></a>
 
 ###  Recording
 
-**● Recording**: *[Recording](_api_recording_.recording.md)* =  new Recording(this.config)
+**● Recording**: *[ONVIFRecording](_api_recording_.onvifrecording.md)* =  new ONVIFRecording(this.config)
 
-*Defined in [api/index.ts:24](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L24)*
+*Defined in [api/index.ts:24](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L24)*
 
 ___
 <a id="replay"></a>
 
 ###  Replay
 
-**● Replay**: *[Replay](_api_replay_.replay.md)* =  new Replay(this.config)
+**● Replay**: *[ONVIFReplay](_api_replay_.onvifreplay.md)* =  new ONVIFReplay(this.config)
 
-*Defined in [api/index.ts:25](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L25)*
+*Defined in [api/index.ts:25](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L25)*
 
 ___
 <a id="search"></a>
 
 ###  Search
 
-**● Search**: *[Search](_api_search_.search.md)* =  new Search(this.config)
+**● Search**: *[ONVIFSearch](_api_search_.onvifsearch.md)* =  new ONVIFSearch(this.config)
 
-*Defined in [api/index.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L26)*
+*Defined in [api/index.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L26)*
 
 ___
 <a id="config"></a>
@@ -166,7 +166,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/index.ts:29](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/index.ts#L29)*
+*Defined in [api/index.ts:29](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/index.ts#L29)*
 
 ___
 

--- a/docs/classes/_api_media_.onvifmedia.md
+++ b/docs/classes/_api_media_.onvifmedia.md
@@ -1,181 +1,181 @@
-[onvif-rx](../README.md) > ["api/media"](../modules/_api_media_.md) > [Media](../classes/_api_media_.media.md)
+[onvif-rx](../README.md) > ["api/media"](../modules/_api_media_.md) > [ONVIFMedia](../classes/_api_media_.onvifmedia.md)
 
-# Class: Media
+# Class: ONVIFMedia
 
 ## Hierarchy
 
-**Media**
+**ONVIFMedia**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_media_.media.md#constructor)
+* [constructor](_api_media_.onvifmedia.md#constructor)
 
 ### Properties
 
-* [config](_api_media_.media.md#config)
+* [config](_api_media_.onvifmedia.md#config)
 
 ### Methods
 
-* [AddAudioDecoderConfiguration](_api_media_.media.md#addaudiodecoderconfiguration)
-* [AddAudioEncoderConfiguration](_api_media_.media.md#addaudioencoderconfiguration)
-* [AddAudioOutputConfiguration](_api_media_.media.md#addaudiooutputconfiguration)
-* [AddAudioSourceConfiguration](_api_media_.media.md#addaudiosourceconfiguration)
-* [AddMetadataConfiguration](_api_media_.media.md#addmetadataconfiguration)
-* [AddPTZConfiguration](_api_media_.media.md#addptzconfiguration)
-* [AddVideoAnalyticsConfiguration](_api_media_.media.md#addvideoanalyticsconfiguration)
-* [AddVideoEncoderConfiguration](_api_media_.media.md#addvideoencoderconfiguration)
-* [AddVideoSourceConfiguration](_api_media_.media.md#addvideosourceconfiguration)
-* [CreateOSD](_api_media_.media.md#createosd)
-* [CreateProfile](_api_media_.media.md#createprofile)
-* [DeleteOSD](_api_media_.media.md#deleteosd)
-* [DeleteProfile](_api_media_.media.md#deleteprofile)
-* [GetAudioDecoderConfiguration](_api_media_.media.md#getaudiodecoderconfiguration)
-* [GetAudioDecoderConfigurationOptions](_api_media_.media.md#getaudiodecoderconfigurationoptions)
-* [GetAudioDecoderConfigurations](_api_media_.media.md#getaudiodecoderconfigurations)
-* [GetAudioEncoderConfiguration](_api_media_.media.md#getaudioencoderconfiguration)
-* [GetAudioEncoderConfigurationOptions](_api_media_.media.md#getaudioencoderconfigurationoptions)
-* [GetAudioEncoderConfigurations](_api_media_.media.md#getaudioencoderconfigurations)
-* [GetAudioOutputConfiguration](_api_media_.media.md#getaudiooutputconfiguration)
-* [GetAudioOutputConfigurationOptions](_api_media_.media.md#getaudiooutputconfigurationoptions)
-* [GetAudioOutputConfigurations](_api_media_.media.md#getaudiooutputconfigurations)
-* [GetAudioOutputs](_api_media_.media.md#getaudiooutputs)
-* [GetAudioSourceConfiguration](_api_media_.media.md#getaudiosourceconfiguration)
-* [GetAudioSourceConfigurationOptions](_api_media_.media.md#getaudiosourceconfigurationoptions)
-* [GetAudioSourceConfigurations](_api_media_.media.md#getaudiosourceconfigurations)
-* [GetAudioSources](_api_media_.media.md#getaudiosources)
-* [GetCompatibleAudioDecoderConfigurations](_api_media_.media.md#getcompatibleaudiodecoderconfigurations)
-* [GetCompatibleAudioEncoderConfigurations](_api_media_.media.md#getcompatibleaudioencoderconfigurations)
-* [GetCompatibleAudioOutputConfigurations](_api_media_.media.md#getcompatibleaudiooutputconfigurations)
-* [GetCompatibleAudioSourceConfigurations](_api_media_.media.md#getcompatibleaudiosourceconfigurations)
-* [GetCompatibleMetadataConfigurations](_api_media_.media.md#getcompatiblemetadataconfigurations)
-* [GetCompatibleVideoAnalyticsConfigurations](_api_media_.media.md#getcompatiblevideoanalyticsconfigurations)
-* [GetCompatibleVideoEncoderConfigurations](_api_media_.media.md#getcompatiblevideoencoderconfigurations)
-* [GetCompatibleVideoSourceConfigurations](_api_media_.media.md#getcompatiblevideosourceconfigurations)
-* [GetGuaranteedNumberOfVideoEncoderInstances](_api_media_.media.md#getguaranteednumberofvideoencoderinstances)
-* [GetMetadataConfiguration](_api_media_.media.md#getmetadataconfiguration)
-* [GetMetadataConfigurationOptions](_api_media_.media.md#getmetadataconfigurationoptions)
-* [GetMetadataConfigurations](_api_media_.media.md#getmetadataconfigurations)
-* [GetOSD](_api_media_.media.md#getosd)
-* [GetOSDOptions](_api_media_.media.md#getosdoptions)
-* [GetOSDs](_api_media_.media.md#getosds)
-* [GetProfile](_api_media_.media.md#getprofile)
-* [GetProfiles](_api_media_.media.md#getprofiles)
-* [GetServiceCapabilities](_api_media_.media.md#getservicecapabilities)
-* [GetSnapshotUri](_api_media_.media.md#getsnapshoturi)
-* [GetStreamUri](_api_media_.media.md#getstreamuri)
-* [GetVideoAnalyticsConfiguration](_api_media_.media.md#getvideoanalyticsconfiguration)
-* [GetVideoAnalyticsConfigurations](_api_media_.media.md#getvideoanalyticsconfigurations)
-* [GetVideoEncoderConfiguration](_api_media_.media.md#getvideoencoderconfiguration)
-* [GetVideoEncoderConfigurationOptions](_api_media_.media.md#getvideoencoderconfigurationoptions)
-* [GetVideoEncoderConfigurations](_api_media_.media.md#getvideoencoderconfigurations)
-* [GetVideoSourceConfiguration](_api_media_.media.md#getvideosourceconfiguration)
-* [GetVideoSourceConfigurationOptions](_api_media_.media.md#getvideosourceconfigurationoptions)
-* [GetVideoSourceConfigurations](_api_media_.media.md#getvideosourceconfigurations)
-* [GetVideoSourceModes](_api_media_.media.md#getvideosourcemodes)
-* [GetVideoSources](_api_media_.media.md#getvideosources)
-* [RemoveAudioDecoderConfiguration](_api_media_.media.md#removeaudiodecoderconfiguration)
-* [RemoveAudioEncoderConfiguration](_api_media_.media.md#removeaudioencoderconfiguration)
-* [RemoveAudioOutputConfiguration](_api_media_.media.md#removeaudiooutputconfiguration)
-* [RemoveAudioSourceConfiguration](_api_media_.media.md#removeaudiosourceconfiguration)
-* [RemoveMetadataConfiguration](_api_media_.media.md#removemetadataconfiguration)
-* [RemovePTZConfiguration](_api_media_.media.md#removeptzconfiguration)
-* [RemoveVideoAnalyticsConfiguration](_api_media_.media.md#removevideoanalyticsconfiguration)
-* [RemoveVideoEncoderConfiguration](_api_media_.media.md#removevideoencoderconfiguration)
-* [RemoveVideoSourceConfiguration](_api_media_.media.md#removevideosourceconfiguration)
-* [SetAudioDecoderConfiguration](_api_media_.media.md#setaudiodecoderconfiguration)
-* [SetAudioEncoderConfiguration](_api_media_.media.md#setaudioencoderconfiguration)
-* [SetAudioOutputConfiguration](_api_media_.media.md#setaudiooutputconfiguration)
-* [SetAudioSourceConfiguration](_api_media_.media.md#setaudiosourceconfiguration)
-* [SetMetadataConfiguration](_api_media_.media.md#setmetadataconfiguration)
-* [SetOSD](_api_media_.media.md#setosd)
-* [SetSynchronizationPoint](_api_media_.media.md#setsynchronizationpoint)
-* [SetVideoAnalyticsConfiguration](_api_media_.media.md#setvideoanalyticsconfiguration)
-* [SetVideoEncoderConfiguration](_api_media_.media.md#setvideoencoderconfiguration)
-* [SetVideoSourceConfiguration](_api_media_.media.md#setvideosourceconfiguration)
-* [SetVideoSourceMode](_api_media_.media.md#setvideosourcemode)
-* [StartMulticastStreaming](_api_media_.media.md#startmulticaststreaming)
-* [StopMulticastStreaming](_api_media_.media.md#stopmulticaststreaming)
-* [AddAudioDecoderConfiguration](_api_media_.media.md#addaudiodecoderconfiguration-1)
-* [AddAudioEncoderConfiguration](_api_media_.media.md#addaudioencoderconfiguration-1)
-* [AddAudioOutputConfiguration](_api_media_.media.md#addaudiooutputconfiguration-1)
-* [AddAudioSourceConfiguration](_api_media_.media.md#addaudiosourceconfiguration-1)
-* [AddMetadataConfiguration](_api_media_.media.md#addmetadataconfiguration-1)
-* [AddPTZConfiguration](_api_media_.media.md#addptzconfiguration-1)
-* [AddVideoAnalyticsConfiguration](_api_media_.media.md#addvideoanalyticsconfiguration-1)
-* [AddVideoEncoderConfiguration](_api_media_.media.md#addvideoencoderconfiguration-1)
-* [AddVideoSourceConfiguration](_api_media_.media.md#addvideosourceconfiguration-1)
-* [CreateOSD](_api_media_.media.md#createosd-1)
-* [CreateProfile](_api_media_.media.md#createprofile-1)
-* [DeleteOSD](_api_media_.media.md#deleteosd-1)
-* [DeleteProfile](_api_media_.media.md#deleteprofile-1)
-* [GetAudioDecoderConfiguration](_api_media_.media.md#getaudiodecoderconfiguration-1)
-* [GetAudioDecoderConfigurationOptions](_api_media_.media.md#getaudiodecoderconfigurationoptions-1)
-* [GetAudioDecoderConfigurations](_api_media_.media.md#getaudiodecoderconfigurations-1)
-* [GetAudioEncoderConfiguration](_api_media_.media.md#getaudioencoderconfiguration-1)
-* [GetAudioEncoderConfigurationOptions](_api_media_.media.md#getaudioencoderconfigurationoptions-1)
-* [GetAudioEncoderConfigurations](_api_media_.media.md#getaudioencoderconfigurations-1)
-* [GetAudioOutputConfiguration](_api_media_.media.md#getaudiooutputconfiguration-1)
-* [GetAudioOutputConfigurationOptions](_api_media_.media.md#getaudiooutputconfigurationoptions-1)
-* [GetAudioOutputConfigurations](_api_media_.media.md#getaudiooutputconfigurations-1)
-* [GetAudioOutputs](_api_media_.media.md#getaudiooutputs-1)
-* [GetAudioSourceConfiguration](_api_media_.media.md#getaudiosourceconfiguration-1)
-* [GetAudioSourceConfigurationOptions](_api_media_.media.md#getaudiosourceconfigurationoptions-1)
-* [GetAudioSourceConfigurations](_api_media_.media.md#getaudiosourceconfigurations-1)
-* [GetAudioSources](_api_media_.media.md#getaudiosources-1)
-* [GetCompatibleAudioDecoderConfigurations](_api_media_.media.md#getcompatibleaudiodecoderconfigurations-1)
-* [GetCompatibleAudioEncoderConfigurations](_api_media_.media.md#getcompatibleaudioencoderconfigurations-1)
-* [GetCompatibleAudioOutputConfigurations](_api_media_.media.md#getcompatibleaudiooutputconfigurations-1)
-* [GetCompatibleAudioSourceConfigurations](_api_media_.media.md#getcompatibleaudiosourceconfigurations-1)
-* [GetCompatibleMetadataConfigurations](_api_media_.media.md#getcompatiblemetadataconfigurations-1)
-* [GetCompatibleVideoAnalyticsConfigurations](_api_media_.media.md#getcompatiblevideoanalyticsconfigurations-1)
-* [GetCompatibleVideoEncoderConfigurations](_api_media_.media.md#getcompatiblevideoencoderconfigurations-1)
-* [GetCompatibleVideoSourceConfigurations](_api_media_.media.md#getcompatiblevideosourceconfigurations-1)
-* [GetGuaranteedNumberOfVideoEncoderInstances](_api_media_.media.md#getguaranteednumberofvideoencoderinstances-1)
-* [GetMetadataConfiguration](_api_media_.media.md#getmetadataconfiguration-1)
-* [GetMetadataConfigurationOptions](_api_media_.media.md#getmetadataconfigurationoptions-1)
-* [GetMetadataConfigurations](_api_media_.media.md#getmetadataconfigurations-1)
-* [GetOSD](_api_media_.media.md#getosd-1)
-* [GetOSDOptions](_api_media_.media.md#getosdoptions-1)
-* [GetOSDs](_api_media_.media.md#getosds-1)
-* [GetProfile](_api_media_.media.md#getprofile-1)
-* [GetProfiles](_api_media_.media.md#getprofiles-1)
-* [GetServiceCapabilities](_api_media_.media.md#getservicecapabilities-1)
-* [GetSnapshotUri](_api_media_.media.md#getsnapshoturi-1)
-* [GetStreamUri](_api_media_.media.md#getstreamuri-1)
-* [GetVideoAnalyticsConfiguration](_api_media_.media.md#getvideoanalyticsconfiguration-1)
-* [GetVideoAnalyticsConfigurations](_api_media_.media.md#getvideoanalyticsconfigurations-1)
-* [GetVideoEncoderConfiguration](_api_media_.media.md#getvideoencoderconfiguration-1)
-* [GetVideoEncoderConfigurationOptions](_api_media_.media.md#getvideoencoderconfigurationoptions-1)
-* [GetVideoEncoderConfigurations](_api_media_.media.md#getvideoencoderconfigurations-1)
-* [GetVideoSourceConfiguration](_api_media_.media.md#getvideosourceconfiguration-1)
-* [GetVideoSourceConfigurationOptions](_api_media_.media.md#getvideosourceconfigurationoptions-1)
-* [GetVideoSourceConfigurations](_api_media_.media.md#getvideosourceconfigurations-1)
-* [GetVideoSourceModes](_api_media_.media.md#getvideosourcemodes-1)
-* [GetVideoSources](_api_media_.media.md#getvideosources-1)
-* [RemoveAudioDecoderConfiguration](_api_media_.media.md#removeaudiodecoderconfiguration-1)
-* [RemoveAudioEncoderConfiguration](_api_media_.media.md#removeaudioencoderconfiguration-1)
-* [RemoveAudioOutputConfiguration](_api_media_.media.md#removeaudiooutputconfiguration-1)
-* [RemoveAudioSourceConfiguration](_api_media_.media.md#removeaudiosourceconfiguration-1)
-* [RemoveMetadataConfiguration](_api_media_.media.md#removemetadataconfiguration-1)
-* [RemovePTZConfiguration](_api_media_.media.md#removeptzconfiguration-1)
-* [RemoveVideoAnalyticsConfiguration](_api_media_.media.md#removevideoanalyticsconfiguration-1)
-* [RemoveVideoEncoderConfiguration](_api_media_.media.md#removevideoencoderconfiguration-1)
-* [RemoveVideoSourceConfiguration](_api_media_.media.md#removevideosourceconfiguration-1)
-* [SetAudioDecoderConfiguration](_api_media_.media.md#setaudiodecoderconfiguration-1)
-* [SetAudioEncoderConfiguration](_api_media_.media.md#setaudioencoderconfiguration-1)
-* [SetAudioOutputConfiguration](_api_media_.media.md#setaudiooutputconfiguration-1)
-* [SetAudioSourceConfiguration](_api_media_.media.md#setaudiosourceconfiguration-1)
-* [SetMetadataConfiguration](_api_media_.media.md#setmetadataconfiguration-1)
-* [SetOSD](_api_media_.media.md#setosd-1)
-* [SetSynchronizationPoint](_api_media_.media.md#setsynchronizationpoint-1)
-* [SetVideoAnalyticsConfiguration](_api_media_.media.md#setvideoanalyticsconfiguration-1)
-* [SetVideoEncoderConfiguration](_api_media_.media.md#setvideoencoderconfiguration-1)
-* [SetVideoSourceConfiguration](_api_media_.media.md#setvideosourceconfiguration-1)
-* [SetVideoSourceMode](_api_media_.media.md#setvideosourcemode-1)
-* [StartMulticastStreaming](_api_media_.media.md#startmulticaststreaming-1)
-* [StopMulticastStreaming](_api_media_.media.md#stopmulticaststreaming-1)
+* [AddAudioDecoderConfiguration](_api_media_.onvifmedia.md#addaudiodecoderconfiguration)
+* [AddAudioEncoderConfiguration](_api_media_.onvifmedia.md#addaudioencoderconfiguration)
+* [AddAudioOutputConfiguration](_api_media_.onvifmedia.md#addaudiooutputconfiguration)
+* [AddAudioSourceConfiguration](_api_media_.onvifmedia.md#addaudiosourceconfiguration)
+* [AddMetadataConfiguration](_api_media_.onvifmedia.md#addmetadataconfiguration)
+* [AddPTZConfiguration](_api_media_.onvifmedia.md#addptzconfiguration)
+* [AddVideoAnalyticsConfiguration](_api_media_.onvifmedia.md#addvideoanalyticsconfiguration)
+* [AddVideoEncoderConfiguration](_api_media_.onvifmedia.md#addvideoencoderconfiguration)
+* [AddVideoSourceConfiguration](_api_media_.onvifmedia.md#addvideosourceconfiguration)
+* [CreateOSD](_api_media_.onvifmedia.md#createosd)
+* [CreateProfile](_api_media_.onvifmedia.md#createprofile)
+* [DeleteOSD](_api_media_.onvifmedia.md#deleteosd)
+* [DeleteProfile](_api_media_.onvifmedia.md#deleteprofile)
+* [GetAudioDecoderConfiguration](_api_media_.onvifmedia.md#getaudiodecoderconfiguration)
+* [GetAudioDecoderConfigurationOptions](_api_media_.onvifmedia.md#getaudiodecoderconfigurationoptions)
+* [GetAudioDecoderConfigurations](_api_media_.onvifmedia.md#getaudiodecoderconfigurations)
+* [GetAudioEncoderConfiguration](_api_media_.onvifmedia.md#getaudioencoderconfiguration)
+* [GetAudioEncoderConfigurationOptions](_api_media_.onvifmedia.md#getaudioencoderconfigurationoptions)
+* [GetAudioEncoderConfigurations](_api_media_.onvifmedia.md#getaudioencoderconfigurations)
+* [GetAudioOutputConfiguration](_api_media_.onvifmedia.md#getaudiooutputconfiguration)
+* [GetAudioOutputConfigurationOptions](_api_media_.onvifmedia.md#getaudiooutputconfigurationoptions)
+* [GetAudioOutputConfigurations](_api_media_.onvifmedia.md#getaudiooutputconfigurations)
+* [GetAudioOutputs](_api_media_.onvifmedia.md#getaudiooutputs)
+* [GetAudioSourceConfiguration](_api_media_.onvifmedia.md#getaudiosourceconfiguration)
+* [GetAudioSourceConfigurationOptions](_api_media_.onvifmedia.md#getaudiosourceconfigurationoptions)
+* [GetAudioSourceConfigurations](_api_media_.onvifmedia.md#getaudiosourceconfigurations)
+* [GetAudioSources](_api_media_.onvifmedia.md#getaudiosources)
+* [GetCompatibleAudioDecoderConfigurations](_api_media_.onvifmedia.md#getcompatibleaudiodecoderconfigurations)
+* [GetCompatibleAudioEncoderConfigurations](_api_media_.onvifmedia.md#getcompatibleaudioencoderconfigurations)
+* [GetCompatibleAudioOutputConfigurations](_api_media_.onvifmedia.md#getcompatibleaudiooutputconfigurations)
+* [GetCompatibleAudioSourceConfigurations](_api_media_.onvifmedia.md#getcompatibleaudiosourceconfigurations)
+* [GetCompatibleMetadataConfigurations](_api_media_.onvifmedia.md#getcompatiblemetadataconfigurations)
+* [GetCompatibleVideoAnalyticsConfigurations](_api_media_.onvifmedia.md#getcompatiblevideoanalyticsconfigurations)
+* [GetCompatibleVideoEncoderConfigurations](_api_media_.onvifmedia.md#getcompatiblevideoencoderconfigurations)
+* [GetCompatibleVideoSourceConfigurations](_api_media_.onvifmedia.md#getcompatiblevideosourceconfigurations)
+* [GetGuaranteedNumberOfVideoEncoderInstances](_api_media_.onvifmedia.md#getguaranteednumberofvideoencoderinstances)
+* [GetMetadataConfiguration](_api_media_.onvifmedia.md#getmetadataconfiguration)
+* [GetMetadataConfigurationOptions](_api_media_.onvifmedia.md#getmetadataconfigurationoptions)
+* [GetMetadataConfigurations](_api_media_.onvifmedia.md#getmetadataconfigurations)
+* [GetOSD](_api_media_.onvifmedia.md#getosd)
+* [GetOSDOptions](_api_media_.onvifmedia.md#getosdoptions)
+* [GetOSDs](_api_media_.onvifmedia.md#getosds)
+* [GetProfile](_api_media_.onvifmedia.md#getprofile)
+* [GetProfiles](_api_media_.onvifmedia.md#getprofiles)
+* [GetServiceCapabilities](_api_media_.onvifmedia.md#getservicecapabilities)
+* [GetSnapshotUri](_api_media_.onvifmedia.md#getsnapshoturi)
+* [GetStreamUri](_api_media_.onvifmedia.md#getstreamuri)
+* [GetVideoAnalyticsConfiguration](_api_media_.onvifmedia.md#getvideoanalyticsconfiguration)
+* [GetVideoAnalyticsConfigurations](_api_media_.onvifmedia.md#getvideoanalyticsconfigurations)
+* [GetVideoEncoderConfiguration](_api_media_.onvifmedia.md#getvideoencoderconfiguration)
+* [GetVideoEncoderConfigurationOptions](_api_media_.onvifmedia.md#getvideoencoderconfigurationoptions)
+* [GetVideoEncoderConfigurations](_api_media_.onvifmedia.md#getvideoencoderconfigurations)
+* [GetVideoSourceConfiguration](_api_media_.onvifmedia.md#getvideosourceconfiguration)
+* [GetVideoSourceConfigurationOptions](_api_media_.onvifmedia.md#getvideosourceconfigurationoptions)
+* [GetVideoSourceConfigurations](_api_media_.onvifmedia.md#getvideosourceconfigurations)
+* [GetVideoSourceModes](_api_media_.onvifmedia.md#getvideosourcemodes)
+* [GetVideoSources](_api_media_.onvifmedia.md#getvideosources)
+* [RemoveAudioDecoderConfiguration](_api_media_.onvifmedia.md#removeaudiodecoderconfiguration)
+* [RemoveAudioEncoderConfiguration](_api_media_.onvifmedia.md#removeaudioencoderconfiguration)
+* [RemoveAudioOutputConfiguration](_api_media_.onvifmedia.md#removeaudiooutputconfiguration)
+* [RemoveAudioSourceConfiguration](_api_media_.onvifmedia.md#removeaudiosourceconfiguration)
+* [RemoveMetadataConfiguration](_api_media_.onvifmedia.md#removemetadataconfiguration)
+* [RemovePTZConfiguration](_api_media_.onvifmedia.md#removeptzconfiguration)
+* [RemoveVideoAnalyticsConfiguration](_api_media_.onvifmedia.md#removevideoanalyticsconfiguration)
+* [RemoveVideoEncoderConfiguration](_api_media_.onvifmedia.md#removevideoencoderconfiguration)
+* [RemoveVideoSourceConfiguration](_api_media_.onvifmedia.md#removevideosourceconfiguration)
+* [SetAudioDecoderConfiguration](_api_media_.onvifmedia.md#setaudiodecoderconfiguration)
+* [SetAudioEncoderConfiguration](_api_media_.onvifmedia.md#setaudioencoderconfiguration)
+* [SetAudioOutputConfiguration](_api_media_.onvifmedia.md#setaudiooutputconfiguration)
+* [SetAudioSourceConfiguration](_api_media_.onvifmedia.md#setaudiosourceconfiguration)
+* [SetMetadataConfiguration](_api_media_.onvifmedia.md#setmetadataconfiguration)
+* [SetOSD](_api_media_.onvifmedia.md#setosd)
+* [SetSynchronizationPoint](_api_media_.onvifmedia.md#setsynchronizationpoint)
+* [SetVideoAnalyticsConfiguration](_api_media_.onvifmedia.md#setvideoanalyticsconfiguration)
+* [SetVideoEncoderConfiguration](_api_media_.onvifmedia.md#setvideoencoderconfiguration)
+* [SetVideoSourceConfiguration](_api_media_.onvifmedia.md#setvideosourceconfiguration)
+* [SetVideoSourceMode](_api_media_.onvifmedia.md#setvideosourcemode)
+* [StartMulticastStreaming](_api_media_.onvifmedia.md#startmulticaststreaming)
+* [StopMulticastStreaming](_api_media_.onvifmedia.md#stopmulticaststreaming)
+* [AddAudioDecoderConfiguration](_api_media_.onvifmedia.md#addaudiodecoderconfiguration-1)
+* [AddAudioEncoderConfiguration](_api_media_.onvifmedia.md#addaudioencoderconfiguration-1)
+* [AddAudioOutputConfiguration](_api_media_.onvifmedia.md#addaudiooutputconfiguration-1)
+* [AddAudioSourceConfiguration](_api_media_.onvifmedia.md#addaudiosourceconfiguration-1)
+* [AddMetadataConfiguration](_api_media_.onvifmedia.md#addmetadataconfiguration-1)
+* [AddPTZConfiguration](_api_media_.onvifmedia.md#addptzconfiguration-1)
+* [AddVideoAnalyticsConfiguration](_api_media_.onvifmedia.md#addvideoanalyticsconfiguration-1)
+* [AddVideoEncoderConfiguration](_api_media_.onvifmedia.md#addvideoencoderconfiguration-1)
+* [AddVideoSourceConfiguration](_api_media_.onvifmedia.md#addvideosourceconfiguration-1)
+* [CreateOSD](_api_media_.onvifmedia.md#createosd-1)
+* [CreateProfile](_api_media_.onvifmedia.md#createprofile-1)
+* [DeleteOSD](_api_media_.onvifmedia.md#deleteosd-1)
+* [DeleteProfile](_api_media_.onvifmedia.md#deleteprofile-1)
+* [GetAudioDecoderConfiguration](_api_media_.onvifmedia.md#getaudiodecoderconfiguration-1)
+* [GetAudioDecoderConfigurationOptions](_api_media_.onvifmedia.md#getaudiodecoderconfigurationoptions-1)
+* [GetAudioDecoderConfigurations](_api_media_.onvifmedia.md#getaudiodecoderconfigurations-1)
+* [GetAudioEncoderConfiguration](_api_media_.onvifmedia.md#getaudioencoderconfiguration-1)
+* [GetAudioEncoderConfigurationOptions](_api_media_.onvifmedia.md#getaudioencoderconfigurationoptions-1)
+* [GetAudioEncoderConfigurations](_api_media_.onvifmedia.md#getaudioencoderconfigurations-1)
+* [GetAudioOutputConfiguration](_api_media_.onvifmedia.md#getaudiooutputconfiguration-1)
+* [GetAudioOutputConfigurationOptions](_api_media_.onvifmedia.md#getaudiooutputconfigurationoptions-1)
+* [GetAudioOutputConfigurations](_api_media_.onvifmedia.md#getaudiooutputconfigurations-1)
+* [GetAudioOutputs](_api_media_.onvifmedia.md#getaudiooutputs-1)
+* [GetAudioSourceConfiguration](_api_media_.onvifmedia.md#getaudiosourceconfiguration-1)
+* [GetAudioSourceConfigurationOptions](_api_media_.onvifmedia.md#getaudiosourceconfigurationoptions-1)
+* [GetAudioSourceConfigurations](_api_media_.onvifmedia.md#getaudiosourceconfigurations-1)
+* [GetAudioSources](_api_media_.onvifmedia.md#getaudiosources-1)
+* [GetCompatibleAudioDecoderConfigurations](_api_media_.onvifmedia.md#getcompatibleaudiodecoderconfigurations-1)
+* [GetCompatibleAudioEncoderConfigurations](_api_media_.onvifmedia.md#getcompatibleaudioencoderconfigurations-1)
+* [GetCompatibleAudioOutputConfigurations](_api_media_.onvifmedia.md#getcompatibleaudiooutputconfigurations-1)
+* [GetCompatibleAudioSourceConfigurations](_api_media_.onvifmedia.md#getcompatibleaudiosourceconfigurations-1)
+* [GetCompatibleMetadataConfigurations](_api_media_.onvifmedia.md#getcompatiblemetadataconfigurations-1)
+* [GetCompatibleVideoAnalyticsConfigurations](_api_media_.onvifmedia.md#getcompatiblevideoanalyticsconfigurations-1)
+* [GetCompatibleVideoEncoderConfigurations](_api_media_.onvifmedia.md#getcompatiblevideoencoderconfigurations-1)
+* [GetCompatibleVideoSourceConfigurations](_api_media_.onvifmedia.md#getcompatiblevideosourceconfigurations-1)
+* [GetGuaranteedNumberOfVideoEncoderInstances](_api_media_.onvifmedia.md#getguaranteednumberofvideoencoderinstances-1)
+* [GetMetadataConfiguration](_api_media_.onvifmedia.md#getmetadataconfiguration-1)
+* [GetMetadataConfigurationOptions](_api_media_.onvifmedia.md#getmetadataconfigurationoptions-1)
+* [GetMetadataConfigurations](_api_media_.onvifmedia.md#getmetadataconfigurations-1)
+* [GetOSD](_api_media_.onvifmedia.md#getosd-1)
+* [GetOSDOptions](_api_media_.onvifmedia.md#getosdoptions-1)
+* [GetOSDs](_api_media_.onvifmedia.md#getosds-1)
+* [GetProfile](_api_media_.onvifmedia.md#getprofile-1)
+* [GetProfiles](_api_media_.onvifmedia.md#getprofiles-1)
+* [GetServiceCapabilities](_api_media_.onvifmedia.md#getservicecapabilities-1)
+* [GetSnapshotUri](_api_media_.onvifmedia.md#getsnapshoturi-1)
+* [GetStreamUri](_api_media_.onvifmedia.md#getstreamuri-1)
+* [GetVideoAnalyticsConfiguration](_api_media_.onvifmedia.md#getvideoanalyticsconfiguration-1)
+* [GetVideoAnalyticsConfigurations](_api_media_.onvifmedia.md#getvideoanalyticsconfigurations-1)
+* [GetVideoEncoderConfiguration](_api_media_.onvifmedia.md#getvideoencoderconfiguration-1)
+* [GetVideoEncoderConfigurationOptions](_api_media_.onvifmedia.md#getvideoencoderconfigurationoptions-1)
+* [GetVideoEncoderConfigurations](_api_media_.onvifmedia.md#getvideoencoderconfigurations-1)
+* [GetVideoSourceConfiguration](_api_media_.onvifmedia.md#getvideosourceconfiguration-1)
+* [GetVideoSourceConfigurationOptions](_api_media_.onvifmedia.md#getvideosourceconfigurationoptions-1)
+* [GetVideoSourceConfigurations](_api_media_.onvifmedia.md#getvideosourceconfigurations-1)
+* [GetVideoSourceModes](_api_media_.onvifmedia.md#getvideosourcemodes-1)
+* [GetVideoSources](_api_media_.onvifmedia.md#getvideosources-1)
+* [RemoveAudioDecoderConfiguration](_api_media_.onvifmedia.md#removeaudiodecoderconfiguration-1)
+* [RemoveAudioEncoderConfiguration](_api_media_.onvifmedia.md#removeaudioencoderconfiguration-1)
+* [RemoveAudioOutputConfiguration](_api_media_.onvifmedia.md#removeaudiooutputconfiguration-1)
+* [RemoveAudioSourceConfiguration](_api_media_.onvifmedia.md#removeaudiosourceconfiguration-1)
+* [RemoveMetadataConfiguration](_api_media_.onvifmedia.md#removemetadataconfiguration-1)
+* [RemovePTZConfiguration](_api_media_.onvifmedia.md#removeptzconfiguration-1)
+* [RemoveVideoAnalyticsConfiguration](_api_media_.onvifmedia.md#removevideoanalyticsconfiguration-1)
+* [RemoveVideoEncoderConfiguration](_api_media_.onvifmedia.md#removevideoencoderconfiguration-1)
+* [RemoveVideoSourceConfiguration](_api_media_.onvifmedia.md#removevideosourceconfiguration-1)
+* [SetAudioDecoderConfiguration](_api_media_.onvifmedia.md#setaudiodecoderconfiguration-1)
+* [SetAudioEncoderConfiguration](_api_media_.onvifmedia.md#setaudioencoderconfiguration-1)
+* [SetAudioOutputConfiguration](_api_media_.onvifmedia.md#setaudiooutputconfiguration-1)
+* [SetAudioSourceConfiguration](_api_media_.onvifmedia.md#setaudiosourceconfiguration-1)
+* [SetMetadataConfiguration](_api_media_.onvifmedia.md#setmetadataconfiguration-1)
+* [SetOSD](_api_media_.onvifmedia.md#setosd-1)
+* [SetSynchronizationPoint](_api_media_.onvifmedia.md#setsynchronizationpoint-1)
+* [SetVideoAnalyticsConfiguration](_api_media_.onvifmedia.md#setvideoanalyticsconfiguration-1)
+* [SetVideoEncoderConfiguration](_api_media_.onvifmedia.md#setvideoencoderconfiguration-1)
+* [SetVideoSourceConfiguration](_api_media_.onvifmedia.md#setvideosourceconfiguration-1)
+* [SetVideoSourceMode](_api_media_.onvifmedia.md#setvideosourcemode-1)
+* [StartMulticastStreaming](_api_media_.onvifmedia.md#startmulticaststreaming-1)
+* [StopMulticastStreaming](_api_media_.onvifmedia.md#stopmulticaststreaming-1)
 
 ---
 
@@ -185,9 +185,9 @@
 
 ###  constructor
 
-⊕ **new Media**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Media](_api_media_.media.md)
+⊕ **new ONVIFMedia**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFMedia](_api_media_.onvifmedia.md)
 
-*Defined in [api/media.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L5)*
+*Defined in [api/media.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L5)*
 
 **Parameters:**
 
@@ -195,7 +195,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Media](_api_media_.media.md)
+**Returns:** [ONVIFMedia](_api_media_.onvifmedia.md)
 
 ___
 
@@ -207,7 +207,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/media.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L6)*
+*Defined in [api/media.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L6)*
 
 ___
 
@@ -219,7 +219,7 @@ ___
 
 ▸ **AddAudioDecoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1024](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1024)*
+*Defined in [api/media.ts:1024](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1024)*
 
 This operation adds an AudioDecoderConfiguration to an existing media profile. If a configuration exists in the media profile, it shall be replaced. The change shall be persistent.
 
@@ -239,7 +239,7 @@ ___
 
 ▸ **AddAudioEncoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:926](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L926)*
+*Defined in [api/media.ts:926](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L926)*
 
 This operation adds an AudioEncoderConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. A device shall support adding a compatible AudioEncoderConfiguration to a profile containing an AudioSourceConfiguration and shall support streaming audio data of such a profile.
 
@@ -259,7 +259,7 @@ ___
 
 ▸ **AddAudioOutputConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1010](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1010)*
+*Defined in [api/media.ts:1010](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1010)*
 
 This operation adds an AudioOutputConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent.
 
@@ -279,7 +279,7 @@ ___
 
 ▸ **AddAudioSourceConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:943](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L943)*
+*Defined in [api/media.ts:943](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L943)*
 
 This operation adds an AudioSourceConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent.
 
@@ -299,7 +299,7 @@ ___
 
 ▸ **AddMetadataConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:996](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L996)*
+*Defined in [api/media.ts:996](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L996)*
 
 This operation adds a Metadata configuration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a MetadataConfiguration to a Profile means that streams using that profile contain metadata. Metadata can consist of events, PTZ status, and/or video analytics data.
 
@@ -319,7 +319,7 @@ ___
 
 ▸ **AddPTZConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:963](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L963)*
+*Defined in [api/media.ts:963](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L963)*
 
 This operation adds a PTZConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a PTZConfiguration to a media profile means that streams using that media profile can contain PTZ status (in the metadata), and that the media profile can be used for controlling PTZ movement.
 
@@ -339,7 +339,7 @@ ___
 
 ▸ **AddVideoAnalyticsConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:981](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L981)*
+*Defined in [api/media.ts:981](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L981)*
 
 This operation adds a VideoAnalytics configuration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a VideoAnalyticsConfiguration to a media profile means that streams using that media profile can contain video analytics data (in the metadata) as defined by the submitted configuration reference. A profile containing only a video analytics configuration but no video source configuration is incomplete. Therefore, a client should first add a video source configuration to a profile before adding a video analytics configuration. The device can deny adding of a video analytics configuration before a video source configuration.
 
@@ -359,7 +359,7 @@ ___
 
 ▸ **AddVideoEncoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:890](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L890)*
+*Defined in [api/media.ts:890](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L890)*
 
 This operation adds a VideoEncoderConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. A device shall support adding a compatible VideoEncoderConfiguration to a Profile containing a VideoSourceConfiguration and shall support streaming video data of such a profile.
 
@@ -379,7 +379,7 @@ ___
 
 ▸ **AddVideoSourceConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:906](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L906)*
+*Defined in [api/media.ts:906](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L906)*
 
 This operation adds a VideoSourceConfiguration to an existing media profile. If such a configuration exists in the media profile, it will be replaced. The change shall be persistent.
 
@@ -399,7 +399,7 @@ ___
 
 ▸ **CreateOSD**(OSD: *[OSDConfiguration](../interfaces/_api_types_.osdconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1480](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1480)*
+*Defined in [api/media.ts:1480](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1480)*
 
 Create the OSD.
 
@@ -418,7 +418,7 @@ ___
 
 ▸ **CreateProfile**(Name: *[Name]()*, Token: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:862](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L862)*
+*Defined in [api/media.ts:862](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L862)*
 
 This operation creates a new empty media profile. The media profile shall be created in the device and shall be persistent (remain after reboot). A created profile shall be deletable and a device shall set the “fixed” attribute to false in the returned Profile.
 
@@ -438,7 +438,7 @@ ___
 
 ▸ **DeleteOSD**(OSDToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1487](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1487)*
+*Defined in [api/media.ts:1487](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1487)*
 
 Delete the OSD.
 
@@ -457,7 +457,7 @@ ___
 
 ▸ **DeleteProfile**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1038](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1038)*
+*Defined in [api/media.ts:1038](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1038)*
 
 This operation deletes a profile. This change shall always be persistent. Deletion of a profile is only possible for non-fixed profiles
 
@@ -476,7 +476,7 @@ ___
 
 ▸ **GetAudioDecoderConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1151](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1151)*
+*Defined in [api/media.ts:1151](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1151)*
 
 If the audio decoder configuration token is already known, the decoder configuration can be fetched through the GetAudioDecoderConfiguration command.
 
@@ -495,7 +495,7 @@ ___
 
 ▸ **GetAudioDecoderConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1351](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1351)*
+*Defined in [api/media.ts:1351](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1351)*
 
 This command list the audio decoding capabilities for a given profile and configuration of a device.
 
@@ -515,7 +515,7 @@ ___
 
 ▸ **GetAudioDecoderConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1095](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1095)*
+*Defined in [api/media.ts:1095](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1095)*
 
 This command lists all existing AudioDecoderConfigurations of a device. The NVC need not know anything apriori about the audio decoder configurations in order to use this command.
 
@@ -528,7 +528,7 @@ ___
 
 ▸ **GetAudioEncoderConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1123](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1123)*
+*Defined in [api/media.ts:1123](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1123)*
 
 The GetAudioEncoderConfiguration command fetches the encoder configuration if the audio encoder configuration token is known.
 
@@ -547,7 +547,7 @@ ___
 
 ▸ **GetAudioEncoderConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1329](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1329)*
+*Defined in [api/media.ts:1329](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1329)*
 
 This operation returns the available options (supported values and ranges for audio encoder configuration parameters) when the audio encoder parameters are reconfigured.
 
@@ -567,7 +567,7 @@ ___
 
 ▸ **GetAudioEncoderConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1066](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1066)*
+*Defined in [api/media.ts:1066](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1066)*
 
 This operation lists all existing device audio encoder configurations. The client need not know anything apriori about the audio encoder configurations in order to use the command.
 
@@ -580,7 +580,7 @@ ___
 
 ▸ **GetAudioOutputConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1144](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1144)*
+*Defined in [api/media.ts:1144](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1144)*
 
 If the audio output configuration token is already known, the output configuration can be fetched through the GetAudioOutputConfiguration command.
 
@@ -599,7 +599,7 @@ ___
 
 ▸ **GetAudioOutputConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1343](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1343)*
+*Defined in [api/media.ts:1343](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1343)*
 
 This operation returns the available options (supported values and ranges for audio output configuration parameters) for configuring an audio output.
 
@@ -619,7 +619,7 @@ ___
 
 ▸ **GetAudioOutputConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1087](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1087)*
+*Defined in [api/media.ts:1087](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1087)*
 
 This command lists all existing AudioOutputConfigurations of a device. The NVC need not know anything apriori about the audio configurations to use this command.
 
@@ -632,7 +632,7 @@ ___
 
 ▸ **GetAudioOutputs**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:853](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L853)*
+*Defined in [api/media.ts:853](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L853)*
 
 This command lists all available physical audio outputs of the device.
 
@@ -645,7 +645,7 @@ ___
 
 ▸ **GetAudioSourceConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1116](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1116)*
+*Defined in [api/media.ts:1116](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1116)*
 
 The GetAudioSourceConfiguration command fetches the audio source configurations if the audio source configuration token is already known. An
 
@@ -664,7 +664,7 @@ ___
 
 ▸ **GetAudioSourceConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1321](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1321)*
+*Defined in [api/media.ts:1321](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1321)*
 
 This operation returns the available options (supported values and ranges for audio source configuration parameters) when the audio source parameters are reconfigured. If an audio source configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile.
 
@@ -684,7 +684,7 @@ ___
 
 ▸ **GetAudioSourceConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1059](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1059)*
+*Defined in [api/media.ts:1059](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1059)*
 
 This operation lists all existing audio source configurations of a device. This command lists all audio source configurations in a device. The client need not know anything apriori about the audio source configurations in order to use the command.
 
@@ -697,7 +697,7 @@ ___
 
 ▸ **GetAudioSources**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:846](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L846)*
+*Defined in [api/media.ts:846](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L846)*
 
 This command lists all available physical audio inputs of the device.
 
@@ -710,7 +710,7 @@ ___
 
 ▸ **GetCompatibleAudioDecoderConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1211](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1211)*
+*Defined in [api/media.ts:1211](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1211)*
 
 This operation lists all the audio decoder configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioDecoderConfiguration command on the media profile.
 
@@ -729,7 +729,7 @@ ___
 
 ▸ **GetCompatibleAudioEncoderConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1175](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1175)*
+*Defined in [api/media.ts:1175](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1175)*
 
 This operation requests all audio encoder configurations of a device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioSourceConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
@@ -748,7 +748,7 @@ ___
 
 ▸ **GetCompatibleAudioOutputConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1204](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1204)*
+*Defined in [api/media.ts:1204](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1204)*
 
 This command lists all audio output configurations of a device that are compatible with a certain media profile. Each returned configuration shall be a valid input for the AddAudioOutputConfiguration command.
 
@@ -767,7 +767,7 @@ ___
 
 ▸ **GetCompatibleAudioSourceConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1182](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1182)*
+*Defined in [api/media.ts:1182](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1182)*
 
 This operation requests all audio source configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioEncoderConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
@@ -786,7 +786,7 @@ ___
 
 ▸ **GetCompatibleMetadataConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1196](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1196)*
+*Defined in [api/media.ts:1196](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1196)*
 
 This operation requests all the metadata configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddMetadataConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
@@ -805,7 +805,7 @@ ___
 
 ▸ **GetCompatibleVideoAnalyticsConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1189](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1189)*
+*Defined in [api/media.ts:1189](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1189)*
 
 This operation requests all video analytic configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddVideoAnalyticsConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
@@ -824,7 +824,7 @@ ___
 
 ▸ **GetCompatibleVideoEncoderConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1158](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1158)*
+*Defined in [api/media.ts:1158](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1158)*
 
 This operation lists all the video encoder configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddVideoEncoderConfiguration command on the media profile. The result will vary depending on the capabilities, configurations and settings in the device.
 
@@ -843,7 +843,7 @@ ___
 
 ▸ **GetCompatibleVideoSourceConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1168](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1168)*
+*Defined in [api/media.ts:1168](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1168)*
 
 This operation requests all the video source configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddVideoSourceConfiguration command on the media profile. The result will vary depending on the capabilities, configurations and settings in the device.
 
@@ -862,7 +862,7 @@ ___
 
 ▸ **GetGuaranteedNumberOfVideoEncoderInstances**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1360](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1360)*
+*Defined in [api/media.ts:1360](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1360)*
 
 The GetGuaranteedNumberOfVideoEncoderInstances command can be used to request the minimum number of guaranteed video encoder instances (applications) per Video Source Configuration.
 
@@ -881,7 +881,7 @@ ___
 
 ▸ **GetMetadataConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1137](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1137)*
+*Defined in [api/media.ts:1137](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1137)*
 
 The GetMetadataConfiguration command fetches the metadata configuration if the metadata token is known.
 
@@ -900,7 +900,7 @@ ___
 
 ▸ **GetMetadataConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1336](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1336)*
+*Defined in [api/media.ts:1336](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1336)*
 
 This operation returns the available options (supported values and ranges for metadata configuration parameters) for changing the metadata configuration.
 
@@ -920,7 +920,7 @@ ___
 
 ▸ **GetMetadataConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1080](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1080)*
+*Defined in [api/media.ts:1080](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1080)*
 
 This operation lists all existing metadata configurations. The client need not know anything apriori about the metadata in order to use the command.
 
@@ -933,7 +933,7 @@ ___
 
 ▸ **GetOSD**(OSDToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1459](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1459)*
+*Defined in [api/media.ts:1459](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1459)*
 
 Get the OSD.
 
@@ -952,7 +952,7 @@ ___
 
 ▸ **GetOSDOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1466](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1466)*
+*Defined in [api/media.ts:1466](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1466)*
 
 Get the OSD Options.
 
@@ -971,7 +971,7 @@ ___
 
 ▸ **GetOSDs**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1452](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1452)*
+*Defined in [api/media.ts:1452](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1452)*
 
 Get the OSDs.
 
@@ -990,7 +990,7 @@ ___
 
 ▸ **GetProfile**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:869](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L869)*
+*Defined in [api/media.ts:869](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L869)*
 
 If the profile token is already known, a profile can be fetched through the GetProfile command.
 
@@ -1009,7 +1009,7 @@ ___
 
 ▸ **GetProfiles**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:879](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L879)*
+*Defined in [api/media.ts:879](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L879)*
 
 Any endpoint can ask for the existing media profiles of a device using the GetProfiles command. Pre-configured or dynamically configured profiles can be retrieved using this command. This command lists all configured profiles in a device. The client does not need to know the media profile in order to use the command.
 
@@ -1022,7 +1022,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:832](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L832)*
+*Defined in [api/media.ts:832](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L832)*
 
 Returns the capabilities of the media service. The result is returned in a typed answer.
 
@@ -1035,7 +1035,7 @@ ___
 
 ▸ **GetSnapshotUri**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1431](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1431)*
+*Defined in [api/media.ts:1431](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1431)*
 
 A client uses the GetSnapshotUri command to obtain a JPEG snapshot from the device. The returned URI shall remain valid indefinitely even if the profile is changed. The ValidUntilConnect, ValidUntilReboot and Timeout Parameter shall be set accordingly (ValidUntilConnect=false, ValidUntilReboot=false, timeout=PT0S). The URI can be used for acquiring a JPEG image through a HTTP GET operation. The image encoding will always be JPEG regardless of the encoding setting in the media profile. The Jpeg settings (like resolution or quality) may be taken from the profile if suitable. The provided image will be updated automatically and independent from calls to GetSnapshotUri.
 
@@ -1054,7 +1054,7 @@ ___
 
 ▸ **GetStreamUri**(StreamSetup: *[StreamSetup](../interfaces/_api_types_.streamsetup.md)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1381](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1381)*
+*Defined in [api/media.ts:1381](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1381)*
 
 This operation requests a URI that can be used to initiate a live media stream using RTSP as the control protocol. The returned URI shall remain valid indefinitely even if the profile is changed. The ValidUntilConnect, ValidUntilReboot and Timeout Parameter shall be set accordingly (ValidUntilConnect=false, ValidUntilReboot=false, timeout=PT0S). The correct syntax for the StreamSetup element for these media stream setups defined in 5.1.1 of the streaming specification are as follows:
 
@@ -1078,7 +1078,7 @@ ___
 
 ▸ **GetVideoAnalyticsConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1130](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1130)*
+*Defined in [api/media.ts:1130](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1130)*
 
 The GetVideoAnalyticsConfiguration command fetches the video analytics configuration if the video analytics token is known.
 
@@ -1097,7 +1097,7 @@ ___
 
 ▸ **GetVideoAnalyticsConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1073](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1073)*
+*Defined in [api/media.ts:1073](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1073)*
 
 This operation lists all video analytics configurations of a device. This command lists all configured video analytics in a device. The client need not know anything apriori about the video analytics in order to use the command.
 
@@ -1110,7 +1110,7 @@ ___
 
 ▸ **GetVideoEncoderConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1109](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1109)*
+*Defined in [api/media.ts:1109](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1109)*
 
 If the video encoder configuration token is already known, the encoder configuration can be fetched through the GetVideoEncoderConfiguration command.
 
@@ -1129,7 +1129,7 @@ ___
 
 ▸ **GetVideoEncoderConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1311](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1311)*
+*Defined in [api/media.ts:1311](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1311)*
 
 This operation returns the available options (supported values and ranges for video encoder configuration parameters) when the video encoder parameters are reconfigured. For JPEG, MPEG4 and H264 extension elements have been defined that provide additional information. A device must provide the XxxOption information for all encodings supported and should additionally provide the corresponding XxxOption2 information. This response contains the available video encoder configuration options. If a video encoder configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile. If no tokens are specified, the options shall be considered generic for the device.
 
@@ -1149,7 +1149,7 @@ ___
 
 ▸ **GetVideoEncoderConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1052](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1052)*
+*Defined in [api/media.ts:1052](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1052)*
 
 This operation lists all existing video encoder configurations of a device. This command lists all configured video encoder configurations in a device. The client need not know anything apriori about the video encoder configurations in order to use the command.
 
@@ -1162,7 +1162,7 @@ ___
 
 ▸ **GetVideoSourceConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1102](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1102)*
+*Defined in [api/media.ts:1102](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1102)*
 
 If the video source configuration token is already known, the video source configuration can be fetched through the GetVideoSourceConfiguration command.
 
@@ -1181,7 +1181,7 @@ ___
 
 ▸ **GetVideoSourceConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1297](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1297)*
+*Defined in [api/media.ts:1297](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1297)*
 
 This operation returns the available options (supported values and ranges for video source configuration parameters) when the video source parameters are reconfigured If a video source configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile.
 
@@ -1201,7 +1201,7 @@ ___
 
 ▸ **GetVideoSourceConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1045](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1045)*
+*Defined in [api/media.ts:1045](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1045)*
 
 This operation lists all existing video source configurations for a device. The client need not know anything about the video source configurations in order to use the command.
 
@@ -1214,7 +1214,7 @@ ___
 
 ▸ **GetVideoSourceModes**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1438](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1438)*
+*Defined in [api/media.ts:1438](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1438)*
 
 A device returns the information for current video source mode and settable video source modes of specified video source. A device that indicates a capability of VideoSourceModes shall support this command.
 
@@ -1233,7 +1233,7 @@ ___
 
 ▸ **GetVideoSources**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:839](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L839)*
+*Defined in [api/media.ts:839](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L839)*
 
 This command lists all available physical video inputs of the device.
 
@@ -1246,7 +1246,7 @@ ___
 
 ▸ **RemoveAudioDecoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1031](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1031)*
+*Defined in [api/media.ts:1031](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1031)*
 
 This operation removes an AudioDecoderConfiguration from an existing media profile. If the media profile does not contain an AudioDecoderConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -1265,7 +1265,7 @@ ___
 
 ▸ **RemoveAudioEncoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:935](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L935)*
+*Defined in [api/media.ts:935](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L935)*
 
 This operation removes an AudioEncoderConfiguration from an existing media profile. If the media profile does not contain an AudioEncoderConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -1284,7 +1284,7 @@ ___
 
 ▸ **RemoveAudioOutputConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1017](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1017)*
+*Defined in [api/media.ts:1017](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1017)*
 
 This operation removes an AudioOutputConfiguration from an existing media profile. If the media profile does not contain an AudioOutputConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -1303,7 +1303,7 @@ ___
 
 ▸ **RemoveAudioSourceConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:953](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L953)*
+*Defined in [api/media.ts:953](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L953)*
 
 This operation removes an AudioSourceConfiguration from an existing media profile. If the media profile does not contain an AudioSourceConfiguration, the operation has no effect. The removal shall be persistent. Audio source configurations should only be removed after removing an AudioEncoderConfiguration from the media profile.
 
@@ -1322,7 +1322,7 @@ ___
 
 ▸ **RemoveMetadataConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1003](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1003)*
+*Defined in [api/media.ts:1003](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1003)*
 
 This operation removes a MetadataConfiguration from an existing media profile. If the media profile does not contain a MetadataConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -1341,7 +1341,7 @@ ___
 
 ▸ **RemovePTZConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:971](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L971)*
+*Defined in [api/media.ts:971](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L971)*
 
 This operation removes a PTZConfiguration from an existing media profile. If the media profile does not contain a PTZConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -1360,7 +1360,7 @@ ___
 
 ▸ **RemoveVideoAnalyticsConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:989](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L989)*
+*Defined in [api/media.ts:989](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L989)*
 
 This operation removes a VideoAnalyticsConfiguration from an existing media profile. If the media profile does not contain a VideoAnalyticsConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -1379,7 +1379,7 @@ ___
 
 ▸ **RemoveVideoEncoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:898](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L898)*
+*Defined in [api/media.ts:898](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L898)*
 
 This operation removes a VideoEncoderConfiguration from an existing media profile. If the media profile does not contain a VideoEncoderConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -1398,7 +1398,7 @@ ___
 
 ▸ **RemoveVideoSourceConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:915](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L915)*
+*Defined in [api/media.ts:915](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L915)*
 
 This operation removes a VideoSourceConfiguration from an existing media profile. If the media profile does not contain a VideoSourceConfiguration, the operation has no effect. The removal shall be persistent. Video source configurations should only be removed after removing a VideoEncoderConfiguration from the media profile.
 
@@ -1417,7 +1417,7 @@ ___
 
 ▸ **SetAudioDecoderConfiguration**(Configuration: *[AudioDecoderConfiguration](../interfaces/_api_types_.audiodecoderconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1287](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1287)*
+*Defined in [api/media.ts:1287](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1287)*
 
 This operation modifies an audio decoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device.
 
@@ -1437,7 +1437,7 @@ ___
 
 ▸ **SetAudioEncoderConfiguration**(Configuration: *[AudioEncoderConfiguration](../interfaces/_api_types_.audioencoderconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1247](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1247)*
+*Defined in [api/media.ts:1247](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1247)*
 
 This operation modifies an audio encoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected streams. NVC methods for changing a running stream are out of scope for this specification.
 
@@ -1457,7 +1457,7 @@ ___
 
 ▸ **SetAudioOutputConfiguration**(Configuration: *[AudioOutputConfiguration](../interfaces/_api_types_.audiooutputconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1279](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1279)*
+*Defined in [api/media.ts:1279](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1279)*
 
 This operation modifies an audio output configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device.
 
@@ -1477,7 +1477,7 @@ ___
 
 ▸ **SetAudioSourceConfiguration**(Configuration: *[AudioSourceConfiguration](../interfaces/_api_types_.audiosourceconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1236](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1236)*
+*Defined in [api/media.ts:1236](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1236)*
 
 This operation modifies an audio source configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream NVC methods for changing a running stream are out of scope for this specification.
 
@@ -1497,7 +1497,7 @@ ___
 
 ▸ **SetMetadataConfiguration**(Configuration: *[MetadataConfiguration](../interfaces/_api_types_.metadataconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1271](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1271)*
+*Defined in [api/media.ts:1271](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1271)*
 
 This operation modifies a metadata configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be updated immediately according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected streams. NVC methods for changing a running stream are out of scope for this specification.
 
@@ -1517,7 +1517,7 @@ ___
 
 ▸ **SetOSD**(OSD: *[OSDConfiguration](../interfaces/_api_types_.osdconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1473](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1473)*
+*Defined in [api/media.ts:1473](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1473)*
 
 Set the OSD
 
@@ -1536,7 +1536,7 @@ ___
 
 ▸ **SetSynchronizationPoint**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1417](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1417)*
+*Defined in [api/media.ts:1417](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1417)*
 
 Synchronization points allow clients to decode and correctly use all data after the synchronization point. For example, if a video stream is configured with a large I-frame distance and a client loses a single packet, the client does not display video until the next I-frame is transmitted. In such cases, the client can request a Synchronization Point which enforces the device to add an I-Frame as soon as possible. Clients can request Synchronization Points for profiles. The device shall add synchronization points for all streams associated with this profile. Similarly, a synchronization point is used to get an update on full PTZ or event status through the metadata stream. If a video stream is associated with the profile, an I-frame shall be added to this video stream. If a PTZ metadata stream is associated to the profile, the PTZ position shall be repeated within the metadata stream.
 
@@ -1555,7 +1555,7 @@ ___
 
 ▸ **SetVideoAnalyticsConfiguration**(Configuration: *[VideoAnalyticsConfiguration](../interfaces/_api_types_.videoanalyticsconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1259](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1259)*
+*Defined in [api/media.ts:1259](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1259)*
 
 A video analytics configuration is modified using this command. The ForcePersistence flag indicates if the changes shall remain after reboot of the device or not. Running streams using this configuration shall be immediately updated according to the new settings. Otherwise inconsistencies can occur between the scene description processed by the rule engine and the notifications produced by analytics engine and rule engine which reference the very same video analytics configuration token.
 
@@ -1575,7 +1575,7 @@ ___
 
 ▸ **SetVideoEncoderConfiguration**(Configuration: *[VideoEncoderConfiguration](../interfaces/_api_types_.videoencoderconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1225](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1225)*
+*Defined in [api/media.ts:1225](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1225)*
 
 This operation modifies a video encoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification. SessionTimeout is provided as a hint for keeping rtsp session by a device. If necessary the device may adapt parameter values for SessionTimeout elements without returning an error. For the time between keep alive calls the client shall adhere to the timeout value signaled via RTSP.
 
@@ -1595,7 +1595,7 @@ ___
 
 ▸ **SetVideoSourceConfiguration**(Configuration: *[VideoSourceConfiguration](../interfaces/_api_types_.videosourceconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1218](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1218)*
+*Defined in [api/media.ts:1218](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1218)*
 
 This operation modifies a video source configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification.
 
@@ -1615,7 +1615,7 @@ ___
 
 ▸ **SetVideoSourceMode**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, VideoSourceModeToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1445](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1445)*
+*Defined in [api/media.ts:1445](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1445)*
 
 SetVideoSourceMode changes the media profile structure relating to video source for the specified video source mode. A device that indicates a capability of VideoSourceModes shall support this command. The behavior after changing the mode is not defined in this specification.
 
@@ -1635,7 +1635,7 @@ ___
 
 ▸ **StartMulticastStreaming**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1393](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1393)*
+*Defined in [api/media.ts:1393](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1393)*
 
 This command starts multicast streaming using a specified media profile of a device. Streaming continues until StopMulticastStreaming is called for the same Profile. The streaming shall continue after a reboot of the device until a StopMulticastStreaming request is received. The multicast address, port and TTL are configured in the VideoEncoderConfiguration, AudioEncoderConfiguration and MetadataConfiguration respectively.
 
@@ -1654,7 +1654,7 @@ ___
 
 ▸ **StopMulticastStreaming**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/media.ts:1400](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L1400)*
+*Defined in [api/media.ts:1400](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L1400)*
 
 This command stop multicast streaming using a specified media profile of a device
 
@@ -1673,7 +1673,7 @@ ___
 
 ▸ **AddAudioDecoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:250](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L250)*
+*Defined in [api/media.ts:250](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L250)*
 
 This operation adds an AudioDecoderConfiguration to an existing media profile. If a configuration exists in the media profile, it shall be replaced. The change shall be persistent.
 
@@ -1693,7 +1693,7 @@ ___
 
 ▸ **AddAudioEncoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:128](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L128)*
+*Defined in [api/media.ts:128](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L128)*
 
 This operation adds an AudioEncoderConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. A device shall support adding a compatible AudioEncoderConfiguration to a profile containing an AudioSourceConfiguration and shall support streaming audio data of such a profile.
 
@@ -1713,7 +1713,7 @@ ___
 
 ▸ **AddAudioOutputConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:232](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L232)*
+*Defined in [api/media.ts:232](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L232)*
 
 This operation adds an AudioOutputConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent.
 
@@ -1733,7 +1733,7 @@ ___
 
 ▸ **AddAudioSourceConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:149](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L149)*
+*Defined in [api/media.ts:149](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L149)*
 
 This operation adds an AudioSourceConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent.
 
@@ -1753,7 +1753,7 @@ ___
 
 ▸ **AddMetadataConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:214](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L214)*
+*Defined in [api/media.ts:214](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L214)*
 
 This operation adds a Metadata configuration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a MetadataConfiguration to a Profile means that streams using that profile contain metadata. Metadata can consist of events, PTZ status, and/or video analytics data.
 
@@ -1773,7 +1773,7 @@ ___
 
 ▸ **AddPTZConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:173](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L173)*
+*Defined in [api/media.ts:173](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L173)*
 
 This operation adds a PTZConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a PTZConfiguration to a media profile means that streams using that media profile can contain PTZ status (in the metadata), and that the media profile can be used for controlling PTZ movement.
 
@@ -1793,7 +1793,7 @@ ___
 
 ▸ **AddVideoAnalyticsConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:195](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L195)*
+*Defined in [api/media.ts:195](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L195)*
 
 This operation adds a VideoAnalytics configuration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a VideoAnalyticsConfiguration to a media profile means that streams using that media profile can contain video analytics data (in the metadata) as defined by the submitted configuration reference. A profile containing only a video analytics configuration but no video source configuration is incomplete. Therefore, a client should first add a video source configuration to a profile before adding a video analytics configuration. The device can deny adding of a video analytics configuration before a video source configuration.
 
@@ -1813,7 +1813,7 @@ ___
 
 ▸ **AddVideoEncoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:84](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L84)*
+*Defined in [api/media.ts:84](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L84)*
 
 This operation adds a VideoEncoderConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. A device shall support adding a compatible VideoEncoderConfiguration to a Profile containing a VideoSourceConfiguration and shall support streaming video data of such a profile.
 
@@ -1833,7 +1833,7 @@ ___
 
 ▸ **AddVideoSourceConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:104](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L104)*
+*Defined in [api/media.ts:104](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L104)*
 
 This operation adds a VideoSourceConfiguration to an existing media profile. If such a configuration exists in the media profile, it will be replaced. The change shall be persistent.
 
@@ -1853,7 +1853,7 @@ ___
 
 ▸ **CreateOSD**(OSD: *[OSDConfiguration](../interfaces/_api_types_.osdconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:814](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L814)*
+*Defined in [api/media.ts:814](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L814)*
 
 Create the OSD.
 
@@ -1872,7 +1872,7 @@ ___
 
 ▸ **CreateProfile**(Name: *[Name]()*, Token?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:50](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L50)*
+*Defined in [api/media.ts:50](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L50)*
 
 This operation creates a new empty media profile. The media profile shall be created in the device and shall be persistent (remain after reboot). A created profile shall be deletable and a device shall set the “fixed” attribute to false in the returned Profile.
 
@@ -1892,7 +1892,7 @@ ___
 
 ▸ **DeleteOSD**(OSDToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:823](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L823)*
+*Defined in [api/media.ts:823](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L823)*
 
 Delete the OSD.
 
@@ -1911,7 +1911,7 @@ ___
 
 ▸ **DeleteProfile**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:268](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L268)*
+*Defined in [api/media.ts:268](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L268)*
 
 This operation deletes a profile. This change shall always be persistent. Deletion of a profile is only possible for non-fixed profiles
 
@@ -1930,7 +1930,7 @@ ___
 
 ▸ **GetAudioDecoderConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:413](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L413)*
+*Defined in [api/media.ts:413](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L413)*
 
 If the audio decoder configuration token is already known, the decoder configuration can be fetched through the GetAudioDecoderConfiguration command.
 
@@ -1949,7 +1949,7 @@ ___
 
 ▸ **GetAudioDecoderConfigurationOptions**(ConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:659](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L659)*
+*Defined in [api/media.ts:659](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L659)*
 
 This command list the audio decoding capabilities for a given profile and configuration of a device.
 
@@ -1969,7 +1969,7 @@ ___
 
 ▸ **GetAudioDecoderConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:341](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L341)*
+*Defined in [api/media.ts:341](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L341)*
 
 This command lists all existing AudioDecoderConfigurations of a device. The NVC need not know anything apriori about the audio decoder configurations in order to use this command.
 
@@ -1982,7 +1982,7 @@ ___
 
 ▸ **GetAudioEncoderConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:377](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L377)*
+*Defined in [api/media.ts:377](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L377)*
 
 The GetAudioEncoderConfiguration command fetches the encoder configuration if the audio encoder configuration token is known.
 
@@ -2001,7 +2001,7 @@ ___
 
 ▸ **GetAudioEncoderConfigurationOptions**(ConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:631](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L631)*
+*Defined in [api/media.ts:631](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L631)*
 
 This operation returns the available options (supported values and ranges for audio encoder configuration parameters) when the audio encoder parameters are reconfigured.
 
@@ -2021,7 +2021,7 @@ ___
 
 ▸ **GetAudioEncoderConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:304](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L304)*
+*Defined in [api/media.ts:304](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L304)*
 
 This operation lists all existing device audio encoder configurations. The client need not know anything apriori about the audio encoder configurations in order to use the command.
 
@@ -2034,7 +2034,7 @@ ___
 
 ▸ **GetAudioOutputConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:404](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L404)*
+*Defined in [api/media.ts:404](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L404)*
 
 If the audio output configuration token is already known, the output configuration can be fetched through the GetAudioOutputConfiguration command.
 
@@ -2053,7 +2053,7 @@ ___
 
 ▸ **GetAudioOutputConfigurationOptions**(ConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:649](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L649)*
+*Defined in [api/media.ts:649](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L649)*
 
 This operation returns the available options (supported values and ranges for audio output configuration parameters) for configuring an audio output.
 
@@ -2073,7 +2073,7 @@ ___
 
 ▸ **GetAudioOutputConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:331](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L331)*
+*Defined in [api/media.ts:331](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L331)*
 
 This command lists all existing AudioOutputConfigurations of a device. The NVC need not know anything apriori about the audio configurations to use this command.
 
@@ -2086,7 +2086,7 @@ ___
 
 ▸ **GetAudioOutputs**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L39)*
+*Defined in [api/media.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L39)*
 
 This command lists all available physical audio outputs of the device.
 
@@ -2099,7 +2099,7 @@ ___
 
 ▸ **GetAudioSourceConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:368](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L368)*
+*Defined in [api/media.ts:368](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L368)*
 
 The GetAudioSourceConfiguration command fetches the audio source configurations if the audio source configuration token is already known. An
 
@@ -2118,7 +2118,7 @@ ___
 
 ▸ **GetAudioSourceConfigurationOptions**(ConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:621](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L621)*
+*Defined in [api/media.ts:621](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L621)*
 
 This operation returns the available options (supported values and ranges for audio source configuration parameters) when the audio source parameters are reconfigured. If an audio source configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile.
 
@@ -2138,7 +2138,7 @@ ___
 
 ▸ **GetAudioSourceConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:295](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L295)*
+*Defined in [api/media.ts:295](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L295)*
 
 This operation lists all existing audio source configurations of a device. This command lists all audio source configurations in a device. The client need not know anything apriori about the audio source configurations in order to use the command.
 
@@ -2151,7 +2151,7 @@ ___
 
 ▸ **GetAudioSources**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L30)*
+*Defined in [api/media.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L30)*
 
 This command lists all available physical audio inputs of the device.
 
@@ -2164,7 +2164,7 @@ ___
 
 ▸ **GetCompatibleAudioDecoderConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:489](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L489)*
+*Defined in [api/media.ts:489](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L489)*
 
 This operation lists all the audio decoder configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioDecoderConfiguration command on the media profile.
 
@@ -2183,7 +2183,7 @@ ___
 
 ▸ **GetCompatibleAudioEncoderConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:443](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L443)*
+*Defined in [api/media.ts:443](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L443)*
 
 This operation requests all audio encoder configurations of a device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioSourceConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
@@ -2202,7 +2202,7 @@ ___
 
 ▸ **GetCompatibleAudioOutputConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:480](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L480)*
+*Defined in [api/media.ts:480](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L480)*
 
 This command lists all audio output configurations of a device that are compatible with a certain media profile. Each returned configuration shall be a valid input for the AddAudioOutputConfiguration command.
 
@@ -2221,7 +2221,7 @@ ___
 
 ▸ **GetCompatibleAudioSourceConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:452](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L452)*
+*Defined in [api/media.ts:452](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L452)*
 
 This operation requests all audio source configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioEncoderConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
@@ -2240,7 +2240,7 @@ ___
 
 ▸ **GetCompatibleMetadataConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:470](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L470)*
+*Defined in [api/media.ts:470](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L470)*
 
 This operation requests all the metadata configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddMetadataConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
@@ -2259,7 +2259,7 @@ ___
 
 ▸ **GetCompatibleVideoAnalyticsConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:461](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L461)*
+*Defined in [api/media.ts:461](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L461)*
 
 This operation requests all video analytic configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddVideoAnalyticsConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
@@ -2278,7 +2278,7 @@ ___
 
 ▸ **GetCompatibleVideoEncoderConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:422](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L422)*
+*Defined in [api/media.ts:422](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L422)*
 
 This operation lists all the video encoder configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddVideoEncoderConfiguration command on the media profile. The result will vary depending on the capabilities, configurations and settings in the device.
 
@@ -2297,7 +2297,7 @@ ___
 
 ▸ **GetCompatibleVideoSourceConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:434](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L434)*
+*Defined in [api/media.ts:434](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L434)*
 
 This operation requests all the video source configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddVideoSourceConfiguration command on the media profile. The result will vary depending on the capabilities, configurations and settings in the device.
 
@@ -2316,7 +2316,7 @@ ___
 
 ▸ **GetGuaranteedNumberOfVideoEncoderInstances**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:670](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L670)*
+*Defined in [api/media.ts:670](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L670)*
 
 The GetGuaranteedNumberOfVideoEncoderInstances command can be used to request the minimum number of guaranteed video encoder instances (applications) per Video Source Configuration.
 
@@ -2335,7 +2335,7 @@ ___
 
 ▸ **GetMetadataConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:395](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L395)*
+*Defined in [api/media.ts:395](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L395)*
 
 The GetMetadataConfiguration command fetches the metadata configuration if the metadata token is known.
 
@@ -2354,7 +2354,7 @@ ___
 
 ▸ **GetMetadataConfigurationOptions**(ConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:640](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L640)*
+*Defined in [api/media.ts:640](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L640)*
 
 This operation returns the available options (supported values and ranges for metadata configuration parameters) for changing the metadata configuration.
 
@@ -2374,7 +2374,7 @@ ___
 
 ▸ **GetMetadataConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:322](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L322)*
+*Defined in [api/media.ts:322](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L322)*
 
 This operation lists all existing metadata configurations. The client need not know anything apriori about the metadata in order to use the command.
 
@@ -2387,7 +2387,7 @@ ___
 
 ▸ **GetOSD**(OSDToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:787](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L787)*
+*Defined in [api/media.ts:787](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L787)*
 
 Get the OSD.
 
@@ -2406,7 +2406,7 @@ ___
 
 ▸ **GetOSDOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:796](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L796)*
+*Defined in [api/media.ts:796](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L796)*
 
 Get the OSD Options.
 
@@ -2425,7 +2425,7 @@ ___
 
 ▸ **GetOSDs**(ConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:778](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L778)*
+*Defined in [api/media.ts:778](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L778)*
 
 Get the OSDs.
 
@@ -2444,7 +2444,7 @@ ___
 
 ▸ **GetProfile**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:59](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L59)*
+*Defined in [api/media.ts:59](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L59)*
 
 If the profile token is already known, a profile can be fetched through the GetProfile command.
 
@@ -2463,7 +2463,7 @@ ___
 
 ▸ **GetProfiles**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:71](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L71)*
+*Defined in [api/media.ts:71](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L71)*
 
 Any endpoint can ask for the existing media profiles of a device using the GetProfiles command. Pre-configured or dynamically configured profiles can be retrieved using this command. This command lists all configured profiles in a device. The client does not need to know the media profile in order to use the command.
 
@@ -2476,7 +2476,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L12)*
+*Defined in [api/media.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L12)*
 
 Returns the capabilities of the media service. The result is returned in a typed answer.
 
@@ -2489,7 +2489,7 @@ ___
 
 ▸ **GetSnapshotUri**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:751](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L751)*
+*Defined in [api/media.ts:751](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L751)*
 
 A client uses the GetSnapshotUri command to obtain a JPEG snapshot from the device. The returned URI shall remain valid indefinitely even if the profile is changed. The ValidUntilConnect, ValidUntilReboot and Timeout Parameter shall be set accordingly (ValidUntilConnect=false, ValidUntilReboot=false, timeout=PT0S). The URI can be used for acquiring a JPEG image through a HTTP GET operation. The image encoding will always be JPEG regardless of the encoding setting in the media profile. The Jpeg settings (like resolution or quality) may be taken from the profile if suitable. The provided image will be updated automatically and independent from calls to GetSnapshotUri.
 
@@ -2508,7 +2508,7 @@ ___
 
 ▸ **GetStreamUri**(StreamSetup: *[StreamSetup](../interfaces/_api_types_.streamsetup.md)*, ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:693](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L693)*
+*Defined in [api/media.ts:693](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L693)*
 
 This operation requests a URI that can be used to initiate a live media stream using RTSP as the control protocol. The returned URI shall remain valid indefinitely even if the profile is changed. The ValidUntilConnect, ValidUntilReboot and Timeout Parameter shall be set accordingly (ValidUntilConnect=false, ValidUntilReboot=false, timeout=PT0S). The correct syntax for the StreamSetup element for these media stream setups defined in 5.1.1 of the streaming specification are as follows:
 
@@ -2532,7 +2532,7 @@ ___
 
 ▸ **GetVideoAnalyticsConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:386](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L386)*
+*Defined in [api/media.ts:386](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L386)*
 
 The GetVideoAnalyticsConfiguration command fetches the video analytics configuration if the video analytics token is known.
 
@@ -2551,7 +2551,7 @@ ___
 
 ▸ **GetVideoAnalyticsConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:313](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L313)*
+*Defined in [api/media.ts:313](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L313)*
 
 This operation lists all video analytics configurations of a device. This command lists all configured video analytics in a device. The client need not know anything apriori about the video analytics in order to use the command.
 
@@ -2564,7 +2564,7 @@ ___
 
 ▸ **GetVideoEncoderConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:359](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L359)*
+*Defined in [api/media.ts:359](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L359)*
 
 If the video encoder configuration token is already known, the encoder configuration can be fetched through the GetVideoEncoderConfiguration command.
 
@@ -2583,7 +2583,7 @@ ___
 
 ▸ **GetVideoEncoderConfigurationOptions**(ConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:609](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L609)*
+*Defined in [api/media.ts:609](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L609)*
 
 This operation returns the available options (supported values and ranges for video encoder configuration parameters) when the video encoder parameters are reconfigured. For JPEG, MPEG4 and H264 extension elements have been defined that provide additional information. A device must provide the XxxOption information for all encodings supported and should additionally provide the corresponding XxxOption2 information. This response contains the available video encoder configuration options. If a video encoder configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile. If no tokens are specified, the options shall be considered generic for the device.
 
@@ -2603,7 +2603,7 @@ ___
 
 ▸ **GetVideoEncoderConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:286](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L286)*
+*Defined in [api/media.ts:286](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L286)*
 
 This operation lists all existing video encoder configurations of a device. This command lists all configured video encoder configurations in a device. The client need not know anything apriori about the video encoder configurations in order to use the command.
 
@@ -2616,7 +2616,7 @@ ___
 
 ▸ **GetVideoSourceConfiguration**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:350](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L350)*
+*Defined in [api/media.ts:350](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L350)*
 
 If the video source configuration token is already known, the video source configuration can be fetched through the GetVideoSourceConfiguration command.
 
@@ -2635,7 +2635,7 @@ ___
 
 ▸ **GetVideoSourceConfigurationOptions**(ConfigurationToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, ProfileToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:593](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L593)*
+*Defined in [api/media.ts:593](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L593)*
 
 This operation returns the available options (supported values and ranges for video source configuration parameters) when the video source parameters are reconfigured If a video source configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile.
 
@@ -2655,7 +2655,7 @@ ___
 
 ▸ **GetVideoSourceConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:277](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L277)*
+*Defined in [api/media.ts:277](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L277)*
 
 This operation lists all existing video source configurations for a device. The client need not know anything about the video source configurations in order to use the command.
 
@@ -2668,7 +2668,7 @@ ___
 
 ▸ **GetVideoSourceModes**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:760](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L760)*
+*Defined in [api/media.ts:760](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L760)*
 
 A device returns the information for current video source mode and settable video source modes of specified video source. A device that indicates a capability of VideoSourceModes shall support this command.
 
@@ -2687,7 +2687,7 @@ ___
 
 ▸ **GetVideoSources**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L21)*
+*Defined in [api/media.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L21)*
 
 This command lists all available physical video inputs of the device.
 
@@ -2700,7 +2700,7 @@ ___
 
 ▸ **RemoveAudioDecoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:259](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L259)*
+*Defined in [api/media.ts:259](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L259)*
 
 This operation removes an AudioDecoderConfiguration from an existing media profile. If the media profile does not contain an AudioDecoderConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -2719,7 +2719,7 @@ ___
 
 ▸ **RemoveAudioEncoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:139](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L139)*
+*Defined in [api/media.ts:139](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L139)*
 
 This operation removes an AudioEncoderConfiguration from an existing media profile. If the media profile does not contain an AudioEncoderConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -2738,7 +2738,7 @@ ___
 
 ▸ **RemoveAudioOutputConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:241](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L241)*
+*Defined in [api/media.ts:241](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L241)*
 
 This operation removes an AudioOutputConfiguration from an existing media profile. If the media profile does not contain an AudioOutputConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -2757,7 +2757,7 @@ ___
 
 ▸ **RemoveAudioSourceConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:161](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L161)*
+*Defined in [api/media.ts:161](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L161)*
 
 This operation removes an AudioSourceConfiguration from an existing media profile. If the media profile does not contain an AudioSourceConfiguration, the operation has no effect. The removal shall be persistent. Audio source configurations should only be removed after removing an AudioEncoderConfiguration from the media profile.
 
@@ -2776,7 +2776,7 @@ ___
 
 ▸ **RemoveMetadataConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:223](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L223)*
+*Defined in [api/media.ts:223](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L223)*
 
 This operation removes a MetadataConfiguration from an existing media profile. If the media profile does not contain a MetadataConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -2795,7 +2795,7 @@ ___
 
 ▸ **RemovePTZConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:183](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L183)*
+*Defined in [api/media.ts:183](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L183)*
 
 This operation removes a PTZConfiguration from an existing media profile. If the media profile does not contain a PTZConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -2814,7 +2814,7 @@ ___
 
 ▸ **RemoveVideoAnalyticsConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:205](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L205)*
+*Defined in [api/media.ts:205](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L205)*
 
 This operation removes a VideoAnalyticsConfiguration from an existing media profile. If the media profile does not contain a VideoAnalyticsConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -2833,7 +2833,7 @@ ___
 
 ▸ **RemoveVideoEncoderConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:94](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L94)*
+*Defined in [api/media.ts:94](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L94)*
 
 This operation removes a VideoEncoderConfiguration from an existing media profile. If the media profile does not contain a VideoEncoderConfiguration, the operation has no effect. The removal shall be persistent.
 
@@ -2852,7 +2852,7 @@ ___
 
 ▸ **RemoveVideoSourceConfiguration**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:115](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L115)*
+*Defined in [api/media.ts:115](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L115)*
 
 This operation removes a VideoSourceConfiguration from an existing media profile. If the media profile does not contain a VideoSourceConfiguration, the operation has no effect. The removal shall be persistent. Video source configurations should only be removed after removing a VideoEncoderConfiguration from the media profile.
 
@@ -2871,7 +2871,7 @@ ___
 
 ▸ **SetAudioDecoderConfiguration**(Configuration: *[AudioDecoderConfiguration](../interfaces/_api_types_.audiodecoderconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:581](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L581)*
+*Defined in [api/media.ts:581](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L581)*
 
 This operation modifies an audio decoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device.
 
@@ -2891,7 +2891,7 @@ ___
 
 ▸ **SetAudioEncoderConfiguration**(Configuration: *[AudioEncoderConfiguration](../interfaces/_api_types_.audioencoderconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:533](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L533)*
+*Defined in [api/media.ts:533](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L533)*
 
 This operation modifies an audio encoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected streams. NVC methods for changing a running stream are out of scope for this specification.
 
@@ -2911,7 +2911,7 @@ ___
 
 ▸ **SetAudioOutputConfiguration**(Configuration: *[AudioOutputConfiguration](../interfaces/_api_types_.audiooutputconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:571](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L571)*
+*Defined in [api/media.ts:571](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L571)*
 
 This operation modifies an audio output configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device.
 
@@ -2931,7 +2931,7 @@ ___
 
 ▸ **SetAudioSourceConfiguration**(Configuration: *[AudioSourceConfiguration](../interfaces/_api_types_.audiosourceconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:520](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L520)*
+*Defined in [api/media.ts:520](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L520)*
 
 This operation modifies an audio source configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream NVC methods for changing a running stream are out of scope for this specification.
 
@@ -2951,7 +2951,7 @@ ___
 
 ▸ **SetMetadataConfiguration**(Configuration: *[MetadataConfiguration](../interfaces/_api_types_.metadataconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:561](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L561)*
+*Defined in [api/media.ts:561](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L561)*
 
 This operation modifies a metadata configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be updated immediately according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected streams. NVC methods for changing a running stream are out of scope for this specification.
 
@@ -2971,7 +2971,7 @@ ___
 
 ▸ **SetOSD**(OSD: *[OSDConfiguration](../interfaces/_api_types_.osdconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:805](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L805)*
+*Defined in [api/media.ts:805](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L805)*
 
 Set the OSD
 
@@ -2990,7 +2990,7 @@ ___
 
 ▸ **SetSynchronizationPoint**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:735](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L735)*
+*Defined in [api/media.ts:735](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L735)*
 
 Synchronization points allow clients to decode and correctly use all data after the synchronization point. For example, if a video stream is configured with a large I-frame distance and a client loses a single packet, the client does not display video until the next I-frame is transmitted. In such cases, the client can request a Synchronization Point which enforces the device to add an I-Frame as soon as possible. Clients can request Synchronization Points for profiles. The device shall add synchronization points for all streams associated with this profile. Similarly, a synchronization point is used to get an update on full PTZ or event status through the metadata stream. If a video stream is associated with the profile, an I-frame shall be added to this video stream. If a PTZ metadata stream is associated to the profile, the PTZ position shall be repeated within the metadata stream.
 
@@ -3009,7 +3009,7 @@ ___
 
 ▸ **SetVideoAnalyticsConfiguration**(Configuration: *[VideoAnalyticsConfiguration](../interfaces/_api_types_.videoanalyticsconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:547](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L547)*
+*Defined in [api/media.ts:547](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L547)*
 
 A video analytics configuration is modified using this command. The ForcePersistence flag indicates if the changes shall remain after reboot of the device or not. Running streams using this configuration shall be immediately updated according to the new settings. Otherwise inconsistencies can occur between the scene description processed by the rule engine and the notifications produced by analytics engine and rule engine which reference the very same video analytics configuration token.
 
@@ -3029,7 +3029,7 @@ ___
 
 ▸ **SetVideoEncoderConfiguration**(Configuration: *[VideoEncoderConfiguration](../interfaces/_api_types_.videoencoderconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:507](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L507)*
+*Defined in [api/media.ts:507](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L507)*
 
 This operation modifies a video encoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification. SessionTimeout is provided as a hint for keeping rtsp session by a device. If necessary the device may adapt parameter values for SessionTimeout elements without returning an error. For the time between keep alive calls the client shall adhere to the timeout value signaled via RTSP.
 
@@ -3049,7 +3049,7 @@ ___
 
 ▸ **SetVideoSourceConfiguration**(Configuration: *[VideoSourceConfiguration](../interfaces/_api_types_.videosourceconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:498](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L498)*
+*Defined in [api/media.ts:498](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L498)*
 
 This operation modifies a video source configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification.
 
@@ -3069,7 +3069,7 @@ ___
 
 ▸ **SetVideoSourceMode**(VideoSourceToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, VideoSourceModeToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:769](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L769)*
+*Defined in [api/media.ts:769](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L769)*
 
 SetVideoSourceMode changes the media profile structure relating to video source for the specified video source mode. A device that indicates a capability of VideoSourceModes shall support this command. The behavior after changing the mode is not defined in this specification.
 
@@ -3089,7 +3089,7 @@ ___
 
 ▸ **StartMulticastStreaming**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:707](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L707)*
+*Defined in [api/media.ts:707](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L707)*
 
 This command starts multicast streaming using a specified media profile of a device. Streaming continues until StopMulticastStreaming is called for the same Profile. The streaming shall continue after a reboot of the device until a StopMulticastStreaming request is received. The multicast address, port and TTL are configured in the VideoEncoderConfiguration, AudioEncoderConfiguration and MetadataConfiguration respectively.
 
@@ -3108,7 +3108,7 @@ ___
 
 ▸ **StopMulticastStreaming**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/media.ts:716](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/media.ts#L716)*
+*Defined in [api/media.ts:716](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/media.ts#L716)*
 
 This command stop multicast streaming using a specified media profile of a device
 

--- a/docs/classes/_api_provisioning_.onvifprovisioning.md
+++ b/docs/classes/_api_provisioning_.onvifprovisioning.md
@@ -1,39 +1,39 @@
-[onvif-rx](../README.md) > ["api/provisioning"](../modules/_api_provisioning_.md) > [Provisioning](../classes/_api_provisioning_.provisioning.md)
+[onvif-rx](../README.md) > ["api/provisioning"](../modules/_api_provisioning_.md) > [ONVIFProvisioning](../classes/_api_provisioning_.onvifprovisioning.md)
 
-# Class: Provisioning
+# Class: ONVIFProvisioning
 
 ## Hierarchy
 
-**Provisioning**
+**ONVIFProvisioning**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_provisioning_.provisioning.md#constructor)
+* [constructor](_api_provisioning_.onvifprovisioning.md#constructor)
 
 ### Properties
 
-* [config](_api_provisioning_.provisioning.md#config)
+* [config](_api_provisioning_.onvifprovisioning.md#config)
 
 ### Methods
 
-* [FocusMove](_api_provisioning_.provisioning.md#focusmove)
-* [GetServiceCapabilities](_api_provisioning_.provisioning.md#getservicecapabilities)
-* [GetUsage](_api_provisioning_.provisioning.md#getusage)
-* [PanMove](_api_provisioning_.provisioning.md#panmove)
-* [RollMove](_api_provisioning_.provisioning.md#rollmove)
-* [Stop](_api_provisioning_.provisioning.md#stop)
-* [TiltMove](_api_provisioning_.provisioning.md#tiltmove)
-* [ZoomMove](_api_provisioning_.provisioning.md#zoommove)
-* [FocusMove](_api_provisioning_.provisioning.md#focusmove-1)
-* [GetServiceCapabilities](_api_provisioning_.provisioning.md#getservicecapabilities-1)
-* [GetUsage](_api_provisioning_.provisioning.md#getusage-1)
-* [PanMove](_api_provisioning_.provisioning.md#panmove-1)
-* [RollMove](_api_provisioning_.provisioning.md#rollmove-1)
-* [Stop](_api_provisioning_.provisioning.md#stop-1)
-* [TiltMove](_api_provisioning_.provisioning.md#tiltmove-1)
-* [ZoomMove](_api_provisioning_.provisioning.md#zoommove-1)
+* [FocusMove](_api_provisioning_.onvifprovisioning.md#focusmove)
+* [GetServiceCapabilities](_api_provisioning_.onvifprovisioning.md#getservicecapabilities)
+* [GetUsage](_api_provisioning_.onvifprovisioning.md#getusage)
+* [PanMove](_api_provisioning_.onvifprovisioning.md#panmove)
+* [RollMove](_api_provisioning_.onvifprovisioning.md#rollmove)
+* [Stop](_api_provisioning_.onvifprovisioning.md#stop)
+* [TiltMove](_api_provisioning_.onvifprovisioning.md#tiltmove)
+* [ZoomMove](_api_provisioning_.onvifprovisioning.md#zoommove)
+* [FocusMove](_api_provisioning_.onvifprovisioning.md#focusmove-1)
+* [GetServiceCapabilities](_api_provisioning_.onvifprovisioning.md#getservicecapabilities-1)
+* [GetUsage](_api_provisioning_.onvifprovisioning.md#getusage-1)
+* [PanMove](_api_provisioning_.onvifprovisioning.md#panmove-1)
+* [RollMove](_api_provisioning_.onvifprovisioning.md#rollmove-1)
+* [Stop](_api_provisioning_.onvifprovisioning.md#stop-1)
+* [TiltMove](_api_provisioning_.onvifprovisioning.md#tiltmove-1)
+* [ZoomMove](_api_provisioning_.onvifprovisioning.md#zoommove-1)
 
 ---
 
@@ -43,9 +43,9 @@
 
 ###  constructor
 
-⊕ **new Provisioning**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Provisioning](_api_provisioning_.provisioning.md)
+⊕ **new ONVIFProvisioning**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFProvisioning](_api_provisioning_.onvifprovisioning.md)
 
-*Defined in [api/provisioning.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L5)*
+*Defined in [api/provisioning.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L5)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Provisioning](_api_provisioning_.provisioning.md)
+**Returns:** [ONVIFProvisioning](_api_provisioning_.onvifprovisioning.md)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/provisioning.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L6)*
+*Defined in [api/provisioning.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L6)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 ▸ **FocusMove**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/provisioning.ts:119](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L119)*
+*Defined in [api/provisioning.ts:119](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L119)*
 
 Moves device on the focus axis.
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/provisioning.ts:84](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L84)*
+*Defined in [api/provisioning.ts:84](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L84)*
 
 Returns the capabilities of the provisioning service.
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **GetUsage**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/provisioning.ts:133](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L133)*
+*Defined in [api/provisioning.ts:133](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L133)*
 
 Returns the lifetime move counts.
 
@@ -116,7 +116,7 @@ ___
 
 ▸ **PanMove**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/provisioning.ts:91](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L91)*
+*Defined in [api/provisioning.ts:91](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L91)*
 
 Moves device on the pan axis.
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **RollMove**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/provisioning.ts:112](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L112)*
+*Defined in [api/provisioning.ts:112](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L112)*
 
 Moves device on the roll axis.
 
@@ -142,7 +142,7 @@ ___
 
 ▸ **Stop**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/provisioning.ts:126](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L126)*
+*Defined in [api/provisioning.ts:126](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L126)*
 
 Stops device motion on all axes.
 
@@ -155,7 +155,7 @@ ___
 
 ▸ **TiltMove**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/provisioning.ts:98](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L98)*
+*Defined in [api/provisioning.ts:98](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L98)*
 
 Moves device on the tilt axis.
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **ZoomMove**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/provisioning.ts:105](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L105)*
+*Defined in [api/provisioning.ts:105](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L105)*
 
 Moves device on the zoom axis.
 
@@ -181,7 +181,7 @@ ___
 
 ▸ **FocusMove**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/provisioning.ts:57](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L57)*
+*Defined in [api/provisioning.ts:57](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L57)*
 
 Moves device on the focus axis.
 
@@ -194,7 +194,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/provisioning.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L12)*
+*Defined in [api/provisioning.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L12)*
 
 Returns the capabilities of the provisioning service.
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **GetUsage**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/provisioning.ts:75](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L75)*
+*Defined in [api/provisioning.ts:75](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L75)*
 
 Returns the lifetime move counts.
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **PanMove**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/provisioning.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L21)*
+*Defined in [api/provisioning.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L21)*
 
 Moves device on the pan axis.
 
@@ -233,7 +233,7 @@ ___
 
 ▸ **RollMove**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/provisioning.ts:48](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L48)*
+*Defined in [api/provisioning.ts:48](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L48)*
 
 Moves device on the roll axis.
 
@@ -246,7 +246,7 @@ ___
 
 ▸ **Stop**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/provisioning.ts:66](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L66)*
+*Defined in [api/provisioning.ts:66](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L66)*
 
 Stops device motion on all axes.
 
@@ -259,7 +259,7 @@ ___
 
 ▸ **TiltMove**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/provisioning.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L30)*
+*Defined in [api/provisioning.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L30)*
 
 Moves device on the tilt axis.
 
@@ -272,7 +272,7 @@ ___
 
 ▸ **ZoomMove**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/provisioning.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/provisioning.ts#L39)*
+*Defined in [api/provisioning.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/provisioning.ts#L39)*
 
 Moves device on the zoom axis.
 

--- a/docs/classes/_api_ptz_.onvifptz.md
+++ b/docs/classes/_api_ptz_.onvifptz.md
@@ -1,79 +1,79 @@
-[onvif-rx](../README.md) > ["api/ptz"](../modules/_api_ptz_.md) > [PTZ](../classes/_api_ptz_.ptz.md)
+[onvif-rx](../README.md) > ["api/ptz"](../modules/_api_ptz_.md) > [ONVIFPTZ](../classes/_api_ptz_.onvifptz.md)
 
-# Class: PTZ
+# Class: ONVIFPTZ
 
 ## Hierarchy
 
-**PTZ**
+**ONVIFPTZ**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_ptz_.ptz.md#constructor)
+* [constructor](_api_ptz_.onvifptz.md#constructor)
 
 ### Properties
 
-* [config](_api_ptz_.ptz.md#config)
+* [config](_api_ptz_.onvifptz.md#config)
 
 ### Methods
 
-* [AbsoluteMove](_api_ptz_.ptz.md#absolutemove)
-* [ContinuousMove](_api_ptz_.ptz.md#continuousmove)
-* [CreatePresetTour](_api_ptz_.ptz.md#createpresettour)
-* [GeoMove](_api_ptz_.ptz.md#geomove)
-* [GetCompatibleConfigurations](_api_ptz_.ptz.md#getcompatibleconfigurations)
-* [GetConfiguration](_api_ptz_.ptz.md#getconfiguration)
-* [GetConfigurationOptions](_api_ptz_.ptz.md#getconfigurationoptions)
-* [GetConfigurations](_api_ptz_.ptz.md#getconfigurations)
-* [GetNode](_api_ptz_.ptz.md#getnode)
-* [GetNodes](_api_ptz_.ptz.md#getnodes)
-* [GetPresetTour](_api_ptz_.ptz.md#getpresettour)
-* [GetPresetTourOptions](_api_ptz_.ptz.md#getpresettouroptions)
-* [GetPresetTours](_api_ptz_.ptz.md#getpresettours)
-* [GetPresets](_api_ptz_.ptz.md#getpresets)
-* [GetServiceCapabilities](_api_ptz_.ptz.md#getservicecapabilities)
-* [GetStatus](_api_ptz_.ptz.md#getstatus)
-* [GotoHomePosition](_api_ptz_.ptz.md#gotohomeposition)
-* [GotoPreset](_api_ptz_.ptz.md#gotopreset)
-* [ModifyPresetTour](_api_ptz_.ptz.md#modifypresettour)
-* [OperatePresetTour](_api_ptz_.ptz.md#operatepresettour)
-* [RelativeMove](_api_ptz_.ptz.md#relativemove)
-* [RemovePreset](_api_ptz_.ptz.md#removepreset)
-* [RemovePresetTour](_api_ptz_.ptz.md#removepresettour)
-* [SendAuxiliaryCommand](_api_ptz_.ptz.md#sendauxiliarycommand)
-* [SetConfiguration](_api_ptz_.ptz.md#setconfiguration)
-* [SetHomePosition](_api_ptz_.ptz.md#sethomeposition)
-* [SetPreset](_api_ptz_.ptz.md#setpreset)
-* [Stop](_api_ptz_.ptz.md#stop)
-* [AbsoluteMove](_api_ptz_.ptz.md#absolutemove-1)
-* [ContinuousMove](_api_ptz_.ptz.md#continuousmove-1)
-* [CreatePresetTour](_api_ptz_.ptz.md#createpresettour-1)
-* [GeoMove](_api_ptz_.ptz.md#geomove-1)
-* [GetCompatibleConfigurations](_api_ptz_.ptz.md#getcompatibleconfigurations-1)
-* [GetConfiguration](_api_ptz_.ptz.md#getconfiguration-1)
-* [GetConfigurationOptions](_api_ptz_.ptz.md#getconfigurationoptions-1)
-* [GetConfigurations](_api_ptz_.ptz.md#getconfigurations-1)
-* [GetNode](_api_ptz_.ptz.md#getnode-1)
-* [GetNodes](_api_ptz_.ptz.md#getnodes-1)
-* [GetPresetTour](_api_ptz_.ptz.md#getpresettour-1)
-* [GetPresetTourOptions](_api_ptz_.ptz.md#getpresettouroptions-1)
-* [GetPresetTours](_api_ptz_.ptz.md#getpresettours-1)
-* [GetPresets](_api_ptz_.ptz.md#getpresets-1)
-* [GetServiceCapabilities](_api_ptz_.ptz.md#getservicecapabilities-1)
-* [GetStatus](_api_ptz_.ptz.md#getstatus-1)
-* [GotoHomePosition](_api_ptz_.ptz.md#gotohomeposition-1)
-* [GotoPreset](_api_ptz_.ptz.md#gotopreset-1)
-* [ModifyPresetTour](_api_ptz_.ptz.md#modifypresettour-1)
-* [OperatePresetTour](_api_ptz_.ptz.md#operatepresettour-1)
-* [RelativeMove](_api_ptz_.ptz.md#relativemove-1)
-* [RemovePreset](_api_ptz_.ptz.md#removepreset-1)
-* [RemovePresetTour](_api_ptz_.ptz.md#removepresettour-1)
-* [SendAuxiliaryCommand](_api_ptz_.ptz.md#sendauxiliarycommand-1)
-* [SetConfiguration](_api_ptz_.ptz.md#setconfiguration-1)
-* [SetHomePosition](_api_ptz_.ptz.md#sethomeposition-1)
-* [SetPreset](_api_ptz_.ptz.md#setpreset-1)
-* [Stop](_api_ptz_.ptz.md#stop-1)
+* [AbsoluteMove](_api_ptz_.onvifptz.md#absolutemove)
+* [ContinuousMove](_api_ptz_.onvifptz.md#continuousmove)
+* [CreatePresetTour](_api_ptz_.onvifptz.md#createpresettour)
+* [GeoMove](_api_ptz_.onvifptz.md#geomove)
+* [GetCompatibleConfigurations](_api_ptz_.onvifptz.md#getcompatibleconfigurations)
+* [GetConfiguration](_api_ptz_.onvifptz.md#getconfiguration)
+* [GetConfigurationOptions](_api_ptz_.onvifptz.md#getconfigurationoptions)
+* [GetConfigurations](_api_ptz_.onvifptz.md#getconfigurations)
+* [GetNode](_api_ptz_.onvifptz.md#getnode)
+* [GetNodes](_api_ptz_.onvifptz.md#getnodes)
+* [GetPresetTour](_api_ptz_.onvifptz.md#getpresettour)
+* [GetPresetTourOptions](_api_ptz_.onvifptz.md#getpresettouroptions)
+* [GetPresetTours](_api_ptz_.onvifptz.md#getpresettours)
+* [GetPresets](_api_ptz_.onvifptz.md#getpresets)
+* [GetServiceCapabilities](_api_ptz_.onvifptz.md#getservicecapabilities)
+* [GetStatus](_api_ptz_.onvifptz.md#getstatus)
+* [GotoHomePosition](_api_ptz_.onvifptz.md#gotohomeposition)
+* [GotoPreset](_api_ptz_.onvifptz.md#gotopreset)
+* [ModifyPresetTour](_api_ptz_.onvifptz.md#modifypresettour)
+* [OperatePresetTour](_api_ptz_.onvifptz.md#operatepresettour)
+* [RelativeMove](_api_ptz_.onvifptz.md#relativemove)
+* [RemovePreset](_api_ptz_.onvifptz.md#removepreset)
+* [RemovePresetTour](_api_ptz_.onvifptz.md#removepresettour)
+* [SendAuxiliaryCommand](_api_ptz_.onvifptz.md#sendauxiliarycommand)
+* [SetConfiguration](_api_ptz_.onvifptz.md#setconfiguration)
+* [SetHomePosition](_api_ptz_.onvifptz.md#sethomeposition)
+* [SetPreset](_api_ptz_.onvifptz.md#setpreset)
+* [Stop](_api_ptz_.onvifptz.md#stop)
+* [AbsoluteMove](_api_ptz_.onvifptz.md#absolutemove-1)
+* [ContinuousMove](_api_ptz_.onvifptz.md#continuousmove-1)
+* [CreatePresetTour](_api_ptz_.onvifptz.md#createpresettour-1)
+* [GeoMove](_api_ptz_.onvifptz.md#geomove-1)
+* [GetCompatibleConfigurations](_api_ptz_.onvifptz.md#getcompatibleconfigurations-1)
+* [GetConfiguration](_api_ptz_.onvifptz.md#getconfiguration-1)
+* [GetConfigurationOptions](_api_ptz_.onvifptz.md#getconfigurationoptions-1)
+* [GetConfigurations](_api_ptz_.onvifptz.md#getconfigurations-1)
+* [GetNode](_api_ptz_.onvifptz.md#getnode-1)
+* [GetNodes](_api_ptz_.onvifptz.md#getnodes-1)
+* [GetPresetTour](_api_ptz_.onvifptz.md#getpresettour-1)
+* [GetPresetTourOptions](_api_ptz_.onvifptz.md#getpresettouroptions-1)
+* [GetPresetTours](_api_ptz_.onvifptz.md#getpresettours-1)
+* [GetPresets](_api_ptz_.onvifptz.md#getpresets-1)
+* [GetServiceCapabilities](_api_ptz_.onvifptz.md#getservicecapabilities-1)
+* [GetStatus](_api_ptz_.onvifptz.md#getstatus-1)
+* [GotoHomePosition](_api_ptz_.onvifptz.md#gotohomeposition-1)
+* [GotoPreset](_api_ptz_.onvifptz.md#gotopreset-1)
+* [ModifyPresetTour](_api_ptz_.onvifptz.md#modifypresettour-1)
+* [OperatePresetTour](_api_ptz_.onvifptz.md#operatepresettour-1)
+* [RelativeMove](_api_ptz_.onvifptz.md#relativemove-1)
+* [RemovePreset](_api_ptz_.onvifptz.md#removepreset-1)
+* [RemovePresetTour](_api_ptz_.onvifptz.md#removepresettour-1)
+* [SendAuxiliaryCommand](_api_ptz_.onvifptz.md#sendauxiliarycommand-1)
+* [SetConfiguration](_api_ptz_.onvifptz.md#setconfiguration-1)
+* [SetHomePosition](_api_ptz_.onvifptz.md#sethomeposition-1)
+* [SetPreset](_api_ptz_.onvifptz.md#setpreset-1)
+* [Stop](_api_ptz_.onvifptz.md#stop-1)
 
 ---
 
@@ -83,9 +83,9 @@
 
 ###  constructor
 
-⊕ **new PTZ**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [PTZ](_api_ptz_.ptz.md)
+⊕ **new ONVIFPTZ**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFPTZ](_api_ptz_.onvifptz.md)
 
-*Defined in [api/ptz.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L5)*
+*Defined in [api/ptz.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L5)*
 
 **Parameters:**
 
@@ -93,7 +93,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [PTZ](_api_ptz_.ptz.md)
+**Returns:** [ONVIFPTZ](_api_ptz_.onvifptz.md)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/ptz.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L6)*
+*Defined in [api/ptz.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L6)*
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 ▸ **AbsoluteMove**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Position: *[PTZVector](../interfaces/_api_types_.ptzvector.md)*, Speed: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:578](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L578)*
+*Defined in [api/ptz.ts:578](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L578)*
 
 Operation to move pan,tilt or zoom to a absolute destination. The speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
 
@@ -138,7 +138,7 @@ ___
 
 ▸ **ContinuousMove**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Velocity: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*, Timeout: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:547](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L547)*
+*Defined in [api/ptz.ts:547](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L547)*
 
 Operation for continuous Pan/Tilt and Zoom movements. The operation is supported if the PTZNode supports at least one continuous Pan/Tilt or Zoom space. If the space argument is omitted, the default space set by the PTZConfiguration will be used.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **CreatePresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:627](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L627)*
+*Defined in [api/ptz.ts:627](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L627)*
 
 Operation to create a preset tour for the selected media profile.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **GeoMove**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Target: *[GeoLocation](../interfaces/_api_types_.geolocation.md)*, Speed: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*, AreaHeight: *`number`*, AreaWidth: *`number`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:591](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L591)*
+*Defined in [api/ptz.ts:591](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L591)*
 
 Operation to move pan,tilt or zoom to point to a destination based on the geolocation of the target. The speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used. The area height and area dwidth parameters are optional, they can be used independently and may be used by the device to automatically determine the best zoom level to show the target.
 
@@ -201,7 +201,7 @@ ___
 
 ▸ **GetCompatibleConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:659](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L659)*
+*Defined in [api/ptz.ts:659](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L659)*
 
 Operation to get all available PTZConfigurations that can be added to the referenced media profile. A device providing more than one PTZConfiguration or more than one VideoSourceConfiguration or which has any other resource interdependency between PTZConfiguration entities and other resources listable in a media profile should implement this operation. PTZConfiguration entities returned by this operation shall not fail on adding them to the referenced media profile.
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **GetConfiguration**(PTZConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:413](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L413)*
+*Defined in [api/ptz.ts:413](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L413)*
 
 Get a specific PTZconfiguration from the device, identified by its reference token or name.
 
@@ -241,7 +241,7 @@ ___
 
 ▸ **GetConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:460](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L460)*
+*Defined in [api/ptz.ts:460](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L460)*
 
 List supported coordinate systems including their range limitations. Therefore, the options MAY differ depending on whether the PTZ Configuration is assigned to a Profile containing a Video Source Configuration. In that case, the options may additionally contain coordinate systems referring to the image coordinate system described by the Video Source Configuration. If the PTZ Node supports continuous movements, it shall return a Timeout Range within which Timeouts are accepted by the PTZ Node.
 
@@ -260,7 +260,7 @@ ___
 
 ▸ **GetConfigurations**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:437](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L437)*
+*Defined in [api/ptz.ts:437](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L437)*
 
 ```
       Get all the existing PTZConfigurations from the device.
@@ -277,7 +277,7 @@ ___
 
 ▸ **GetNode**(NodeToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:390](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L390)*
+*Defined in [api/ptz.ts:390](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L390)*
 
 Get a specific PTZ Node identified by a reference token or a name.
 
@@ -296,7 +296,7 @@ ___
 
 ▸ **GetNodes**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:381](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L381)*
+*Defined in [api/ptz.ts:381](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L381)*
 
 Get the descriptions of the available PTZ Nodes.
 
@@ -311,7 +311,7 @@ ___
 
 ▸ **GetPresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTourToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:613](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L613)*
+*Defined in [api/ptz.ts:613](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L613)*
 
 Operation to request a specific PTZ preset tour in the selected media profile.
 
@@ -331,7 +331,7 @@ ___
 
 ▸ **GetPresetTourOptions**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTourToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:620](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L620)*
+*Defined in [api/ptz.ts:620](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L620)*
 
 Operation to request available options to configure PTZ preset tour.
 
@@ -351,7 +351,7 @@ ___
 
 ▸ **GetPresetTours**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:606](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L606)*
+*Defined in [api/ptz.ts:606](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L606)*
 
 Operation to request PTZ preset tours in the selected media profiles.
 
@@ -370,7 +370,7 @@ ___
 
 ▸ **GetPresets**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:482](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L482)*
+*Defined in [api/ptz.ts:482](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L482)*
 
 ```
       Operation to request all PTZ presets for the PTZNode
@@ -393,7 +393,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:367](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L367)*
+*Defined in [api/ptz.ts:367](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L367)*
 
 Returns the capabilities of the PTZ service. The result is returned in a typed answer.
 
@@ -406,7 +406,7 @@ ___
 
 ▸ **GetStatus**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:567](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L567)*
+*Defined in [api/ptz.ts:567](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L567)*
 
 Operation to request PTZ status for the Node in the selected profile.
 
@@ -425,7 +425,7 @@ ___
 
 ▸ **GotoHomePosition**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Speed: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:530](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L530)*
+*Defined in [api/ptz.ts:530](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L530)*
 
 ```
       Operation to move the PTZ device to it's "home" position. The operation is supported if the HomeSupported element in the PTZNode is true.
@@ -447,7 +447,7 @@ ___
 
 ▸ **GotoPreset**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Speed: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:522](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L522)*
+*Defined in [api/ptz.ts:522](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L522)*
 
 ```
       Operation to go to a saved preset position for the
@@ -472,7 +472,7 @@ ___
 
 ▸ **ModifyPresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTour: *[PresetTour](../interfaces/_api_types_.presettour.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:634](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L634)*
+*Defined in [api/ptz.ts:634](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L634)*
 
 Operation to modify a preset tour for the selected media profile.
 
@@ -492,7 +492,7 @@ ___
 
 ▸ **OperatePresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTourToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Operation: *[PTZPresetTourOperation](../enums/_api_types_.ptzpresettouroperation.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:641](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L641)*
+*Defined in [api/ptz.ts:641](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L641)*
 
 Operation to perform specific operation on the preset tour in selected media profile.
 
@@ -513,7 +513,7 @@ ___
 
 ▸ **RelativeMove**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Translation: *[PTZVector](../interfaces/_api_types_.ptzvector.md)*, Speed: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:558](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L558)*
+*Defined in [api/ptz.ts:558](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L558)*
 
 Operation for Relative Pan/Tilt and Zoom Move. The operation is supported if the PTZNode supports at least one relative Pan/Tilt or Zoom space. The speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
 
@@ -534,7 +534,7 @@ ___
 
 ▸ **RemovePreset**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:512](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L512)*
+*Defined in [api/ptz.ts:512](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L512)*
 
 ```
       Operation to remove a PTZ preset for the Node in
@@ -561,7 +561,7 @@ ___
 
 ▸ **RemovePresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTourToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:648](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L648)*
+*Defined in [api/ptz.ts:648](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L648)*
 
 Operation to delete a specific preset tour from the media profile.
 
@@ -581,7 +581,7 @@ ___
 
 ▸ **SendAuxiliaryCommand**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, AuxiliaryData: *[AuxiliaryData]()*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:472](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L472)*
+*Defined in [api/ptz.ts:472](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L472)*
 
 ```
       Operation to send auxiliary commands to the PTZ device
@@ -606,7 +606,7 @@ ___
 
 ▸ **SetConfiguration**(PTZConfiguration: *[PTZConfiguration](../interfaces/_api_types_.ptzconfiguration.md)*, ForcePersistence: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:446](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L446)*
+*Defined in [api/ptz.ts:446](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L446)*
 
 ```
       Set/update a existing PTZConfiguration on the device.
@@ -628,7 +628,7 @@ ___
 
 ▸ **SetHomePosition**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:540](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L540)*
+*Defined in [api/ptz.ts:540](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L540)*
 
 Operation to save current position as the home position. The SetHomePosition command returns with a failure if the “home” position is fixed and cannot be overwritten. If the SetHomePosition is successful, it is possible to recall the Home Position with the GotoHomePosition command.
 
@@ -647,7 +647,7 @@ ___
 
 ▸ **SetPreset**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetName: *`string`*, PresetToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:498](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L498)*
+*Defined in [api/ptz.ts:498](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L498)*
 
 The SetPreset command saves the current device position parameters so that the device can move to the saved preset position through the GotoPreset operation. In order to create a new preset, the SetPresetRequest contains no PresetToken. If creation is successful, the Response contains the PresetToken which uniquely identifies the Preset. An existing Preset can be overwritten by specifying the PresetToken of the corresponding Preset. In both cases (overwriting or creation) an optional PresetName can be specified. The operation fails if the PTZ device is moving during the SetPreset operation. The device MAY internally save additional states such as imaging properties in the PTZ Preset which then should be recalled in the GotoPreset operation.
 
@@ -668,7 +668,7 @@ ___
 
 ▸ **Stop**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PanTilt: *`boolean`*, Zoom: *`boolean`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/ptz.ts:599](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L599)*
+*Defined in [api/ptz.ts:599](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L599)*
 
 Operation to stop ongoing pan, tilt and zoom movements of absolute relative and continuous type. If no stop argument for pan, tilt or zoom is set, the device will stop all ongoing pan, tilt and zoom movements.
 
@@ -689,7 +689,7 @@ ___
 
 ▸ **AbsoluteMove**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Position: *[PTZVector](../interfaces/_api_types_.ptzvector.md)*, Speed?: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:257](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L257)*
+*Defined in [api/ptz.ts:257](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L257)*
 
 Operation to move pan,tilt or zoom to a absolute destination. The speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
 
@@ -710,7 +710,7 @@ ___
 
 ▸ **ContinuousMove**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Velocity: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*, Timeout?: *`undefined` \| `string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:220](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L220)*
+*Defined in [api/ptz.ts:220](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L220)*
 
 Operation for continuous Pan/Tilt and Zoom movements. The operation is supported if the PTZNode supports at least one continuous Pan/Tilt or Zoom space. If the space argument is omitted, the default space set by the PTZConfiguration will be used.
 
@@ -731,7 +731,7 @@ ___
 
 ▸ **CreatePresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:318](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L318)*
+*Defined in [api/ptz.ts:318](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L318)*
 
 Operation to create a preset tour for the selected media profile.
 
@@ -750,7 +750,7 @@ ___
 
 ▸ **GeoMove**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Target: *[GeoLocation](../interfaces/_api_types_.geolocation.md)*, Speed?: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*, AreaHeight?: *`undefined` \| `number`*, AreaWidth?: *`undefined` \| `number`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:272](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L272)*
+*Defined in [api/ptz.ts:272](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L272)*
 
 Operation to move pan,tilt or zoom to point to a destination based on the geolocation of the target. The speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used. The area height and area dwidth parameters are optional, they can be used independently and may be used by the device to automatically determine the best zoom level to show the target.
 
@@ -773,7 +773,7 @@ ___
 
 ▸ **GetCompatibleConfigurations**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:358](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L358)*
+*Defined in [api/ptz.ts:358](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L358)*
 
 Operation to get all available PTZConfigurations that can be added to the referenced media profile. A device providing more than one PTZConfiguration or more than one VideoSourceConfiguration or which has any other resource interdependency between PTZConfiguration entities and other resources listable in a media profile should implement this operation. PTZConfiguration entities returned by this operation shall not fail on adding them to the referenced media profile.
 
@@ -792,7 +792,7 @@ ___
 
 ▸ **GetConfiguration**(PTZConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:64](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L64)*
+*Defined in [api/ptz.ts:64](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L64)*
 
 Get a specific PTZconfiguration from the device, identified by its reference token or name.
 
@@ -813,7 +813,7 @@ ___
 
 ▸ **GetConfigurationOptions**(ConfigurationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:117](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L117)*
+*Defined in [api/ptz.ts:117](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L117)*
 
 List supported coordinate systems including their range limitations. Therefore, the options MAY differ depending on whether the PTZ Configuration is assigned to a Profile containing a Video Source Configuration. In that case, the options may additionally contain coordinate systems referring to the image coordinate system described by the Video Source Configuration. If the PTZ Node supports continuous movements, it shall return a Timeout Range within which Timeouts are accepted by the PTZ Node.
 
@@ -832,7 +832,7 @@ ___
 
 ▸ **GetConfigurations**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:90](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L90)*
+*Defined in [api/ptz.ts:90](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L90)*
 
 ```
       Get all the existing PTZConfigurations from the device.
@@ -849,7 +849,7 @@ ___
 
 ▸ **GetNode**(NodeToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L39)*
+*Defined in [api/ptz.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L39)*
 
 Get a specific PTZ Node identified by a reference token or a name.
 
@@ -868,7 +868,7 @@ ___
 
 ▸ **GetNodes**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:28](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L28)*
+*Defined in [api/ptz.ts:28](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L28)*
 
 Get the descriptions of the available PTZ Nodes.
 
@@ -883,7 +883,7 @@ ___
 
 ▸ **GetPresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTourToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:300](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L300)*
+*Defined in [api/ptz.ts:300](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L300)*
 
 Operation to request a specific PTZ preset tour in the selected media profile.
 
@@ -903,7 +903,7 @@ ___
 
 ▸ **GetPresetTourOptions**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTourToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:309](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L309)*
+*Defined in [api/ptz.ts:309](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L309)*
 
 Operation to request available options to configure PTZ preset tour.
 
@@ -923,7 +923,7 @@ ___
 
 ▸ **GetPresetTours**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:291](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L291)*
+*Defined in [api/ptz.ts:291](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L291)*
 
 Operation to request PTZ preset tours in the selected media profiles.
 
@@ -942,7 +942,7 @@ ___
 
 ▸ **GetPresets**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:143](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L143)*
+*Defined in [api/ptz.ts:143](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L143)*
 
 ```
       Operation to request all PTZ presets for the PTZNode
@@ -965,7 +965,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L12)*
+*Defined in [api/ptz.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L12)*
 
 Returns the capabilities of the PTZ service. The result is returned in a typed answer.
 
@@ -978,7 +978,7 @@ ___
 
 ▸ **GetStatus**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:244](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L244)*
+*Defined in [api/ptz.ts:244](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L244)*
 
 Operation to request PTZ status for the Node in the selected profile.
 
@@ -997,7 +997,7 @@ ___
 
 ▸ **GotoHomePosition**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Speed?: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:199](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L199)*
+*Defined in [api/ptz.ts:199](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L199)*
 
 ```
       Operation to move the PTZ device to it's "home" position. The operation is supported if the HomeSupported element in the PTZNode is true.
@@ -1019,7 +1019,7 @@ ___
 
 ▸ **GotoPreset**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Speed?: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:189](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L189)*
+*Defined in [api/ptz.ts:189](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L189)*
 
 ```
       Operation to go to a saved preset position for the
@@ -1044,7 +1044,7 @@ ___
 
 ▸ **ModifyPresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTour: *[PresetTour](../interfaces/_api_types_.presettour.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:327](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L327)*
+*Defined in [api/ptz.ts:327](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L327)*
 
 Operation to modify a preset tour for the selected media profile.
 
@@ -1064,7 +1064,7 @@ ___
 
 ▸ **OperatePresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTourToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Operation: *[PTZPresetTourOperation](../enums/_api_types_.ptzpresettouroperation.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:336](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L336)*
+*Defined in [api/ptz.ts:336](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L336)*
 
 Operation to perform specific operation on the preset tour in selected media profile.
 
@@ -1085,7 +1085,7 @@ ___
 
 ▸ **RelativeMove**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Translation: *[PTZVector](../interfaces/_api_types_.ptzvector.md)*, Speed?: *[PTZSpeed](../interfaces/_api_types_.ptzspeed.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:233](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L233)*
+*Defined in [api/ptz.ts:233](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L233)*
 
 Operation for Relative Pan/Tilt and Zoom Move. The operation is supported if the PTZNode supports at least one relative Pan/Tilt or Zoom space. The speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
 
@@ -1106,7 +1106,7 @@ ___
 
 ▸ **RemovePreset**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:177](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L177)*
+*Defined in [api/ptz.ts:177](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L177)*
 
 ```
       Operation to remove a PTZ preset for the Node in
@@ -1133,7 +1133,7 @@ ___
 
 ▸ **RemovePresetTour**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetTourToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:345](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L345)*
+*Defined in [api/ptz.ts:345](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L345)*
 
 Operation to delete a specific preset tour from the media profile.
 
@@ -1153,7 +1153,7 @@ ___
 
 ▸ **SendAuxiliaryCommand**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, AuxiliaryData: *[AuxiliaryData]()*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:131](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L131)*
+*Defined in [api/ptz.ts:131](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L131)*
 
 ```
       Operation to send auxiliary commands to the PTZ device
@@ -1178,7 +1178,7 @@ ___
 
 ▸ **SetConfiguration**(PTZConfiguration: *[PTZConfiguration](../interfaces/_api_types_.ptzconfiguration.md)*, ForcePersistence: *`boolean`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:101](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L101)*
+*Defined in [api/ptz.ts:101](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L101)*
 
 ```
       Set/update a existing PTZConfiguration on the device.
@@ -1200,7 +1200,7 @@ ___
 
 ▸ **SetHomePosition**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:211](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L211)*
+*Defined in [api/ptz.ts:211](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L211)*
 
 Operation to save current position as the home position. The SetHomePosition command returns with a failure if the “home” position is fixed and cannot be overwritten. If the SetHomePosition is successful, it is possible to recall the Home Position with the GotoHomePosition command.
 
@@ -1219,7 +1219,7 @@ ___
 
 ▸ **SetPreset**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PresetName?: *`undefined` \| `string`*, PresetToken?: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:161](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L161)*
+*Defined in [api/ptz.ts:161](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L161)*
 
 The SetPreset command saves the current device position parameters so that the device can move to the saved preset position through the GotoPreset operation. In order to create a new preset, the SetPresetRequest contains no PresetToken. If creation is successful, the Response contains the PresetToken which uniquely identifies the Preset. An existing Preset can be overwritten by specifying the PresetToken of the corresponding Preset. In both cases (overwriting or creation) an optional PresetName can be specified. The operation fails if the PTZ device is moving during the SetPreset operation. The device MAY internally save additional states such as imaging properties in the PTZ Preset which then should be recalled in the GotoPreset operation.
 
@@ -1240,7 +1240,7 @@ ___
 
 ▸ **Stop**(ProfileToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, PanTilt?: *`undefined` \| `false` \| `true`*, Zoom?: *`undefined` \| `false` \| `true`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/ptz.ts:282](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/ptz.ts#L282)*
+*Defined in [api/ptz.ts:282](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/ptz.ts#L282)*
 
 Operation to stop ongoing pan, tilt and zoom movements of absolute relative and continuous type. If no stop argument for pan, tilt or zoom is set, the device will stop all ongoing pan, tilt and zoom movements.
 

--- a/docs/classes/_api_receiver_.onvifreceiver.md
+++ b/docs/classes/_api_receiver_.onvifreceiver.md
@@ -1,39 +1,39 @@
-[onvif-rx](../README.md) > ["api/receiver"](../modules/_api_receiver_.md) > [Receiver](../classes/_api_receiver_.receiver.md)
+[onvif-rx](../README.md) > ["api/receiver"](../modules/_api_receiver_.md) > [ONVIFReceiver](../classes/_api_receiver_.onvifreceiver.md)
 
-# Class: Receiver
+# Class: ONVIFReceiver
 
 ## Hierarchy
 
-**Receiver**
+**ONVIFReceiver**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_receiver_.receiver.md#constructor)
+* [constructor](_api_receiver_.onvifreceiver.md#constructor)
 
 ### Properties
 
-* [config](_api_receiver_.receiver.md#config)
+* [config](_api_receiver_.onvifreceiver.md#config)
 
 ### Methods
 
-* [ConfigureReceiver](_api_receiver_.receiver.md#configurereceiver)
-* [CreateReceiver](_api_receiver_.receiver.md#createreceiver)
-* [DeleteReceiver](_api_receiver_.receiver.md#deletereceiver)
-* [GetReceiver](_api_receiver_.receiver.md#getreceiver)
-* [GetReceiverState](_api_receiver_.receiver.md#getreceiverstate)
-* [GetReceivers](_api_receiver_.receiver.md#getreceivers)
-* [GetServiceCapabilities](_api_receiver_.receiver.md#getservicecapabilities)
-* [SetReceiverMode](_api_receiver_.receiver.md#setreceivermode)
-* [ConfigureReceiver](_api_receiver_.receiver.md#configurereceiver-1)
-* [CreateReceiver](_api_receiver_.receiver.md#createreceiver-1)
-* [DeleteReceiver](_api_receiver_.receiver.md#deletereceiver-1)
-* [GetReceiver](_api_receiver_.receiver.md#getreceiver-1)
-* [GetReceiverState](_api_receiver_.receiver.md#getreceiverstate-1)
-* [GetReceivers](_api_receiver_.receiver.md#getreceivers-1)
-* [GetServiceCapabilities](_api_receiver_.receiver.md#getservicecapabilities-1)
-* [SetReceiverMode](_api_receiver_.receiver.md#setreceivermode-1)
+* [ConfigureReceiver](_api_receiver_.onvifreceiver.md#configurereceiver)
+* [CreateReceiver](_api_receiver_.onvifreceiver.md#createreceiver)
+* [DeleteReceiver](_api_receiver_.onvifreceiver.md#deletereceiver)
+* [GetReceiver](_api_receiver_.onvifreceiver.md#getreceiver)
+* [GetReceiverState](_api_receiver_.onvifreceiver.md#getreceiverstate)
+* [GetReceivers](_api_receiver_.onvifreceiver.md#getreceivers)
+* [GetServiceCapabilities](_api_receiver_.onvifreceiver.md#getservicecapabilities)
+* [SetReceiverMode](_api_receiver_.onvifreceiver.md#setreceivermode)
+* [ConfigureReceiver](_api_receiver_.onvifreceiver.md#configurereceiver-1)
+* [CreateReceiver](_api_receiver_.onvifreceiver.md#createreceiver-1)
+* [DeleteReceiver](_api_receiver_.onvifreceiver.md#deletereceiver-1)
+* [GetReceiver](_api_receiver_.onvifreceiver.md#getreceiver-1)
+* [GetReceiverState](_api_receiver_.onvifreceiver.md#getreceiverstate-1)
+* [GetReceivers](_api_receiver_.onvifreceiver.md#getreceivers-1)
+* [GetServiceCapabilities](_api_receiver_.onvifreceiver.md#getservicecapabilities-1)
+* [SetReceiverMode](_api_receiver_.onvifreceiver.md#setreceivermode-1)
 
 ---
 
@@ -43,9 +43,9 @@
 
 ###  constructor
 
-⊕ **new Receiver**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Receiver](_api_receiver_.receiver.md)
+⊕ **new ONVIFReceiver**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFReceiver](_api_receiver_.onvifreceiver.md)
 
-*Defined in [api/receiver.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L5)*
+*Defined in [api/receiver.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L5)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Receiver](_api_receiver_.receiver.md)
+**Returns:** [ONVIFReceiver](_api_receiver_.onvifreceiver.md)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/receiver.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L6)*
+*Defined in [api/receiver.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L6)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 ▸ **ConfigureReceiver**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Configuration: *[ReceiverConfiguration](../interfaces/_api_types_.receiverconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/receiver.ts:152](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L152)*
+*Defined in [api/receiver.ts:152](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L152)*
 
 Configures an existing receiver. This operation is mandatory.
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **CreateReceiver**(Configuration: *[ReceiverConfiguration](../interfaces/_api_types_.receiverconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/receiver.ts:132](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L132)*
+*Defined in [api/receiver.ts:132](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L132)*
 
 Creates a new receiver. This operation is mandatory, although the service may raise a fault if the receiver cannot be created.
 
@@ -116,7 +116,7 @@ ___
 
 ▸ **DeleteReceiver**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/receiver.ts:143](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L143)*
+*Defined in [api/receiver.ts:143](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L143)*
 
 Deletes an existing receiver. A receiver may be deleted only if it is not currently in use; otherwise a fault shall be raised. This operation is mandatory.
 
@@ -135,7 +135,7 @@ ___
 
 ▸ **GetReceiver**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/receiver.ts:122](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L122)*
+*Defined in [api/receiver.ts:122](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L122)*
 
 Retrieves the details of a specific receiver. This operation is mandatory.
 
@@ -154,7 +154,7 @@ ___
 
 ▸ **GetReceiverState**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/receiver.ts:173](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L173)*
+*Defined in [api/receiver.ts:173](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L173)*
 
 Determines whether the receiver is currently disconnected, connected or attempting to connect. This operation is mandatory.
 
@@ -173,7 +173,7 @@ ___
 
 ▸ **GetReceivers**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/receiver.ts:113](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L113)*
+*Defined in [api/receiver.ts:113](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L113)*
 
 Lists all receivers currently present on a device. This operation is mandatory.
 
@@ -186,7 +186,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/receiver.ts:104](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L104)*
+*Defined in [api/receiver.ts:104](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L104)*
 
 Returns the capabilities of the receiver service. The result is returned in a typed answer.
 
@@ -199,7 +199,7 @@ ___
 
 ▸ **SetReceiverMode**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Mode: *[ReceiverMode](../enums/_api_types_.receivermode.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/receiver.ts:162](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L162)*
+*Defined in [api/receiver.ts:162](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L162)*
 
 Sets the mode of the receiver without affecting the rest of its configuration. This operation is mandatory.
 
@@ -219,7 +219,7 @@ ___
 
 ▸ **ConfigureReceiver**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Configuration: *[ReceiverConfiguration](../interfaces/_api_types_.receiverconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/receiver.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L70)*
+*Defined in [api/receiver.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L70)*
 
 Configures an existing receiver. This operation is mandatory.
 
@@ -239,7 +239,7 @@ ___
 
 ▸ **CreateReceiver**(Configuration: *[ReceiverConfiguration](../interfaces/_api_types_.receiverconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/receiver.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L46)*
+*Defined in [api/receiver.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L46)*
 
 Creates a new receiver. This operation is mandatory, although the service may raise a fault if the receiver cannot be created.
 
@@ -258,7 +258,7 @@ ___
 
 ▸ **DeleteReceiver**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/receiver.ts:59](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L59)*
+*Defined in [api/receiver.ts:59](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L59)*
 
 Deletes an existing receiver. A receiver may be deleted only if it is not currently in use; otherwise a fault shall be raised. This operation is mandatory.
 
@@ -277,7 +277,7 @@ ___
 
 ▸ **GetReceiver**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/receiver.ts:34](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L34)*
+*Defined in [api/receiver.ts:34](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L34)*
 
 Retrieves the details of a specific receiver. This operation is mandatory.
 
@@ -296,7 +296,7 @@ ___
 
 ▸ **GetReceiverState**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/receiver.ts:95](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L95)*
+*Defined in [api/receiver.ts:95](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L95)*
 
 Determines whether the receiver is currently disconnected, connected or attempting to connect. This operation is mandatory.
 
@@ -315,7 +315,7 @@ ___
 
 ▸ **GetReceivers**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/receiver.ts:23](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L23)*
+*Defined in [api/receiver.ts:23](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L23)*
 
 Lists all receivers currently present on a device. This operation is mandatory.
 
@@ -328,7 +328,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/receiver.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L12)*
+*Defined in [api/receiver.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L12)*
 
 Returns the capabilities of the receiver service. The result is returned in a typed answer.
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **SetReceiverMode**(ReceiverToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*, Mode: *[ReceiverMode](../enums/_api_types_.receivermode.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/receiver.ts:82](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/receiver.ts#L82)*
+*Defined in [api/receiver.ts:82](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/receiver.ts#L82)*
 
 Sets the mode of the receiver without affecting the rest of its configuration. This operation is mandatory.
 

--- a/docs/classes/_api_recording_.onvifrecording.md
+++ b/docs/classes/_api_recording_.onvifrecording.md
@@ -1,65 +1,65 @@
-[onvif-rx](../README.md) > ["api/recording"](../modules/_api_recording_.md) > [Recording](../classes/_api_recording_.recording.md)
+[onvif-rx](../README.md) > ["api/recording"](../modules/_api_recording_.md) > [ONVIFRecording](../classes/_api_recording_.onvifrecording.md)
 
-# Class: Recording
+# Class: ONVIFRecording
 
 ## Hierarchy
 
-**Recording**
+**ONVIFRecording**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_recording_.recording.md#constructor)
+* [constructor](_api_recording_.onvifrecording.md#constructor)
 
 ### Properties
 
-* [config](_api_recording_.recording.md#config)
+* [config](_api_recording_.onvifrecording.md#config)
 
 ### Methods
 
-* [CreateRecording](_api_recording_.recording.md#createrecording)
-* [CreateRecordingJob](_api_recording_.recording.md#createrecordingjob)
-* [CreateTrack](_api_recording_.recording.md#createtrack)
-* [DeleteRecording](_api_recording_.recording.md#deleterecording)
-* [DeleteRecordingJob](_api_recording_.recording.md#deleterecordingjob)
-* [DeleteTrack](_api_recording_.recording.md#deletetrack)
-* [ExportRecordedData](_api_recording_.recording.md#exportrecordeddata)
-* [GetExportRecordedDataState](_api_recording_.recording.md#getexportrecordeddatastate)
-* [GetRecordingConfiguration](_api_recording_.recording.md#getrecordingconfiguration)
-* [GetRecordingJobConfiguration](_api_recording_.recording.md#getrecordingjobconfiguration)
-* [GetRecordingJobState](_api_recording_.recording.md#getrecordingjobstate)
-* [GetRecordingJobs](_api_recording_.recording.md#getrecordingjobs)
-* [GetRecordingOptions](_api_recording_.recording.md#getrecordingoptions)
-* [GetRecordings](_api_recording_.recording.md#getrecordings)
-* [GetServiceCapabilities](_api_recording_.recording.md#getservicecapabilities)
-* [GetTrackConfiguration](_api_recording_.recording.md#gettrackconfiguration)
-* [SetRecordingConfiguration](_api_recording_.recording.md#setrecordingconfiguration)
-* [SetRecordingJobConfiguration](_api_recording_.recording.md#setrecordingjobconfiguration)
-* [SetRecordingJobMode](_api_recording_.recording.md#setrecordingjobmode)
-* [SetTrackConfiguration](_api_recording_.recording.md#settrackconfiguration)
-* [StopExportRecordedData](_api_recording_.recording.md#stopexportrecordeddata)
-* [CreateRecording](_api_recording_.recording.md#createrecording-1)
-* [CreateRecordingJob](_api_recording_.recording.md#createrecordingjob-1)
-* [CreateTrack](_api_recording_.recording.md#createtrack-1)
-* [DeleteRecording](_api_recording_.recording.md#deleterecording-1)
-* [DeleteRecordingJob](_api_recording_.recording.md#deleterecordingjob-1)
-* [DeleteTrack](_api_recording_.recording.md#deletetrack-1)
-* [ExportRecordedData](_api_recording_.recording.md#exportrecordeddata-1)
-* [GetExportRecordedDataState](_api_recording_.recording.md#getexportrecordeddatastate-1)
-* [GetRecordingConfiguration](_api_recording_.recording.md#getrecordingconfiguration-1)
-* [GetRecordingJobConfiguration](_api_recording_.recording.md#getrecordingjobconfiguration-1)
-* [GetRecordingJobState](_api_recording_.recording.md#getrecordingjobstate-1)
-* [GetRecordingJobs](_api_recording_.recording.md#getrecordingjobs-1)
-* [GetRecordingOptions](_api_recording_.recording.md#getrecordingoptions-1)
-* [GetRecordings](_api_recording_.recording.md#getrecordings-1)
-* [GetServiceCapabilities](_api_recording_.recording.md#getservicecapabilities-1)
-* [GetTrackConfiguration](_api_recording_.recording.md#gettrackconfiguration-1)
-* [SetRecordingConfiguration](_api_recording_.recording.md#setrecordingconfiguration-1)
-* [SetRecordingJobConfiguration](_api_recording_.recording.md#setrecordingjobconfiguration-1)
-* [SetRecordingJobMode](_api_recording_.recording.md#setrecordingjobmode-1)
-* [SetTrackConfiguration](_api_recording_.recording.md#settrackconfiguration-1)
-* [StopExportRecordedData](_api_recording_.recording.md#stopexportrecordeddata-1)
+* [CreateRecording](_api_recording_.onvifrecording.md#createrecording)
+* [CreateRecordingJob](_api_recording_.onvifrecording.md#createrecordingjob)
+* [CreateTrack](_api_recording_.onvifrecording.md#createtrack)
+* [DeleteRecording](_api_recording_.onvifrecording.md#deleterecording)
+* [DeleteRecordingJob](_api_recording_.onvifrecording.md#deleterecordingjob)
+* [DeleteTrack](_api_recording_.onvifrecording.md#deletetrack)
+* [ExportRecordedData](_api_recording_.onvifrecording.md#exportrecordeddata)
+* [GetExportRecordedDataState](_api_recording_.onvifrecording.md#getexportrecordeddatastate)
+* [GetRecordingConfiguration](_api_recording_.onvifrecording.md#getrecordingconfiguration)
+* [GetRecordingJobConfiguration](_api_recording_.onvifrecording.md#getrecordingjobconfiguration)
+* [GetRecordingJobState](_api_recording_.onvifrecording.md#getrecordingjobstate)
+* [GetRecordingJobs](_api_recording_.onvifrecording.md#getrecordingjobs)
+* [GetRecordingOptions](_api_recording_.onvifrecording.md#getrecordingoptions)
+* [GetRecordings](_api_recording_.onvifrecording.md#getrecordings)
+* [GetServiceCapabilities](_api_recording_.onvifrecording.md#getservicecapabilities)
+* [GetTrackConfiguration](_api_recording_.onvifrecording.md#gettrackconfiguration)
+* [SetRecordingConfiguration](_api_recording_.onvifrecording.md#setrecordingconfiguration)
+* [SetRecordingJobConfiguration](_api_recording_.onvifrecording.md#setrecordingjobconfiguration)
+* [SetRecordingJobMode](_api_recording_.onvifrecording.md#setrecordingjobmode)
+* [SetTrackConfiguration](_api_recording_.onvifrecording.md#settrackconfiguration)
+* [StopExportRecordedData](_api_recording_.onvifrecording.md#stopexportrecordeddata)
+* [CreateRecording](_api_recording_.onvifrecording.md#createrecording-1)
+* [CreateRecordingJob](_api_recording_.onvifrecording.md#createrecordingjob-1)
+* [CreateTrack](_api_recording_.onvifrecording.md#createtrack-1)
+* [DeleteRecording](_api_recording_.onvifrecording.md#deleterecording-1)
+* [DeleteRecordingJob](_api_recording_.onvifrecording.md#deleterecordingjob-1)
+* [DeleteTrack](_api_recording_.onvifrecording.md#deletetrack-1)
+* [ExportRecordedData](_api_recording_.onvifrecording.md#exportrecordeddata-1)
+* [GetExportRecordedDataState](_api_recording_.onvifrecording.md#getexportrecordeddatastate-1)
+* [GetRecordingConfiguration](_api_recording_.onvifrecording.md#getrecordingconfiguration-1)
+* [GetRecordingJobConfiguration](_api_recording_.onvifrecording.md#getrecordingjobconfiguration-1)
+* [GetRecordingJobState](_api_recording_.onvifrecording.md#getrecordingjobstate-1)
+* [GetRecordingJobs](_api_recording_.onvifrecording.md#getrecordingjobs-1)
+* [GetRecordingOptions](_api_recording_.onvifrecording.md#getrecordingoptions-1)
+* [GetRecordings](_api_recording_.onvifrecording.md#getrecordings-1)
+* [GetServiceCapabilities](_api_recording_.onvifrecording.md#getservicecapabilities-1)
+* [GetTrackConfiguration](_api_recording_.onvifrecording.md#gettrackconfiguration-1)
+* [SetRecordingConfiguration](_api_recording_.onvifrecording.md#setrecordingconfiguration-1)
+* [SetRecordingJobConfiguration](_api_recording_.onvifrecording.md#setrecordingjobconfiguration-1)
+* [SetRecordingJobMode](_api_recording_.onvifrecording.md#setrecordingjobmode-1)
+* [SetTrackConfiguration](_api_recording_.onvifrecording.md#settrackconfiguration-1)
+* [StopExportRecordedData](_api_recording_.onvifrecording.md#stopexportrecordeddata-1)
 
 ---
 
@@ -69,9 +69,9 @@
 
 ###  constructor
 
-⊕ **new Recording**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Recording](_api_recording_.recording.md)
+⊕ **new ONVIFRecording**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFRecording](_api_recording_.onvifrecording.md)
 
-*Defined in [api/recording.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L5)*
+*Defined in [api/recording.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L5)*
 
 **Parameters:**
 
@@ -79,7 +79,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Recording](_api_recording_.recording.md)
+**Returns:** [ONVIFRecording](_api_recording_.onvifrecording.md)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/recording.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L6)*
+*Defined in [api/recording.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L6)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **CreateRecording**(RecordingConfiguration: *[RecordingConfiguration](../interfaces/_api_types_.recordingconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:272](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L272)*
+*Defined in [api/recording.ts:272](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L272)*
 
 CreateRecording shall create a new recording. The new recording shall be created with a track for each supported TrackType see Recording Control Spec. This method is optional. It shall be available if the Recording/DynamicRecordings capability is TRUE. When successfully completed, CreateRecording shall have created three tracks with the following configurations:
 
@@ -132,7 +132,7 @@ ___
 
 ▸ **CreateRecordingJob**(JobConfiguration: *[RecordingJobConfiguration](../interfaces/_api_types_.recordingjobconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:361](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L361)*
+*Defined in [api/recording.ts:361](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L361)*
 
 CreateRecordingJob shall create a new recording job. The JobConfiguration returned from CreateRecordingJob shall be identical to the JobConfiguration passed into CreateRecordingJob, except for the ReceiverToken and the AutoCreateReceiver. In the returned structure, the ReceiverToken shall be present and valid and the AutoCreateReceiver field shall be omitted.
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **CreateTrack**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, TrackConfiguration: *[TrackConfiguration](../interfaces/_api_types_.trackconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:326](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L326)*
+*Defined in [api/recording.ts:326](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L326)*
 
 This method shall create a new track within a recording. This method is optional. It shall be available if the Recording/DynamicTracks capability is TRUE. A TrackToken in itself does not uniquely identify a specific track. Tracks within different recordings may have the same TrackToken.
 
@@ -171,7 +171,7 @@ ___
 
 ▸ **DeleteRecording**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:286](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L286)*
+*Defined in [api/recording.ts:286](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L286)*
 
 DeleteRecording shall delete a recording object. Whenever a recording is deleted, the device shall delete all the tracks that are part of the recording, and it shall delete all the Recording Jobs that record into the recording. For each deleted recording job, the device shall also delete all the receiver objects associated with the recording job that are automatically created using the AutoCreateReceiver field of the recording job configuration structure and are not used in any other recording job. This method is optional. It shall be available if the Recording/DynamicRecordings capability is TRUE.
 
@@ -190,7 +190,7 @@ ___
 
 ▸ **DeleteRecordingJob**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:371](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L371)*
+*Defined in [api/recording.ts:371](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L371)*
 
 DeleteRecordingJob removes a recording job. It shall also implicitly delete all the receiver objects associated with the recording job that are automatically created using the AutoCreateReceiver field of the recording job configuration structure and are not used in any other recording job.
 
@@ -209,7 +209,7 @@ ___
 
 ▸ **DeleteTrack**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, TrackToken: *[TrackReference](../modules/_api_types_.md#trackreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:335](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L335)*
+*Defined in [api/recording.ts:335](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L335)*
 
 DeleteTrack shall remove a track from a recording. All the data in the track shall be deleted. This method is optional. It shall be available if the Recording/DynamicTracks capability is TRUE.
 
@@ -229,7 +229,7 @@ ___
 
 ▸ **ExportRecordedData**(SearchScope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, FileFormat: *`string`*, StorageDestination: *[StorageReferencePath](../interfaces/_api_types_.storagereferencepath.md)*, StartPoint: *`string`*, EndPoint: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:421](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L421)*
+*Defined in [api/recording.ts:421](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L421)*
 
 Exports the selected recordings (from existing recorded data) to the given storage target based on the requested file format.
 
@@ -252,7 +252,7 @@ ___
 
 ▸ **GetExportRecordedDataState**(OperationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:439](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L439)*
+*Defined in [api/recording.ts:439](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L439)*
 
 Retrieves the status of selected ExportRecordedData operation.
 
@@ -271,7 +271,7 @@ ___
 
 ▸ **GetRecordingConfiguration**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:308](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L308)*
+*Defined in [api/recording.ts:308](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L308)*
 
 GetRecordingConfiguration shall retrieve the recording configuration for a recording.
 
@@ -290,7 +290,7 @@ ___
 
 ▸ **GetRecordingJobConfiguration**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:395](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L395)*
+*Defined in [api/recording.ts:395](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L395)*
 
 GetRecordingJobConfiguration shall return the current configuration for a recording job.
 
@@ -309,7 +309,7 @@ ___
 
 ▸ **GetRecordingJobState**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:412](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L412)*
+*Defined in [api/recording.ts:412](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L412)*
 
 GetRecordingJobState returns the state of a recording job. It includes an aggregated state, and state for each track of the recording job.
 
@@ -328,7 +328,7 @@ ___
 
 ▸ **GetRecordingJobs**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:378](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L378)*
+*Defined in [api/recording.ts:378](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L378)*
 
 GetRecordingJobs shall return a list of all the recording jobs in the device.
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **GetRecordingOptions**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:315](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L315)*
+*Defined in [api/recording.ts:315](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L315)*
 
 GetRecordingOptions returns information for a recording identified by the RecordingToken. The information includes the number of additonal tracks as well as recording jobs that can be configured.
 
@@ -360,7 +360,7 @@ ___
 
 ▸ **GetRecordings**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:294](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L294)*
+*Defined in [api/recording.ts:294](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L294)*
 
 GetRecordings shall return a description of all the recordings in the device. This description shall include a list of all the tracks for each recording.
 
@@ -373,7 +373,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:250](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L250)*
+*Defined in [api/recording.ts:250](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L250)*
 
 Returns the capabilities of the recording service. The result is returned in a typed answer.
 
@@ -386,7 +386,7 @@ ___
 
 ▸ **GetTrackConfiguration**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, TrackToken: *[TrackReference](../modules/_api_types_.md#trackreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:342](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L342)*
+*Defined in [api/recording.ts:342](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L342)*
 
 GetTrackConfiguration shall retrieve the configuration for a specific track.
 
@@ -406,7 +406,7 @@ ___
 
 ▸ **SetRecordingConfiguration**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, RecordingConfiguration: *[RecordingConfiguration](../interfaces/_api_types_.recordingconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:301](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L301)*
+*Defined in [api/recording.ts:301](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L301)*
 
 SetRecordingConfiguration shall change the configuration of a recording.
 
@@ -426,7 +426,7 @@ ___
 
 ▸ **SetRecordingJobConfiguration**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*, JobConfiguration: *[RecordingJobConfiguration](../interfaces/_api_types_.recordingjobconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:388](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L388)*
+*Defined in [api/recording.ts:388](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L388)*
 
 SetRecordingJobConfiguration shall change the configuration for a recording job. SetRecordingJobConfiguration shall implicitly delete any receiver objects that were created automatically if they are no longer used as a result of changing the recording job configuration.
 
@@ -446,7 +446,7 @@ ___
 
 ▸ **SetRecordingJobMode**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*, Mode: *[RecordingJobMode](../modules/_api_types_.md#recordingjobmode)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:404](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L404)*
+*Defined in [api/recording.ts:404](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L404)*
 
 SetRecordingJobMode shall change the mode of the recording job. Using this method shall be equivalent to retrieving the recording job configuration, and writing it back with a different mode.
 
@@ -466,7 +466,7 @@ ___
 
 ▸ **SetTrackConfiguration**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, TrackToken: *[TrackReference](../modules/_api_types_.md#trackreference)*, TrackConfiguration: *[TrackConfiguration](../interfaces/_api_types_.trackconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:349](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L349)*
+*Defined in [api/recording.ts:349](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L349)*
 
 SetTrackConfiguration shall change the configuration of a track.
 
@@ -487,7 +487,7 @@ ___
 
 ▸ **StopExportRecordedData**(OperationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/recording.ts:430](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L430)*
+*Defined in [api/recording.ts:430](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L430)*
 
 Stops the selected ExportRecordedData operation.
 
@@ -506,7 +506,7 @@ ___
 
 ▸ **CreateRecording**(RecordingConfiguration: *[RecordingConfiguration](../interfaces/_api_types_.recordingconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:36](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L36)*
+*Defined in [api/recording.ts:36](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L36)*
 
 CreateRecording shall create a new recording. The new recording shall be created with a track for each supported TrackType see Recording Control Spec. This method is optional. It shall be available if the Recording/DynamicRecordings capability is TRUE. When successfully completed, CreateRecording shall have created three tracks with the following configurations:
 
@@ -535,7 +535,7 @@ ___
 
 ▸ **CreateRecordingJob**(JobConfiguration: *[RecordingJobConfiguration](../interfaces/_api_types_.recordingjobconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:145](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L145)*
+*Defined in [api/recording.ts:145](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L145)*
 
 CreateRecordingJob shall create a new recording job. The JobConfiguration returned from CreateRecordingJob shall be identical to the JobConfiguration passed into CreateRecordingJob, except for the ReceiverToken and the AutoCreateReceiver. In the returned structure, the ReceiverToken shall be present and valid and the AutoCreateReceiver field shall be omitted.
 
@@ -554,7 +554,7 @@ ___
 
 ▸ **CreateTrack**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, TrackConfiguration: *[TrackConfiguration](../interfaces/_api_types_.trackconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L102)*
+*Defined in [api/recording.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L102)*
 
 This method shall create a new track within a recording. This method is optional. It shall be available if the Recording/DynamicTracks capability is TRUE. A TrackToken in itself does not uniquely identify a specific track. Tracks within different recordings may have the same TrackToken.
 
@@ -574,7 +574,7 @@ ___
 
 ▸ **DeleteRecording**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:52](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L52)*
+*Defined in [api/recording.ts:52](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L52)*
 
 DeleteRecording shall delete a recording object. Whenever a recording is deleted, the device shall delete all the tracks that are part of the recording, and it shall delete all the Recording Jobs that record into the recording. For each deleted recording job, the device shall also delete all the receiver objects associated with the recording job that are automatically created using the AutoCreateReceiver field of the recording job configuration structure and are not used in any other recording job. This method is optional. It shall be available if the Recording/DynamicRecordings capability is TRUE.
 
@@ -593,7 +593,7 @@ ___
 
 ▸ **DeleteRecordingJob**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:157](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L157)*
+*Defined in [api/recording.ts:157](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L157)*
 
 DeleteRecordingJob removes a recording job. It shall also implicitly delete all the receiver objects associated with the recording job that are automatically created using the AutoCreateReceiver field of the recording job configuration structure and are not used in any other recording job.
 
@@ -612,7 +612,7 @@ ___
 
 ▸ **DeleteTrack**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, TrackToken: *[TrackReference](../modules/_api_types_.md#trackreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:113](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L113)*
+*Defined in [api/recording.ts:113](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L113)*
 
 DeleteTrack shall remove a track from a recording. All the data in the track shall be deleted. This method is optional. It shall be available if the Recording/DynamicTracks capability is TRUE.
 
@@ -632,7 +632,7 @@ ___
 
 ▸ **ExportRecordedData**(SearchScope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, FileFormat: *`string`*, StorageDestination: *[StorageReferencePath](../interfaces/_api_types_.storagereferencepath.md)*, StartPoint?: *`undefined` \| `string`*, EndPoint?: *`undefined` \| `string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:219](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L219)*
+*Defined in [api/recording.ts:219](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L219)*
 
 Exports the selected recordings (from existing recorded data) to the given storage target based on the requested file format.
 
@@ -655,7 +655,7 @@ ___
 
 ▸ **GetExportRecordedDataState**(OperationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:241](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L241)*
+*Defined in [api/recording.ts:241](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L241)*
 
 Retrieves the status of selected ExportRecordedData operation.
 
@@ -674,7 +674,7 @@ ___
 
 ▸ **GetRecordingConfiguration**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:80](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L80)*
+*Defined in [api/recording.ts:80](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L80)*
 
 GetRecordingConfiguration shall retrieve the recording configuration for a recording.
 
@@ -693,7 +693,7 @@ ___
 
 ▸ **GetRecordingJobConfiguration**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:187](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L187)*
+*Defined in [api/recording.ts:187](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L187)*
 
 GetRecordingJobConfiguration shall return the current configuration for a recording job.
 
@@ -712,7 +712,7 @@ ___
 
 ▸ **GetRecordingJobState**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:208](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L208)*
+*Defined in [api/recording.ts:208](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L208)*
 
 GetRecordingJobState returns the state of a recording job. It includes an aggregated state, and state for each track of the recording job.
 
@@ -731,7 +731,7 @@ ___
 
 ▸ **GetRecordingJobs**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:166](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L166)*
+*Defined in [api/recording.ts:166](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L166)*
 
 GetRecordingJobs shall return a list of all the recording jobs in the device.
 
@@ -744,7 +744,7 @@ ___
 
 ▸ **GetRecordingOptions**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:89](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L89)*
+*Defined in [api/recording.ts:89](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L89)*
 
 GetRecordingOptions returns information for a recording identified by the RecordingToken. The information includes the number of additonal tracks as well as recording jobs that can be configured.
 
@@ -763,7 +763,7 @@ ___
 
 ▸ **GetRecordings**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:62](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L62)*
+*Defined in [api/recording.ts:62](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L62)*
 
 GetRecordings shall return a description of all the recordings in the device. This description shall include a list of all the tracks for each recording.
 
@@ -776,7 +776,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L12)*
+*Defined in [api/recording.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L12)*
 
 Returns the capabilities of the recording service. The result is returned in a typed answer.
 
@@ -789,7 +789,7 @@ ___
 
 ▸ **GetTrackConfiguration**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, TrackToken: *[TrackReference](../modules/_api_types_.md#trackreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:122](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L122)*
+*Defined in [api/recording.ts:122](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L122)*
 
 GetTrackConfiguration shall retrieve the configuration for a specific track.
 
@@ -809,7 +809,7 @@ ___
 
 ▸ **SetRecordingConfiguration**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, RecordingConfiguration: *[RecordingConfiguration](../interfaces/_api_types_.recordingconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:71](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L71)*
+*Defined in [api/recording.ts:71](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L71)*
 
 SetRecordingConfiguration shall change the configuration of a recording.
 
@@ -829,7 +829,7 @@ ___
 
 ▸ **SetRecordingJobConfiguration**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*, JobConfiguration: *[RecordingJobConfiguration](../interfaces/_api_types_.recordingjobconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:178](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L178)*
+*Defined in [api/recording.ts:178](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L178)*
 
 SetRecordingJobConfiguration shall change the configuration for a recording job. SetRecordingJobConfiguration shall implicitly delete any receiver objects that were created automatically if they are no longer used as a result of changing the recording job configuration.
 
@@ -849,7 +849,7 @@ ___
 
 ▸ **SetRecordingJobMode**(JobToken: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*, Mode: *[RecordingJobMode](../modules/_api_types_.md#recordingjobmode)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:198](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L198)*
+*Defined in [api/recording.ts:198](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L198)*
 
 SetRecordingJobMode shall change the mode of the recording job. Using this method shall be equivalent to retrieving the recording job configuration, and writing it back with a different mode.
 
@@ -869,7 +869,7 @@ ___
 
 ▸ **SetTrackConfiguration**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*, TrackToken: *[TrackReference](../modules/_api_types_.md#trackreference)*, TrackConfiguration: *[TrackConfiguration](../interfaces/_api_types_.trackconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:131](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L131)*
+*Defined in [api/recording.ts:131](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L131)*
 
 SetTrackConfiguration shall change the configuration of a track.
 
@@ -890,7 +890,7 @@ ___
 
 ▸ **StopExportRecordedData**(OperationToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/recording.ts:230](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/recording.ts#L230)*
+*Defined in [api/recording.ts:230](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/recording.ts#L230)*
 
 Stops the selected ExportRecordedData operation.
 

--- a/docs/classes/_api_replay_.onvifreplay.md
+++ b/docs/classes/_api_replay_.onvifreplay.md
@@ -1,31 +1,31 @@
-[onvif-rx](../README.md) > ["api/replay"](../modules/_api_replay_.md) > [Replay](../classes/_api_replay_.replay.md)
+[onvif-rx](../README.md) > ["api/replay"](../modules/_api_replay_.md) > [ONVIFReplay](../classes/_api_replay_.onvifreplay.md)
 
-# Class: Replay
+# Class: ONVIFReplay
 
 ## Hierarchy
 
-**Replay**
+**ONVIFReplay**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_replay_.replay.md#constructor)
+* [constructor](_api_replay_.onvifreplay.md#constructor)
 
 ### Properties
 
-* [config](_api_replay_.replay.md#config)
+* [config](_api_replay_.onvifreplay.md#config)
 
 ### Methods
 
-* [GetReplayConfiguration](_api_replay_.replay.md#getreplayconfiguration)
-* [GetReplayUri](_api_replay_.replay.md#getreplayuri)
-* [GetServiceCapabilities](_api_replay_.replay.md#getservicecapabilities)
-* [SetReplayConfiguration](_api_replay_.replay.md#setreplayconfiguration)
-* [GetReplayConfiguration](_api_replay_.replay.md#getreplayconfiguration-1)
-* [GetReplayUri](_api_replay_.replay.md#getreplayuri-1)
-* [GetServiceCapabilities](_api_replay_.replay.md#getservicecapabilities-1)
-* [SetReplayConfiguration](_api_replay_.replay.md#setreplayconfiguration-1)
+* [GetReplayConfiguration](_api_replay_.onvifreplay.md#getreplayconfiguration)
+* [GetReplayUri](_api_replay_.onvifreplay.md#getreplayuri)
+* [GetServiceCapabilities](_api_replay_.onvifreplay.md#getservicecapabilities)
+* [SetReplayConfiguration](_api_replay_.onvifreplay.md#setreplayconfiguration)
+* [GetReplayConfiguration](_api_replay_.onvifreplay.md#getreplayconfiguration-1)
+* [GetReplayUri](_api_replay_.onvifreplay.md#getreplayuri-1)
+* [GetServiceCapabilities](_api_replay_.onvifreplay.md#getservicecapabilities-1)
+* [SetReplayConfiguration](_api_replay_.onvifreplay.md#setreplayconfiguration-1)
 
 ---
 
@@ -35,9 +35,9 @@
 
 ###  constructor
 
-⊕ **new Replay**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Replay](_api_replay_.replay.md)
+⊕ **new ONVIFReplay**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFReplay](_api_replay_.onvifreplay.md)
 
-*Defined in [api/replay.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L5)*
+*Defined in [api/replay.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L5)*
 
 **Parameters:**
 
@@ -45,7 +45,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Replay](_api_replay_.replay.md)
+**Returns:** [ONVIFReplay](_api_replay_.onvifreplay.md)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/replay.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L6)*
+*Defined in [api/replay.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L6)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 ▸ **GetReplayConfiguration**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/replay.ts:81](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L81)*
+*Defined in [api/replay.ts:81](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L81)*
 
 Returns the current configuration of the replay service. This operation is mandatory.
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **GetReplayUri**(StreamSetup: *[StreamSetup](../interfaces/_api_types_.streamsetup.md)*, RecordingToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/replay.ts:71](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L71)*
+*Defined in [api/replay.ts:71](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L71)*
 
 Requests a URI that can be used to initiate playback of a recorded stream using RTSP as the control protocol. The URI is valid only as it is specified in the response. This operation is mandatory.
 
@@ -102,7 +102,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/replay.ts:59](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L59)*
+*Defined in [api/replay.ts:59](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L59)*
 
 Returns the capabilities of the replay service. The result is returned in a typed answer.
 
@@ -115,7 +115,7 @@ ___
 
 ▸ **SetReplayConfiguration**(Configuration: *[ReplayConfiguration](../interfaces/_api_types_.replayconfiguration.md)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/replay.ts:91](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L91)*
+*Defined in [api/replay.ts:91](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L91)*
 
 Changes the current configuration of the replay service. This operation is mandatory.
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **GetReplayConfiguration**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/replay.ts:38](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L38)*
+*Defined in [api/replay.ts:38](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L38)*
 
 Returns the current configuration of the replay service. This operation is mandatory.
 
@@ -147,7 +147,7 @@ ___
 
 ▸ **GetReplayUri**(StreamSetup: *[StreamSetup](../interfaces/_api_types_.streamsetup.md)*, RecordingToken: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/replay.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L26)*
+*Defined in [api/replay.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L26)*
 
 Requests a URI that can be used to initiate playback of a recorded stream using RTSP as the control protocol. The URI is valid only as it is specified in the response. This operation is mandatory.
 
@@ -167,7 +167,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/replay.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L12)*
+*Defined in [api/replay.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L12)*
 
 Returns the capabilities of the replay service. The result is returned in a typed answer.
 
@@ -180,7 +180,7 @@ ___
 
 ▸ **SetReplayConfiguration**(Configuration: *[ReplayConfiguration](../interfaces/_api_types_.replayconfiguration.md)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/replay.ts:50](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/replay.ts#L50)*
+*Defined in [api/replay.ts:50](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/replay.ts#L50)*
 
 Changes the current configuration of the replay service. This operation is mandatory.
 

--- a/docs/classes/_api_search_.onvifsearch.md
+++ b/docs/classes/_api_search_.onvifsearch.md
@@ -1,51 +1,51 @@
-[onvif-rx](../README.md) > ["api/search"](../modules/_api_search_.md) > [Search](../classes/_api_search_.search.md)
+[onvif-rx](../README.md) > ["api/search"](../modules/_api_search_.md) > [ONVIFSearch](../classes/_api_search_.onvifsearch.md)
 
-# Class: Search
+# Class: ONVIFSearch
 
 ## Hierarchy
 
-**Search**
+**ONVIFSearch**
 
 ## Index
 
 ### Constructors
 
-* [constructor](_api_search_.search.md#constructor)
+* [constructor](_api_search_.onvifsearch.md#constructor)
 
 ### Properties
 
-* [config](_api_search_.search.md#config)
+* [config](_api_search_.onvifsearch.md#config)
 
 ### Methods
 
-* [EndSearch](_api_search_.search.md#endsearch)
-* [FindEvents](_api_search_.search.md#findevents)
-* [FindMetadata](_api_search_.search.md#findmetadata)
-* [FindPTZPosition](_api_search_.search.md#findptzposition)
-* [FindRecordings](_api_search_.search.md#findrecordings)
-* [GetEventSearchResults](_api_search_.search.md#geteventsearchresults)
-* [GetMediaAttributes](_api_search_.search.md#getmediaattributes)
-* [GetMetadataSearchResults](_api_search_.search.md#getmetadatasearchresults)
-* [GetPTZPositionSearchResults](_api_search_.search.md#getptzpositionsearchresults)
-* [GetRecordingInformation](_api_search_.search.md#getrecordinginformation)
-* [GetRecordingSearchResults](_api_search_.search.md#getrecordingsearchresults)
-* [GetRecordingSummary](_api_search_.search.md#getrecordingsummary)
-* [GetSearchState](_api_search_.search.md#getsearchstate)
-* [GetServiceCapabilities](_api_search_.search.md#getservicecapabilities)
-* [EndSearch](_api_search_.search.md#endsearch-1)
-* [FindEvents](_api_search_.search.md#findevents-1)
-* [FindMetadata](_api_search_.search.md#findmetadata-1)
-* [FindPTZPosition](_api_search_.search.md#findptzposition-1)
-* [FindRecordings](_api_search_.search.md#findrecordings-1)
-* [GetEventSearchResults](_api_search_.search.md#geteventsearchresults-1)
-* [GetMediaAttributes](_api_search_.search.md#getmediaattributes-1)
-* [GetMetadataSearchResults](_api_search_.search.md#getmetadatasearchresults-1)
-* [GetPTZPositionSearchResults](_api_search_.search.md#getptzpositionsearchresults-1)
-* [GetRecordingInformation](_api_search_.search.md#getrecordinginformation-1)
-* [GetRecordingSearchResults](_api_search_.search.md#getrecordingsearchresults-1)
-* [GetRecordingSummary](_api_search_.search.md#getrecordingsummary-1)
-* [GetSearchState](_api_search_.search.md#getsearchstate-1)
-* [GetServiceCapabilities](_api_search_.search.md#getservicecapabilities-1)
+* [EndSearch](_api_search_.onvifsearch.md#endsearch)
+* [FindEvents](_api_search_.onvifsearch.md#findevents)
+* [FindMetadata](_api_search_.onvifsearch.md#findmetadata)
+* [FindPTZPosition](_api_search_.onvifsearch.md#findptzposition)
+* [FindRecordings](_api_search_.onvifsearch.md#findrecordings)
+* [GetEventSearchResults](_api_search_.onvifsearch.md#geteventsearchresults)
+* [GetMediaAttributes](_api_search_.onvifsearch.md#getmediaattributes)
+* [GetMetadataSearchResults](_api_search_.onvifsearch.md#getmetadatasearchresults)
+* [GetPTZPositionSearchResults](_api_search_.onvifsearch.md#getptzpositionsearchresults)
+* [GetRecordingInformation](_api_search_.onvifsearch.md#getrecordinginformation)
+* [GetRecordingSearchResults](_api_search_.onvifsearch.md#getrecordingsearchresults)
+* [GetRecordingSummary](_api_search_.onvifsearch.md#getrecordingsummary)
+* [GetSearchState](_api_search_.onvifsearch.md#getsearchstate)
+* [GetServiceCapabilities](_api_search_.onvifsearch.md#getservicecapabilities)
+* [EndSearch](_api_search_.onvifsearch.md#endsearch-1)
+* [FindEvents](_api_search_.onvifsearch.md#findevents-1)
+* [FindMetadata](_api_search_.onvifsearch.md#findmetadata-1)
+* [FindPTZPosition](_api_search_.onvifsearch.md#findptzposition-1)
+* [FindRecordings](_api_search_.onvifsearch.md#findrecordings-1)
+* [GetEventSearchResults](_api_search_.onvifsearch.md#geteventsearchresults-1)
+* [GetMediaAttributes](_api_search_.onvifsearch.md#getmediaattributes-1)
+* [GetMetadataSearchResults](_api_search_.onvifsearch.md#getmetadatasearchresults-1)
+* [GetPTZPositionSearchResults](_api_search_.onvifsearch.md#getptzpositionsearchresults-1)
+* [GetRecordingInformation](_api_search_.onvifsearch.md#getrecordinginformation-1)
+* [GetRecordingSearchResults](_api_search_.onvifsearch.md#getrecordingsearchresults-1)
+* [GetRecordingSummary](_api_search_.onvifsearch.md#getrecordingsummary-1)
+* [GetSearchState](_api_search_.onvifsearch.md#getsearchstate-1)
+* [GetServiceCapabilities](_api_search_.onvifsearch.md#getservicecapabilities-1)
 
 ---
 
@@ -55,9 +55,9 @@
 
 ###  constructor
 
-⊕ **new Search**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [Search](_api_search_.search.md)
+⊕ **new ONVIFSearch**(config: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*): [ONVIFSearch](_api_search_.onvifsearch.md)
 
-*Defined in [api/search.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L5)*
+*Defined in [api/search.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L5)*
 
 **Parameters:**
 
@@ -65,7 +65,7 @@
 | ------ | ------ |
 | config | [IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md) |
 
-**Returns:** [Search](_api_search_.search.md)
+**Returns:** [ONVIFSearch](_api_search_.onvifsearch.md)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 **● config**: *[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md)*
 
-*Defined in [api/search.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L6)*
+*Defined in [api/search.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L6)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 ▸ **EndSearch**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:418](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L418)*
+*Defined in [api/search.ts:418](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L418)*
 
 EndSearch stops and ongoing search session, causing any blocking result request to return and the SearchToken to become invalid. If the search was interrupted before completion, the point in time that the search had reached shall be returned. If the search had not yet begun, the StartPoint shall be returned. If the search was completed the original EndPoint supplied by the Find operation shall be returned. When issuing EndSearch on a FindRecordings request the EndPoint is undefined and shall not be used since the FindRecordings request doesn't have StartPoint/EndPoint. This operation is mandatory to support for a device implementing the recording search service.
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **FindEvents**(StartPoint: *`string`*, Scope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, SearchFilter: *[EventFilter](../interfaces/_api_types_.eventfilter.md)*, IncludeStartState: *`boolean`*, KeepAliveTime: *`string`*, EndPoint: *`string`*, MaxMatches: *`number`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:339](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L339)*
+*Defined in [api/search.ts:339](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L339)*
 
 FindEvents starts a search session, looking for recording events (in the scope that matches the search filter defined in the request. Results from the search are acquired using the GetEventSearchResults request, specifying the search token returned from this request. The device shall continue searching until one of the following occurs:
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **FindMetadata**(StartPoint: *`string`*, Scope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, MetadataFilter: *[MetadataFilter](../interfaces/_api_types_.metadatafilter.md)*, KeepAliveTime: *`string`*, EndPoint: *`string`*, MaxMatches: *`number`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:438](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L438)*
+*Defined in [api/search.ts:438](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L438)*
 
 FindMetadata starts a search session, looking for metadata in the scope (See 20.2.4) that matches the search filter defined in the request. Results from the search are acquired using the GetMetadataSearchResults request, specifying the search token returned from this request. The device shall continue searching until one of the following occurs:
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **FindPTZPosition**(StartPoint: *`string`*, Scope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, SearchFilter: *[PTZPositionFilter](../interfaces/_api_types_.ptzpositionfilter.md)*, KeepAliveTime: *`string`*, EndPoint: *`string`*, MaxMatches: *`number`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:377](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L377)*
+*Defined in [api/search.ts:377](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L377)*
 
 FindPTZPosition starts a search session, looking for ptz positions in the scope (See 20.2.4) that matches the search filter defined in the request. Results from the search are acquired using the GetPTZPositionSearchResults request, specifying the search token returned from this request. The device shall continue searching until one of the following occurs:
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **FindRecordings**(Scope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, KeepAliveTime: *`string`*, MaxMatches: *`number`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:299](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L299)*
+*Defined in [api/search.ts:299](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L299)*
 
 FindRecordings starts a search session, looking for recordings that matches the scope (See 20.2.4) defined in the request. Results from the search are acquired using the GetRecordingSearchResults request, specifying the search token returned from this request. The device shall continue searching until one of the following occurs: The entire time range from StartPoint to EndPoint has been searched through. The total number of matches has been found, defined by the MaxMatches parameter. The session has been ended by a client EndSession request. The session has been ended because KeepAliveTime since the last request related to this session has expired.
 
@@ -216,7 +216,7 @@ ___
 
 ▸ **GetEventSearchResults**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*, MinResults: *`number`*, MaxResults: *`number`*, WaitTime: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:357](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L357)*
+*Defined in [api/search.ts:357](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L357)*
 
 GetEventSearchResults acquires the results from a recording event search session previously initiated by a FindEvents operation. The response shall not include results already returned in previous requests for the same session. If MaxResults is specified, the response shall not contain more than MaxResults results. GetEventSearchResults shall block until:
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **GetMediaAttributes**(Time: *`string`*, RecordingTokens: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:280](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L280)*
+*Defined in [api/search.ts:280](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L280)*
 
 Returns a set of media attributes for all tracks of the specified recordings at a specified point in time. Clients using this operation shall be able to use it as a non blocking operation. A device shall set the starttime and endtime of the MediaAttributes structure to equal values if calculating this range would causes this operation to block. See MediaAttributes structure for more information. This operation is mandatory to support for a device implementing the recording search service.
 
@@ -262,7 +262,7 @@ ___
 
 ▸ **GetMetadataSearchResults**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*, MinResults: *`number`*, MaxResults: *`number`*, WaitTime: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:457](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L457)*
+*Defined in [api/search.ts:457](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L457)*
 
 GetMetadataSearchResults acquires the results from a recording search session previously initiated by a FindMetadata operation. The response shall not include results already returned in previous requests for the same session. If MaxResults is specified, the response shall not contain more than MaxResults results. GetMetadataSearchResults shall block until:
 
@@ -288,7 +288,7 @@ ___
 
 ▸ **GetPTZPositionSearchResults**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*, MinResults: *`number`*, MaxResults: *`number`*, WaitTime: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:396](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L396)*
+*Defined in [api/search.ts:396](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L396)*
 
 GetPTZPositionSearchResults acquires the results from a ptz position search session previously initiated by a FindPTZPosition operation. The response shall not include results already returned in previous requests for the same session. If MaxResults is specified, the response shall not contain more than MaxResults results. GetPTZPositionSearchResults shall block until:
 
@@ -314,7 +314,7 @@ ___
 
 ▸ **GetRecordingInformation**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:268](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L268)*
+*Defined in [api/search.ts:268](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L268)*
 
 Returns information about a single Recording specified by a RecordingToken. This operation is mandatory to support for a device implementing the recording search service.
 
@@ -333,7 +333,7 @@ ___
 
 ▸ **GetRecordingSearchResults**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*, MinResults: *`number`*, MaxResults: *`number`*, WaitTime: *`string`*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:318](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L318)*
+*Defined in [api/search.ts:318](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L318)*
 
 GetRecordingSearchResults acquires the results from a recording search session previously initiated by a FindRecordings operation. The response shall not include results already returned in previous requests for the same session. If MaxResults is specified, the response shall not contain more than MaxResults results. The number of results relates to the number of recordings. For viewing individual recorded data for a signal track use the FindEvents method. GetRecordingSearchResults shall block until:
 
@@ -359,7 +359,7 @@ ___
 
 ▸ **GetRecordingSummary**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:260](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L260)*
+*Defined in [api/search.ts:260](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L260)*
 
 GetRecordingSummary is used to get a summary description of all recorded data. This operation is mandatory to support for a device implementing the recording search service.
 
@@ -372,7 +372,7 @@ ___
 
 ▸ **GetSearchState**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:403](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L403)*
+*Defined in [api/search.ts:403](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L403)*
 
 GetSearchState returns the current state of the specified search session. This command is deprecated .
 
@@ -391,7 +391,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>
 
-*Defined in [api/search.ts:252](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L252)*
+*Defined in [api/search.ts:252](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L252)*
 
 Returns the capabilities of the search service. The result is returned in a typed answer.
 
@@ -404,7 +404,7 @@ ___
 
 ▸ **EndSearch**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:200](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L200)*
+*Defined in [api/search.ts:200](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L200)*
 
 EndSearch stops and ongoing search session, causing any blocking result request to return and the SearchToken to become invalid. If the search was interrupted before completion, the point in time that the search had reached shall be returned. If the search had not yet begun, the StartPoint shall be returned. If the search was completed the original EndPoint supplied by the Find operation shall be returned. When issuing EndSearch on a FindRecordings request the EndPoint is undefined and shall not be used since the FindRecordings request doesn't have StartPoint/EndPoint. This operation is mandatory to support for a device implementing the recording search service.
 
@@ -423,7 +423,7 @@ ___
 
 ▸ **FindEvents**(StartPoint: *`string`*, Scope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, SearchFilter: *[EventFilter](../interfaces/_api_types_.eventfilter.md)*, IncludeStartState: *`boolean`*, KeepAliveTime: *`string`*, EndPoint?: *`undefined` \| `string`*, MaxMatches?: *`undefined` \| `number`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:111](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L111)*
+*Defined in [api/search.ts:111](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L111)*
 
 FindEvents starts a search session, looking for recording events (in the scope that matches the search filter defined in the request. Results from the search are acquired using the GetEventSearchResults request, specifying the search token returned from this request. The device shall continue searching until one of the following occurs:
 
@@ -452,7 +452,7 @@ ___
 
 ▸ **FindMetadata**(StartPoint: *`string`*, Scope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, MetadataFilter: *[MetadataFilter](../interfaces/_api_types_.metadatafilter.md)*, KeepAliveTime: *`string`*, EndPoint?: *`undefined` \| `string`*, MaxMatches?: *`undefined` \| `number`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:222](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L222)*
+*Defined in [api/search.ts:222](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L222)*
 
 FindMetadata starts a search session, looking for metadata in the scope (See 20.2.4) that matches the search filter defined in the request. Results from the search are acquired using the GetMetadataSearchResults request, specifying the search token returned from this request. The device shall continue searching until one of the following occurs:
 
@@ -480,7 +480,7 @@ ___
 
 ▸ **FindPTZPosition**(StartPoint: *`string`*, Scope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, SearchFilter: *[PTZPositionFilter](../interfaces/_api_types_.ptzpositionfilter.md)*, KeepAliveTime: *`string`*, EndPoint?: *`undefined` \| `string`*, MaxMatches?: *`undefined` \| `number`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:153](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L153)*
+*Defined in [api/search.ts:153](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L153)*
 
 FindPTZPosition starts a search session, looking for ptz positions in the scope (See 20.2.4) that matches the search filter defined in the request. Results from the search are acquired using the GetPTZPositionSearchResults request, specifying the search token returned from this request. The device shall continue searching until one of the following occurs:
 
@@ -508,7 +508,7 @@ ___
 
 ▸ **FindRecordings**(Scope: *[SearchScope](../interfaces/_api_types_.searchscope.md)*, KeepAliveTime: *`string`*, MaxMatches?: *`undefined` \| `number`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:67](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L67)*
+*Defined in [api/search.ts:67](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L67)*
 
 FindRecordings starts a search session, looking for recordings that matches the scope (See 20.2.4) defined in the request. Results from the search are acquired using the GetRecordingSearchResults request, specifying the search token returned from this request. The device shall continue searching until one of the following occurs: The entire time range from StartPoint to EndPoint has been searched through. The total number of matches has been found, defined by the MaxMatches parameter. The session has been ended by a client EndSession request. The session has been ended because KeepAliveTime since the last request related to this session has expired.
 
@@ -531,7 +531,7 @@ ___
 
 ▸ **GetEventSearchResults**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*, MinResults?: *`undefined` \| `number`*, MaxResults?: *`undefined` \| `number`*, WaitTime?: *`undefined` \| `string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:131](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L131)*
+*Defined in [api/search.ts:131](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L131)*
 
 GetEventSearchResults acquires the results from a recording event search session previously initiated by a FindEvents operation. The response shall not include results already returned in previous requests for the same session. If MaxResults is specified, the response shall not contain more than MaxResults results. GetEventSearchResults shall block until:
 
@@ -557,7 +557,7 @@ ___
 
 ▸ **GetMediaAttributes**(Time: *`string`*, RecordingTokens?: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L46)*
+*Defined in [api/search.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L46)*
 
 Returns a set of media attributes for all tracks of the specified recordings at a specified point in time. Clients using this operation shall be able to use it as a non blocking operation. A device shall set the starttime and endtime of the MediaAttributes structure to equal values if calculating this range would causes this operation to block. See MediaAttributes structure for more information. This operation is mandatory to support for a device implementing the recording search service.
 
@@ -577,7 +577,7 @@ ___
 
 ▸ **GetMetadataSearchResults**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*, MinResults?: *`undefined` \| `number`*, MaxResults?: *`undefined` \| `number`*, WaitTime?: *`undefined` \| `string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:243](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L243)*
+*Defined in [api/search.ts:243](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L243)*
 
 GetMetadataSearchResults acquires the results from a recording search session previously initiated by a FindMetadata operation. The response shall not include results already returned in previous requests for the same session. If MaxResults is specified, the response shall not contain more than MaxResults results. GetMetadataSearchResults shall block until:
 
@@ -603,7 +603,7 @@ ___
 
 ▸ **GetPTZPositionSearchResults**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*, MinResults?: *`undefined` \| `number`*, MaxResults?: *`undefined` \| `number`*, WaitTime?: *`undefined` \| `string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:174](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L174)*
+*Defined in [api/search.ts:174](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L174)*
 
 GetPTZPositionSearchResults acquires the results from a ptz position search session previously initiated by a FindPTZPosition operation. The response shall not include results already returned in previous requests for the same session. If MaxResults is specified, the response shall not contain more than MaxResults results. GetPTZPositionSearchResults shall block until:
 
@@ -629,7 +629,7 @@ ___
 
 ▸ **GetRecordingInformation**(RecordingToken: *[RecordingReference](../modules/_api_types_.md#recordingreference)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:32](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L32)*
+*Defined in [api/search.ts:32](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L32)*
 
 Returns information about a single Recording specified by a RecordingToken. This operation is mandatory to support for a device implementing the recording search service.
 
@@ -648,7 +648,7 @@ ___
 
 ▸ **GetRecordingSearchResults**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*, MinResults?: *`undefined` \| `number`*, MaxResults?: *`undefined` \| `number`*, WaitTime?: *`undefined` \| `string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:88](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L88)*
+*Defined in [api/search.ts:88](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L88)*
 
 GetRecordingSearchResults acquires the results from a recording search session previously initiated by a FindRecordings operation. The response shall not include results already returned in previous requests for the same session. If MaxResults is specified, the response shall not contain more than MaxResults results. The number of results relates to the number of recordings. For viewing individual recorded data for a signal track use the FindEvents method. GetRecordingSearchResults shall block until:
 
@@ -674,7 +674,7 @@ ___
 
 ▸ **GetRecordingSummary**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:22](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L22)*
+*Defined in [api/search.ts:22](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L22)*
 
 GetRecordingSummary is used to get a summary description of all recorded data. This operation is mandatory to support for a device implementing the recording search service.
 
@@ -687,7 +687,7 @@ ___
 
 ▸ **GetSearchState**(SearchToken: *[JobToken](../interfaces/_api_types_.getrecordingjobsresponseitem.md#jobtoken)*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:183](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L183)*
+*Defined in [api/search.ts:183](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L183)*
 
 GetSearchState returns the current state of the specified search session. This command is deprecated .
 
@@ -706,7 +706,7 @@ ___
 
 ▸ **GetServiceCapabilities**(): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`any`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [api/search.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/search.ts#L12)*
+*Defined in [api/search.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/search.ts#L12)*
 
 Returns the capabilities of the search service. The result is returned in a typed answer.
 

--- a/docs/enums/_api_types_.audioencoding.md
+++ b/docs/enums/_api_types_.audioencoding.md
@@ -20,7 +20,7 @@
 
 **AAC**:  = "AAC"
 
-*Defined in [api/types.ts:4469](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4469)*
+*Defined in [api/types.ts:4469](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4469)*
 
 ___
 <a id="g711"></a>
@@ -29,7 +29,7 @@ ___
 
 **G711**:  = "G711"
 
-*Defined in [api/types.ts:4461](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4461)*
+*Defined in [api/types.ts:4461](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4461)*
 
 ___
 <a id="g726"></a>
@@ -38,7 +38,7 @@ ___
 
 **G726**:  = "G726"
 
-*Defined in [api/types.ts:4465](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4465)*
+*Defined in [api/types.ts:4465](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4465)*
 
 ___
 

--- a/docs/enums/_api_types_.audioencodingmimenames.md
+++ b/docs/enums/_api_types_.audioencodingmimenames.md
@@ -22,7 +22,7 @@ Audio Media Subtypes as referenced by IANA (without the leading "audio/" Audio M
 
 **G726**:  = "G726"
 
-*Defined in [api/types.ts:4483](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4483)*
+*Defined in [api/types.ts:4483](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4483)*
 
 ___
 <a id="mp4a_latm"></a>
@@ -31,7 +31,7 @@ ___
 
 **MP4A-LATM**:  = "MP4A-LATM"
 
-*Defined in [api/types.ts:4487](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4487)*
+*Defined in [api/types.ts:4487](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4487)*
 
 ___
 <a id="pcmu"></a>
@@ -40,7 +40,7 @@ ___
 
 **PCMU**:  = "PCMU"
 
-*Defined in [api/types.ts:4479](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4479)*
+*Defined in [api/types.ts:4479](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4479)*
 
 ___
 

--- a/docs/enums/_api_types_.autofocusmode.md
+++ b/docs/enums/_api_types_.autofocusmode.md
@@ -19,7 +19,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:5075](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5075)*
+*Defined in [api/types.ts:5075](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5075)*
 
 ___
 <a id="manual"></a>
@@ -28,7 +28,7 @@ ___
 
 **MANUAL**:  = "MANUAL"
 
-*Defined in [api/types.ts:5079](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5079)*
+*Defined in [api/types.ts:5079](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5079)*
 
 ___
 

--- a/docs/enums/_api_types_.backlightcompensationmode.md
+++ b/docs/enums/_api_types_.backlightcompensationmode.md
@@ -21,7 +21,7 @@ Enumeration describing the available backlight compenstation modes.
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:5103](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5103)*
+*Defined in [api/types.ts:5103](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5103)*
 
 Backlight compensation is disabled.
 
@@ -32,7 +32,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:5107](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5107)*
+*Defined in [api/types.ts:5107](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5107)*
 
 Backlight compensation is enabled.
 

--- a/docs/enums/_api_types_.capabilitycategory.md
+++ b/docs/enums/_api_types_.capabilitycategory.md
@@ -24,7 +24,7 @@
 
 **All**:  = "All"
 
-*Defined in [api/types.ts:4815](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4815)*
+*Defined in [api/types.ts:4815](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4815)*
 
 ___
 <a id="analytics"></a>
@@ -33,7 +33,7 @@ ___
 
 **Analytics**:  = "Analytics"
 
-*Defined in [api/types.ts:4819](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4819)*
+*Defined in [api/types.ts:4819](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4819)*
 
 ___
 <a id="device"></a>
@@ -42,7 +42,7 @@ ___
 
 **Device**:  = "Device"
 
-*Defined in [api/types.ts:4823](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4823)*
+*Defined in [api/types.ts:4823](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4823)*
 
 ___
 <a id="events"></a>
@@ -51,7 +51,7 @@ ___
 
 **Events**:  = "Events"
 
-*Defined in [api/types.ts:4827](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4827)*
+*Defined in [api/types.ts:4827](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4827)*
 
 ___
 <a id="imaging"></a>
@@ -60,7 +60,7 @@ ___
 
 **Imaging**:  = "Imaging"
 
-*Defined in [api/types.ts:4831](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4831)*
+*Defined in [api/types.ts:4831](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4831)*
 
 ___
 <a id="media"></a>
@@ -69,7 +69,7 @@ ___
 
 **Media**:  = "Media"
 
-*Defined in [api/types.ts:4835](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4835)*
+*Defined in [api/types.ts:4835](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4835)*
 
 ___
 <a id="ptz"></a>
@@ -78,7 +78,7 @@ ___
 
 **PTZ**:  = "PTZ"
 
-*Defined in [api/types.ts:4839](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4839)*
+*Defined in [api/types.ts:4839](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4839)*
 
 ___
 

--- a/docs/enums/_api_types_.defoggingmode.md
+++ b/docs/enums/_api_types_.defoggingmode.md
@@ -20,7 +20,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:5261](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5261)*
+*Defined in [api/types.ts:5261](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5261)*
 
 ___
 <a id="off"></a>
@@ -29,7 +29,7 @@ ___
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:5253](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5253)*
+*Defined in [api/types.ts:5253](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5253)*
 
 ___
 <a id="on"></a>
@@ -38,7 +38,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:5257](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5257)*
+*Defined in [api/types.ts:5257](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5257)*
 
 ___
 

--- a/docs/enums/_api_types_.digitalidlestate.md
+++ b/docs/enums/_api_types_.digitalidlestate.md
@@ -19,7 +19,7 @@
 
 **closed**:  = "closed"
 
-*Defined in [api/types.ts:4959](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4959)*
+*Defined in [api/types.ts:4959](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4959)*
 
 ___
 <a id="open"></a>
@@ -28,7 +28,7 @@ ___
 
 **open**:  = "open"
 
-*Defined in [api/types.ts:4963](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4963)*
+*Defined in [api/types.ts:4963](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4963)*
 
 ___
 

--- a/docs/enums/_api_types_.direction.md
+++ b/docs/enums/_api_types_.direction.md
@@ -20,7 +20,7 @@
 
 **Any**:  = "Any"
 
-*Defined in [api/types.ts:5297](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5297)*
+*Defined in [api/types.ts:5297](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5297)*
 
 ___
 <a id="left"></a>
@@ -29,7 +29,7 @@ ___
 
 **Left**:  = "Left"
 
-*Defined in [api/types.ts:5289](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5289)*
+*Defined in [api/types.ts:5289](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5289)*
 
 ___
 <a id="right"></a>
@@ -38,7 +38,7 @@ ___
 
 **Right**:  = "Right"
 
-*Defined in [api/types.ts:5293](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5293)*
+*Defined in [api/types.ts:5293](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5293)*
 
 ___
 

--- a/docs/enums/_api_types_.discoverymode.md
+++ b/docs/enums/_api_types_.discoverymode.md
@@ -19,7 +19,7 @@
 
 **Discoverable**:  = "Discoverable"
 
-*Defined in [api/types.ts:4565](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4565)*
+*Defined in [api/types.ts:4565](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4565)*
 
 ___
 <a id="nondiscoverable"></a>
@@ -28,7 +28,7 @@ ___
 
 **NonDiscoverable**:  = "NonDiscoverable"
 
-*Defined in [api/types.ts:4569](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4569)*
+*Defined in [api/types.ts:4569](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4569)*
 
 ___
 

--- a/docs/enums/_api_types_.dot11authandmangementsuite.md
+++ b/docs/enums/_api_types_.dot11authandmangementsuite.md
@@ -21,7 +21,7 @@
 
 **Dot1X**:  = "Dot1X"
 
-*Defined in [api/types.ts:4797](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4797)*
+*Defined in [api/types.ts:4797](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4797)*
 
 ___
 <a id="extended"></a>
@@ -30,7 +30,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4805](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4805)*
+*Defined in [api/types.ts:4805](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4805)*
 
 ___
 <a id="none"></a>
@@ -39,7 +39,7 @@ ___
 
 **None**:  = "None"
 
-*Defined in [api/types.ts:4793](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4793)*
+*Defined in [api/types.ts:4793](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4793)*
 
 ___
 <a id="psk"></a>
@@ -48,7 +48,7 @@ ___
 
 **PSK**:  = "PSK"
 
-*Defined in [api/types.ts:4801](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4801)*
+*Defined in [api/types.ts:4801](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4801)*
 
 ___
 

--- a/docs/enums/_api_types_.dot11cipher.md
+++ b/docs/enums/_api_types_.dot11cipher.md
@@ -21,7 +21,7 @@
 
 **Any**:  = "Any"
 
-*Defined in [api/types.ts:4749](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4749)*
+*Defined in [api/types.ts:4749](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4749)*
 
 ___
 <a id="ccmp"></a>
@@ -30,7 +30,7 @@ ___
 
 **CCMP**:  = "CCMP"
 
-*Defined in [api/types.ts:4741](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4741)*
+*Defined in [api/types.ts:4741](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4741)*
 
 ___
 <a id="extended"></a>
@@ -39,7 +39,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4753](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4753)*
+*Defined in [api/types.ts:4753](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4753)*
 
 ___
 <a id="tkip"></a>
@@ -48,7 +48,7 @@ ___
 
 **TKIP**:  = "TKIP"
 
-*Defined in [api/types.ts:4745](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4745)*
+*Defined in [api/types.ts:4745](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4745)*
 
 ___
 

--- a/docs/enums/_api_types_.dot11securitymode.md
+++ b/docs/enums/_api_types_.dot11securitymode.md
@@ -22,7 +22,7 @@
 
 **Dot1X**:  = "Dot1X"
 
-*Defined in [api/types.ts:4727](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4727)*
+*Defined in [api/types.ts:4727](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4727)*
 
 ___
 <a id="extended"></a>
@@ -31,7 +31,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4731](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4731)*
+*Defined in [api/types.ts:4731](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4731)*
 
 ___
 <a id="none"></a>
@@ -40,7 +40,7 @@ ___
 
 **None**:  = "None"
 
-*Defined in [api/types.ts:4715](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4715)*
+*Defined in [api/types.ts:4715](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4715)*
 
 ___
 <a id="psk"></a>
@@ -49,7 +49,7 @@ ___
 
 **PSK**:  = "PSK"
 
-*Defined in [api/types.ts:4723](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4723)*
+*Defined in [api/types.ts:4723](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4723)*
 
 ___
 <a id="wep"></a>
@@ -58,7 +58,7 @@ ___
 
 **WEP**:  = "WEP"
 
-*Defined in [api/types.ts:4719](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4719)*
+*Defined in [api/types.ts:4719](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4719)*
 
 ___
 

--- a/docs/enums/_api_types_.dot11signalstrength.md
+++ b/docs/enums/_api_types_.dot11signalstrength.md
@@ -23,7 +23,7 @@
 
 **Bad**:  = "Bad"
 
-*Defined in [api/types.ts:4771](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4771)*
+*Defined in [api/types.ts:4771](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4771)*
 
 ___
 <a id="extended"></a>
@@ -32,7 +32,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4783](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4783)*
+*Defined in [api/types.ts:4783](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4783)*
 
 ___
 <a id="good"></a>
@@ -41,7 +41,7 @@ ___
 
 **Good**:  = "Good"
 
-*Defined in [api/types.ts:4775](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4775)*
+*Defined in [api/types.ts:4775](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4775)*
 
 ___
 <a id="none"></a>
@@ -50,7 +50,7 @@ ___
 
 **None**:  = "None"
 
-*Defined in [api/types.ts:4763](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4763)*
+*Defined in [api/types.ts:4763](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4763)*
 
 ___
 <a id="very_bad"></a>
@@ -59,7 +59,7 @@ ___
 
 **Very Bad**:  = "Very Bad"
 
-*Defined in [api/types.ts:4767](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4767)*
+*Defined in [api/types.ts:4767](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4767)*
 
 ___
 <a id="very_good"></a>
@@ -68,7 +68,7 @@ ___
 
 **Very Good**:  = "Very Good"
 
-*Defined in [api/types.ts:4779](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4779)*
+*Defined in [api/types.ts:4779](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4779)*
 
 ___
 

--- a/docs/enums/_api_types_.dot11stationmode.md
+++ b/docs/enums/_api_types_.dot11stationmode.md
@@ -20,7 +20,7 @@
 
 **Ad-hoc**:  = "Ad-hoc"
 
-*Defined in [api/types.ts:4697](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4697)*
+*Defined in [api/types.ts:4697](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4697)*
 
 ___
 <a id="extended"></a>
@@ -29,7 +29,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4705](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4705)*
+*Defined in [api/types.ts:4705](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4705)*
 
 ___
 <a id="infrastructure"></a>
@@ -38,7 +38,7 @@ ___
 
 **Infrastructure**:  = "Infrastructure"
 
-*Defined in [api/types.ts:4701](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4701)*
+*Defined in [api/types.ts:4701](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4701)*
 
 ___
 

--- a/docs/enums/_api_types_.duplex.md
+++ b/docs/enums/_api_types_.duplex.md
@@ -19,7 +19,7 @@
 
 **Full**:  = "Full"
 
-*Defined in [api/types.ts:4579](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4579)*
+*Defined in [api/types.ts:4579](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4579)*
 
 ___
 <a id="half"></a>
@@ -28,7 +28,7 @@ ___
 
 **Half**:  = "Half"
 
-*Defined in [api/types.ts:4583](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4583)*
+*Defined in [api/types.ts:4583](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4583)*
 
 ___
 

--- a/docs/enums/_api_types_.dynamicdnstype.md
+++ b/docs/enums/_api_types_.dynamicdnstype.md
@@ -20,7 +20,7 @@
 
 **ClientUpdates**:  = "ClientUpdates"
 
-*Defined in [api/types.ts:4683](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4683)*
+*Defined in [api/types.ts:4683](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4683)*
 
 ___
 <a id="noupdate"></a>
@@ -29,7 +29,7 @@ ___
 
 **NoUpdate**:  = "NoUpdate"
 
-*Defined in [api/types.ts:4679](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4679)*
+*Defined in [api/types.ts:4679](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4679)*
 
 ___
 <a id="serverupdates"></a>
@@ -38,7 +38,7 @@ ___
 
 **ServerUpdates**:  = "ServerUpdates"
 
-*Defined in [api/types.ts:4687](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4687)*
+*Defined in [api/types.ts:4687](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4687)*
 
 ___
 

--- a/docs/enums/_api_types_.eflipmode.md
+++ b/docs/enums/_api_types_.eflipmode.md
@@ -20,7 +20,7 @@
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4981](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4981)*
+*Defined in [api/types.ts:4981](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4981)*
 
 ___
 <a id="off"></a>
@@ -29,7 +29,7 @@ ___
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:4973](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4973)*
+*Defined in [api/types.ts:4973](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4973)*
 
 ___
 <a id="on"></a>
@@ -38,7 +38,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:4977](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4977)*
+*Defined in [api/types.ts:4977](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4977)*
 
 ___
 

--- a/docs/enums/_api_types_.enabled.md
+++ b/docs/enums/_api_types_.enabled.md
@@ -19,7 +19,7 @@
 
 **DISABLED**:  = "DISABLED"
 
-*Defined in [api/types.ts:5149](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5149)*
+*Defined in [api/types.ts:5149](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5149)*
 
 ___
 <a id="enabled"></a>
@@ -28,7 +28,7 @@ ___
 
 **ENABLED**:  = "ENABLED"
 
-*Defined in [api/types.ts:5145](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5145)*
+*Defined in [api/types.ts:5145](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5145)*
 
 ___
 

--- a/docs/enums/_api_types_.entity.md
+++ b/docs/enums/_api_types_.entity.md
@@ -20,7 +20,7 @@
 
 **AudioSource**:  = "AudioSource"
 
-*Defined in [api/types.ts:4251](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4251)*
+*Defined in [api/types.ts:4251](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4251)*
 
 ___
 <a id="device"></a>
@@ -29,7 +29,7 @@ ___
 
 **Device**:  = "Device"
 
-*Defined in [api/types.ts:4243](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4243)*
+*Defined in [api/types.ts:4243](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4243)*
 
 ___
 <a id="videosource"></a>
@@ -38,7 +38,7 @@ ___
 
 **VideoSource**:  = "VideoSource"
 
-*Defined in [api/types.ts:4247](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4247)*
+*Defined in [api/types.ts:4247](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4247)*
 
 ___
 

--- a/docs/enums/_api_types_.exposuremode.md
+++ b/docs/enums/_api_types_.exposuremode.md
@@ -19,7 +19,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:5131](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5131)*
+*Defined in [api/types.ts:5131](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5131)*
 
 ___
 <a id="manual"></a>
@@ -28,7 +28,7 @@ ___
 
 **MANUAL**:  = "MANUAL"
 
-*Defined in [api/types.ts:5135](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5135)*
+*Defined in [api/types.ts:5135](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5135)*
 
 ___
 

--- a/docs/enums/_api_types_.exposurepriority.md
+++ b/docs/enums/_api_types_.exposurepriority.md
@@ -19,7 +19,7 @@
 
 **FrameRate**:  = "FrameRate"
 
-*Defined in [api/types.ts:5121](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5121)*
+*Defined in [api/types.ts:5121](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5121)*
 
 ___
 <a id="lownoise"></a>
@@ -28,7 +28,7 @@ ___
 
 **LowNoise**:  = "LowNoise"
 
-*Defined in [api/types.ts:5117](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5117)*
+*Defined in [api/types.ts:5117](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5117)*
 
 ___
 

--- a/docs/enums/_api_types_.factorydefaulttype.md
+++ b/docs/enums/_api_types_.factorydefaulttype.md
@@ -21,7 +21,7 @@ Enumeration describing the available factory default modes.
 
 **Hard**:  = "Hard"
 
-*Defined in [api/types.ts:4863](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4863)*
+*Defined in [api/types.ts:4863](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4863)*
 
 Indicates that a hard factory default is requested.
 
@@ -32,7 +32,7 @@ ___
 
 **Soft**:  = "Soft"
 
-*Defined in [api/types.ts:4867](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4867)*
+*Defined in [api/types.ts:4867](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4867)*
 
 Indicates that a soft factory default is requested.
 

--- a/docs/enums/_api_types_.h264profile.md
+++ b/docs/enums/_api_types_.h264profile.md
@@ -21,7 +21,7 @@
 
 **Baseline**:  = "Baseline"
 
-*Defined in [api/types.ts:4383](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4383)*
+*Defined in [api/types.ts:4383](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4383)*
 
 ___
 <a id="extended"></a>
@@ -30,7 +30,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4391](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4391)*
+*Defined in [api/types.ts:4391](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4391)*
 
 ___
 <a id="high"></a>
@@ -39,7 +39,7 @@ ___
 
 **High**:  = "High"
 
-*Defined in [api/types.ts:4395](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4395)*
+*Defined in [api/types.ts:4395](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4395)*
 
 ___
 <a id="main"></a>
@@ -48,7 +48,7 @@ ___
 
 **Main**:  = "Main"
 
-*Defined in [api/types.ts:4387](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4387)*
+*Defined in [api/types.ts:4387](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4387)*
 
 ___
 

--- a/docs/enums/_api_types_.imagestabilizationmode.md
+++ b/docs/enums/_api_types_.imagestabilizationmode.md
@@ -21,7 +21,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:5199](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5199)*
+*Defined in [api/types.ts:5199](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5199)*
 
 ___
 <a id="extended"></a>
@@ -30,7 +30,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:5203](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5203)*
+*Defined in [api/types.ts:5203](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5203)*
 
 ___
 <a id="off"></a>
@@ -39,7 +39,7 @@ ___
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:5191](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5191)*
+*Defined in [api/types.ts:5191](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5191)*
 
 ___
 <a id="on"></a>
@@ -48,7 +48,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:5195](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5195)*
+*Defined in [api/types.ts:5195](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5195)*
 
 ___
 

--- a/docs/enums/_api_types_.ipaddressfiltertype.md
+++ b/docs/enums/_api_types_.ipaddressfiltertype.md
@@ -19,7 +19,7 @@
 
 **Allow**:  = "Allow"
 
-*Defined in [api/types.ts:4665](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4665)*
+*Defined in [api/types.ts:4665](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4665)*
 
 ___
 <a id="deny"></a>
@@ -28,7 +28,7 @@ ___
 
 **Deny**:  = "Deny"
 
-*Defined in [api/types.ts:4669](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4669)*
+*Defined in [api/types.ts:4669](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4669)*
 
 ___
 

--- a/docs/enums/_api_types_.iptype.md
+++ b/docs/enums/_api_types_.iptype.md
@@ -19,7 +19,7 @@
 
 **IPv4**:  = "IPv4"
 
-*Defined in [api/types.ts:4651](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4651)*
+*Defined in [api/types.ts:4651](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4651)*
 
 ___
 <a id="ipv6"></a>
@@ -28,7 +28,7 @@ ___
 
 **IPv6**:  = "IPv6"
 
-*Defined in [api/types.ts:4655](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4655)*
+*Defined in [api/types.ts:4655](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4655)*
 
 ___
 

--- a/docs/enums/_api_types_.ipv6dhcpconfiguration.md
+++ b/docs/enums/_api_types_.ipv6dhcpconfiguration.md
@@ -21,7 +21,7 @@
 
 **Auto**:  = "Auto"
 
-*Defined in [api/types.ts:4593](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4593)*
+*Defined in [api/types.ts:4593](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4593)*
 
 ___
 <a id="off"></a>
@@ -30,7 +30,7 @@ ___
 
 **Off**:  = "Off"
 
-*Defined in [api/types.ts:4605](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4605)*
+*Defined in [api/types.ts:4605](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4605)*
 
 ___
 <a id="stateful"></a>
@@ -39,7 +39,7 @@ ___
 
 **Stateful**:  = "Stateful"
 
-*Defined in [api/types.ts:4597](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4597)*
+*Defined in [api/types.ts:4597](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4597)*
 
 ___
 <a id="stateless"></a>
@@ -48,7 +48,7 @@ ___
 
 **Stateless**:  = "Stateless"
 
-*Defined in [api/types.ts:4601](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4601)*
+*Defined in [api/types.ts:4601](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4601)*
 
 ___
 

--- a/docs/enums/_api_types_.ircutfilterautoboundarytype.md
+++ b/docs/enums/_api_types_.ircutfilterautoboundarytype.md
@@ -21,7 +21,7 @@
 
 **Common**:  = "Common"
 
-*Defined in [api/types.ts:5213](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5213)*
+*Defined in [api/types.ts:5213](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5213)*
 
 ___
 <a id="extended"></a>
@@ -30,7 +30,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:5225](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5225)*
+*Defined in [api/types.ts:5225](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5225)*
 
 ___
 <a id="tooff"></a>
@@ -39,7 +39,7 @@ ___
 
 **ToOff**:  = "ToOff"
 
-*Defined in [api/types.ts:5221](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5221)*
+*Defined in [api/types.ts:5221](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5221)*
 
 ___
 <a id="toon"></a>
@@ -48,7 +48,7 @@ ___
 
 **ToOn**:  = "ToOn"
 
-*Defined in [api/types.ts:5217](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5217)*
+*Defined in [api/types.ts:5217](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5217)*
 
 ___
 

--- a/docs/enums/_api_types_.ircutfiltermode.md
+++ b/docs/enums/_api_types_.ircutfiltermode.md
@@ -20,7 +20,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:5181](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5181)*
+*Defined in [api/types.ts:5181](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5181)*
 
 ___
 <a id="off"></a>
@@ -29,7 +29,7 @@ ___
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:5177](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5177)*
+*Defined in [api/types.ts:5177](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5177)*
 
 ___
 <a id="on"></a>
@@ -38,7 +38,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:5173](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5173)*
+*Defined in [api/types.ts:5173](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5173)*
 
 ___
 

--- a/docs/enums/_api_types_.metadatacompressiontype.md
+++ b/docs/enums/_api_types_.metadatacompressiontype.md
@@ -20,7 +20,7 @@
 
 **EXI**:  = "EXI"
 
-*Defined in [api/types.ts:4505](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4505)*
+*Defined in [api/types.ts:4505](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4505)*
 
 ___
 <a id="gzip"></a>
@@ -29,7 +29,7 @@ ___
 
 **GZIP**:  = "GZIP"
 
-*Defined in [api/types.ts:4501](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4501)*
+*Defined in [api/types.ts:4501](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4501)*
 
 ___
 <a id="none"></a>
@@ -38,7 +38,7 @@ ___
 
 **None**:  = "None"
 
-*Defined in [api/types.ts:4497](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4497)*
+*Defined in [api/types.ts:4497](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4497)*
 
 ___
 

--- a/docs/enums/_api_types_.modeofoperation.md
+++ b/docs/enums/_api_types_.modeofoperation.md
@@ -22,7 +22,7 @@ This case should never happen.
 
 **Active**:  = "Active"
 
-*Defined in [api/types.ts:5433](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5433)*
+*Defined in [api/types.ts:5433](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5433)*
 
 ___
 <a id="idle"></a>
@@ -31,7 +31,7 @@ ___
 
 **Idle**:  = "Idle"
 
-*Defined in [api/types.ts:5429](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5429)*
+*Defined in [api/types.ts:5429](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5429)*
 
 ___
 <a id="unknown"></a>
@@ -40,7 +40,7 @@ ___
 
 **Unknown**:  = "Unknown"
 
-*Defined in [api/types.ts:5437](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5437)*
+*Defined in [api/types.ts:5437](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5437)*
 
 This case should never happen.
 

--- a/docs/enums/_api_types_.movestatus.md
+++ b/docs/enums/_api_types_.movestatus.md
@@ -20,7 +20,7 @@
 
 **IDLE**:  = "IDLE"
 
-*Defined in [api/types.ts:4225](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4225)*
+*Defined in [api/types.ts:4225](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4225)*
 
 ___
 <a id="moving"></a>
@@ -29,7 +29,7 @@ ___
 
 **MOVING**:  = "MOVING"
 
-*Defined in [api/types.ts:4229](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4229)*
+*Defined in [api/types.ts:4229](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4229)*
 
 ___
 <a id="unknown"></a>
@@ -38,7 +38,7 @@ ___
 
 **UNKNOWN**:  = "UNKNOWN"
 
-*Defined in [api/types.ts:4233](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4233)*
+*Defined in [api/types.ts:4233](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4233)*
 
 ___
 

--- a/docs/enums/_api_types_.mpeg4profile.md
+++ b/docs/enums/_api_types_.mpeg4profile.md
@@ -19,7 +19,7 @@
 
 **ASP**:  = "ASP"
 
-*Defined in [api/types.ts:4373](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4373)*
+*Defined in [api/types.ts:4373](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4373)*
 
 ___
 <a id="sp"></a>
@@ -28,7 +28,7 @@ ___
 
 **SP**:  = "SP"
 
-*Defined in [api/types.ts:4369](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4369)*
+*Defined in [api/types.ts:4369](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4369)*
 
 ___
 

--- a/docs/enums/_api_types_.networkhosttype.md
+++ b/docs/enums/_api_types_.networkhosttype.md
@@ -20,7 +20,7 @@
 
 **DNS**:  = "DNS"
 
-*Defined in [api/types.ts:4641](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4641)*
+*Defined in [api/types.ts:4641](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4641)*
 
 ___
 <a id="ipv4"></a>
@@ -29,7 +29,7 @@ ___
 
 **IPv4**:  = "IPv4"
 
-*Defined in [api/types.ts:4633](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4633)*
+*Defined in [api/types.ts:4633](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4633)*
 
 ___
 <a id="ipv6"></a>
@@ -38,7 +38,7 @@ ___
 
 **IPv6**:  = "IPv6"
 
-*Defined in [api/types.ts:4637](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4637)*
+*Defined in [api/types.ts:4637](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4637)*
 
 ___
 

--- a/docs/enums/_api_types_.networkprotocoltype.md
+++ b/docs/enums/_api_types_.networkprotocoltype.md
@@ -20,7 +20,7 @@
 
 **HTTP**:  = "HTTP"
 
-*Defined in [api/types.ts:4615](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4615)*
+*Defined in [api/types.ts:4615](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4615)*
 
 ___
 <a id="https"></a>
@@ -29,7 +29,7 @@ ___
 
 **HTTPS**:  = "HTTPS"
 
-*Defined in [api/types.ts:4619](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4619)*
+*Defined in [api/types.ts:4619](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4619)*
 
 ___
 <a id="rtsp"></a>
@@ -38,7 +38,7 @@ ___
 
 **RTSP**:  = "RTSP"
 
-*Defined in [api/types.ts:4623](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4623)*
+*Defined in [api/types.ts:4623](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4623)*
 
 ___
 

--- a/docs/enums/_api_types_.osdtype.md
+++ b/docs/enums/_api_types_.osdtype.md
@@ -20,7 +20,7 @@
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:5455](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5455)*
+*Defined in [api/types.ts:5455](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5455)*
 
 ___
 <a id="image"></a>
@@ -29,7 +29,7 @@ ___
 
 **Image**:  = "Image"
 
-*Defined in [api/types.ts:5451](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5451)*
+*Defined in [api/types.ts:5451](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5451)*
 
 ___
 <a id="text"></a>
@@ -38,7 +38,7 @@ ___
 
 **Text**:  = "Text"
 
-*Defined in [api/types.ts:5447](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5447)*
+*Defined in [api/types.ts:5447](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5447)*
 
 ___
 

--- a/docs/enums/_api_types_.propertyoperation.md
+++ b/docs/enums/_api_types_.propertyoperation.md
@@ -20,7 +20,7 @@
 
 **Changed**:  = "Changed"
 
-*Defined in [api/types.ts:5279](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5279)*
+*Defined in [api/types.ts:5279](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5279)*
 
 ___
 <a id="deleted"></a>
@@ -29,7 +29,7 @@ ___
 
 **Deleted**:  = "Deleted"
 
-*Defined in [api/types.ts:5275](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5275)*
+*Defined in [api/types.ts:5275](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5275)*
 
 ___
 <a id="initialized"></a>
@@ -38,7 +38,7 @@ ___
 
 **Initialized**:  = "Initialized"
 
-*Defined in [api/types.ts:5271](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5271)*
+*Defined in [api/types.ts:5271](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5271)*
 
 ___
 

--- a/docs/enums/_api_types_.ptzpresettourdirection.md
+++ b/docs/enums/_api_types_.ptzpresettourdirection.md
@@ -20,7 +20,7 @@
 
 **Backward**:  = "Backward"
 
-*Defined in [api/types.ts:5039](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5039)*
+*Defined in [api/types.ts:5039](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5039)*
 
 ___
 <a id="extended"></a>
@@ -29,7 +29,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:5043](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5043)*
+*Defined in [api/types.ts:5043](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5043)*
 
 ___
 <a id="forward"></a>
@@ -38,7 +38,7 @@ ___
 
 **Forward**:  = "Forward"
 
-*Defined in [api/types.ts:5035](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5035)*
+*Defined in [api/types.ts:5035](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5035)*
 
 ___
 

--- a/docs/enums/_api_types_.ptzpresettouroperation.md
+++ b/docs/enums/_api_types_.ptzpresettouroperation.md
@@ -21,7 +21,7 @@
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:5065](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5065)*
+*Defined in [api/types.ts:5065](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5065)*
 
 ___
 <a id="pause"></a>
@@ -30,7 +30,7 @@ ___
 
 **Pause**:  = "Pause"
 
-*Defined in [api/types.ts:5061](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5061)*
+*Defined in [api/types.ts:5061](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5061)*
 
 ___
 <a id="start"></a>
@@ -39,7 +39,7 @@ ___
 
 **Start**:  = "Start"
 
-*Defined in [api/types.ts:5053](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5053)*
+*Defined in [api/types.ts:5053](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5053)*
 
 ___
 <a id="stop"></a>
@@ -48,7 +48,7 @@ ___
 
 **Stop**:  = "Stop"
 
-*Defined in [api/types.ts:5057](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5057)*
+*Defined in [api/types.ts:5057](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5057)*
 
 ___
 

--- a/docs/enums/_api_types_.ptzpresettourstate.md
+++ b/docs/enums/_api_types_.ptzpresettourstate.md
@@ -21,7 +21,7 @@
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:5025](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5025)*
+*Defined in [api/types.ts:5025](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5025)*
 
 ___
 <a id="idle"></a>
@@ -30,7 +30,7 @@ ___
 
 **Idle**:  = "Idle"
 
-*Defined in [api/types.ts:5013](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5013)*
+*Defined in [api/types.ts:5013](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5013)*
 
 ___
 <a id="paused"></a>
@@ -39,7 +39,7 @@ ___
 
 **Paused**:  = "Paused"
 
-*Defined in [api/types.ts:5021](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5021)*
+*Defined in [api/types.ts:5021](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5021)*
 
 ___
 <a id="touring"></a>
@@ -48,7 +48,7 @@ ___
 
 **Touring**:  = "Touring"
 
-*Defined in [api/types.ts:5017](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5017)*
+*Defined in [api/types.ts:5017](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5017)*
 
 ___
 

--- a/docs/enums/_api_types_.receivermode.md
+++ b/docs/enums/_api_types_.receivermode.md
@@ -25,7 +25,7 @@
 
 **AlwaysConnect**:  = "AlwaysConnect"
 
-*Defined in [api/types.ts:5313](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5313)*
+*Defined in [api/types.ts:5313](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5313)*
 
 The receiver attempts to maintain a persistent connection to the configured endpoint.
 
@@ -36,7 +36,7 @@ ___
 
 **AutoConnect**:  = "AutoConnect"
 
-*Defined in [api/types.ts:5309](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5309)*
+*Defined in [api/types.ts:5309](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5309)*
 
 The receiver connects on demand, as required by consumers of the media streams.
 
@@ -47,7 +47,7 @@ ___
 
 **NeverConnect**:  = "NeverConnect"
 
-*Defined in [api/types.ts:5317](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5317)*
+*Defined in [api/types.ts:5317](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5317)*
 
 The receiver does not attempt to connect.
 
@@ -58,7 +58,7 @@ ___
 
 **Unknown**:  = "Unknown"
 
-*Defined in [api/types.ts:5321](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5321)*
+*Defined in [api/types.ts:5321](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5321)*
 
 This case should never happen.
 

--- a/docs/enums/_api_types_.receiverstate.md
+++ b/docs/enums/_api_types_.receiverstate.md
@@ -25,7 +25,7 @@
 
 **Connected**:  = "Connected"
 
-*Defined in [api/types.ts:5341](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5341)*
+*Defined in [api/types.ts:5341](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5341)*
 
 The receiver is connected.
 
@@ -36,7 +36,7 @@ ___
 
 **Connecting**:  = "Connecting"
 
-*Defined in [api/types.ts:5337](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5337)*
+*Defined in [api/types.ts:5337](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5337)*
 
 The receiver is attempting to connect.
 
@@ -47,7 +47,7 @@ ___
 
 **NotConnected**:  = "NotConnected"
 
-*Defined in [api/types.ts:5333](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5333)*
+*Defined in [api/types.ts:5333](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5333)*
 
 The receiver is not connected.
 
@@ -58,7 +58,7 @@ ___
 
 **Unknown**:  = "Unknown"
 
-*Defined in [api/types.ts:5345](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5345)*
+*Defined in [api/types.ts:5345](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5345)*
 
 This case should never happen.
 

--- a/docs/enums/_api_types_.recordingstatus.md
+++ b/docs/enums/_api_types_.recordingstatus.md
@@ -25,7 +25,7 @@ This case should never happen.
 
 **Initiated**:  = "Initiated"
 
-*Defined in [api/types.ts:5377](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5377)*
+*Defined in [api/types.ts:5377](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5377)*
 
 ___
 <a id="recording"></a>
@@ -34,7 +34,7 @@ ___
 
 **Recording**:  = "Recording"
 
-*Defined in [api/types.ts:5381](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5381)*
+*Defined in [api/types.ts:5381](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5381)*
 
 ___
 <a id="removed"></a>
@@ -43,7 +43,7 @@ ___
 
 **Removed**:  = "Removed"
 
-*Defined in [api/types.ts:5393](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5393)*
+*Defined in [api/types.ts:5393](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5393)*
 
 ___
 <a id="removing"></a>
@@ -52,7 +52,7 @@ ___
 
 **Removing**:  = "Removing"
 
-*Defined in [api/types.ts:5389](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5389)*
+*Defined in [api/types.ts:5389](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5389)*
 
 ___
 <a id="stopped"></a>
@@ -61,7 +61,7 @@ ___
 
 **Stopped**:  = "Stopped"
 
-*Defined in [api/types.ts:5385](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5385)*
+*Defined in [api/types.ts:5385](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5385)*
 
 ___
 <a id="unknown"></a>
@@ -70,7 +70,7 @@ ___
 
 **Unknown**:  = "Unknown"
 
-*Defined in [api/types.ts:5397](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5397)*
+*Defined in [api/types.ts:5397](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5397)*
 
 This case should never happen.
 

--- a/docs/enums/_api_types_.relayidlestate.md
+++ b/docs/enums/_api_types_.relayidlestate.md
@@ -19,7 +19,7 @@
 
 **closed**:  = "closed"
 
-*Defined in [api/types.ts:4931](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4931)*
+*Defined in [api/types.ts:4931](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4931)*
 
 ___
 <a id="open"></a>
@@ -28,7 +28,7 @@ ___
 
 **open**:  = "open"
 
-*Defined in [api/types.ts:4935](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4935)*
+*Defined in [api/types.ts:4935](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4935)*
 
 ___
 

--- a/docs/enums/_api_types_.relaylogicalstate.md
+++ b/docs/enums/_api_types_.relaylogicalstate.md
@@ -19,7 +19,7 @@
 
 **active**:  = "active"
 
-*Defined in [api/types.ts:4917](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4917)*
+*Defined in [api/types.ts:4917](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4917)*
 
 ___
 <a id="inactive"></a>
@@ -28,7 +28,7 @@ ___
 
 **inactive**:  = "inactive"
 
-*Defined in [api/types.ts:4921](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4921)*
+*Defined in [api/types.ts:4921](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4921)*
 
 ___
 

--- a/docs/enums/_api_types_.relaymode.md
+++ b/docs/enums/_api_types_.relaymode.md
@@ -19,7 +19,7 @@
 
 **Bistable**:  = "Bistable"
 
-*Defined in [api/types.ts:4949](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4949)*
+*Defined in [api/types.ts:4949](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4949)*
 
 ___
 <a id="monostable"></a>
@@ -28,7 +28,7 @@ ___
 
 **Monostable**:  = "Monostable"
 
-*Defined in [api/types.ts:4945](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4945)*
+*Defined in [api/types.ts:4945](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4945)*
 
 ___
 

--- a/docs/enums/_api_types_.reversemode.md
+++ b/docs/enums/_api_types_.reversemode.md
@@ -21,7 +21,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:4999](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4999)*
+*Defined in [api/types.ts:4999](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4999)*
 
 ___
 <a id="extended"></a>
@@ -30,7 +30,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:5003](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5003)*
+*Defined in [api/types.ts:5003](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5003)*
 
 ___
 <a id="off"></a>
@@ -39,7 +39,7 @@ ___
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:4991](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4991)*
+*Defined in [api/types.ts:4991](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4991)*
 
 ___
 <a id="on"></a>
@@ -48,7 +48,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:4995](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4995)*
+*Defined in [api/types.ts:4995](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4995)*
 
 ___
 

--- a/docs/enums/_api_types_.rotatemode.md
+++ b/docs/enums/_api_types_.rotatemode.md
@@ -22,7 +22,7 @@ Enable the Rotate feature. Degree of rotation is specified Degree parameter.
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:4269](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4269)*
+*Defined in [api/types.ts:4269](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4269)*
 
 Rotate feature is automatically activated by the device.
 
@@ -33,7 +33,7 @@ ___
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:4261](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4261)*
+*Defined in [api/types.ts:4261](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4261)*
 
 Enable the Rotate feature. Degree of rotation is specified Degree parameter.
 
@@ -44,7 +44,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:4265](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4265)*
+*Defined in [api/types.ts:4265](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4265)*
 
 Disable the Rotate feature.
 

--- a/docs/enums/_api_types_.sceneorientationmode.md
+++ b/docs/enums/_api_types_.sceneorientationmode.md
@@ -19,7 +19,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:4283](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4283)*
+*Defined in [api/types.ts:4283](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4283)*
 
 ___
 <a id="manual"></a>
@@ -28,7 +28,7 @@ ___
 
 **MANUAL**:  = "MANUAL"
 
-*Defined in [api/types.ts:4279](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4279)*
+*Defined in [api/types.ts:4279](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4279)*
 
 ___
 

--- a/docs/enums/_api_types_.sceneorientationoption.md
+++ b/docs/enums/_api_types_.sceneorientationoption.md
@@ -24,7 +24,7 @@
 
 **Above**:  = "Above"
 
-*Defined in [api/types.ts:4303](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4303)*
+*Defined in [api/types.ts:4303](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4303)*
 
 ___
 <a id="below"></a>
@@ -33,7 +33,7 @@ ___
 
 **Below**:  = "Below"
 
-*Defined in [api/types.ts:4295](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4295)*
+*Defined in [api/types.ts:4295](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4295)*
 
 ___
 <a id="horizon"></a>
@@ -42,7 +42,7 @@ ___
 
 **Horizon**:  = "Horizon"
 
-*Defined in [api/types.ts:4299](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4299)*
+*Defined in [api/types.ts:4299](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4299)*
 
 ___
 

--- a/docs/enums/_api_types_.scopedefinition.md
+++ b/docs/enums/_api_types_.scopedefinition.md
@@ -19,7 +19,7 @@
 
 **Configurable**:  = "Configurable"
 
-*Defined in [api/types.ts:4555](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4555)*
+*Defined in [api/types.ts:4555](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4555)*
 
 ___
 <a id="fixed"></a>
@@ -28,7 +28,7 @@ ___
 
 **Fixed**:  = "Fixed"
 
-*Defined in [api/types.ts:4551](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4551)*
+*Defined in [api/types.ts:4551](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4551)*
 
 ___
 

--- a/docs/enums/_api_types_.searchstate.md
+++ b/docs/enums/_api_types_.searchstate.md
@@ -23,7 +23,7 @@ The search is queued and not yet started.
 
 **Completed**:  = "Completed"
 
-*Defined in [api/types.ts:5363](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5363)*
+*Defined in [api/types.ts:5363](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5363)*
 
 The search has been completed and no new results will be found.
 
@@ -34,7 +34,7 @@ ___
 
 **Queued**:  = "Queued"
 
-*Defined in [api/types.ts:5355](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5355)*
+*Defined in [api/types.ts:5355](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5355)*
 
 The search is queued and not yet started.
 
@@ -45,7 +45,7 @@ ___
 
 **Searching**:  = "Searching"
 
-*Defined in [api/types.ts:5359](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5359)*
+*Defined in [api/types.ts:5359](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5359)*
 
 The search is underway and not yet completed.
 
@@ -56,7 +56,7 @@ ___
 
 **Unknown**:  = "Unknown"
 
-*Defined in [api/types.ts:5367](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5367)*
+*Defined in [api/types.ts:5367](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5367)*
 
 The state of the search is unknown. (This is not a valid response from GetSearchState.)
 

--- a/docs/enums/_api_types_.setdatetimetype.md
+++ b/docs/enums/_api_types_.setdatetimetype.md
@@ -21,7 +21,7 @@ Indicates that the date and time are set manually.
 
 **Manual**:  = "Manual"
 
-*Defined in [api/types.ts:4877](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4877)*
+*Defined in [api/types.ts:4877](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4877)*
 
 Indicates that the date and time are set manually.
 
@@ -32,7 +32,7 @@ ___
 
 **NTP**:  = "NTP"
 
-*Defined in [api/types.ts:4881](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4881)*
+*Defined in [api/types.ts:4881](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4881)*
 
 Indicates that the date and time are set through NTP
 

--- a/docs/enums/_api_types_.streamtype.md
+++ b/docs/enums/_api_types_.streamtype.md
@@ -19,7 +19,7 @@
 
 **RTP-Multicast**:  = "RTP-Multicast"
 
-*Defined in [api/types.ts:4519](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4519)*
+*Defined in [api/types.ts:4519](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4519)*
 
 ___
 <a id="rtp_unicast"></a>
@@ -28,7 +28,7 @@ ___
 
 **RTP-Unicast**:  = "RTP-Unicast"
 
-*Defined in [api/types.ts:4515](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4515)*
+*Defined in [api/types.ts:4515](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4515)*
 
 ___
 

--- a/docs/enums/_api_types_.systemlogtype.md
+++ b/docs/enums/_api_types_.systemlogtype.md
@@ -21,7 +21,7 @@ Enumeration describing the available system log modes.
 
 **Access**:  = "Access"
 
-*Defined in [api/types.ts:4853](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4853)*
+*Defined in [api/types.ts:4853](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4853)*
 
 Indicates that a access log is requested.
 
@@ -32,7 +32,7 @@ ___
 
 **System**:  = "System"
 
-*Defined in [api/types.ts:4849](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4849)*
+*Defined in [api/types.ts:4849](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4849)*
 
 Indicates that a system log is requested.
 

--- a/docs/enums/_api_types_.tonecompensationmode.md
+++ b/docs/enums/_api_types_.tonecompensationmode.md
@@ -20,7 +20,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:5243](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5243)*
+*Defined in [api/types.ts:5243](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5243)*
 
 ___
 <a id="off"></a>
@@ -29,7 +29,7 @@ ___
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:5235](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5235)*
+*Defined in [api/types.ts:5235](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5235)*
 
 ___
 <a id="on"></a>
@@ -38,7 +38,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:5239](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5239)*
+*Defined in [api/types.ts:5239](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5239)*
 
 ___
 

--- a/docs/enums/_api_types_.tracktype.md
+++ b/docs/enums/_api_types_.tracktype.md
@@ -23,7 +23,7 @@ Placeholder for future extension.
 
 **Audio**:  = "Audio"
 
-*Defined in [api/types.ts:5411](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5411)*
+*Defined in [api/types.ts:5411](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5411)*
 
 ___
 <a id="extended"></a>
@@ -32,7 +32,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:5419](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5419)*
+*Defined in [api/types.ts:5419](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5419)*
 
 Placeholder for future extension.
 
@@ -43,7 +43,7 @@ ___
 
 **Metadata**:  = "Metadata"
 
-*Defined in [api/types.ts:5415](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5415)*
+*Defined in [api/types.ts:5415](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5415)*
 
 ___
 <a id="video"></a>
@@ -52,7 +52,7 @@ ___
 
 **Video**:  = "Video"
 
-*Defined in [api/types.ts:5407](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5407)*
+*Defined in [api/types.ts:5407](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5407)*
 
 ___
 

--- a/docs/enums/_api_types_.transportprotocol.md
+++ b/docs/enums/_api_types_.transportprotocol.md
@@ -23,7 +23,7 @@ This value is deprecated.
 
 **HTTP**:  = "HTTP"
 
-*Defined in [api/types.ts:4541](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4541)*
+*Defined in [api/types.ts:4541](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4541)*
 
 ___
 <a id="rtsp"></a>
@@ -32,7 +32,7 @@ ___
 
 **RTSP**:  = "RTSP"
 
-*Defined in [api/types.ts:4537](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4537)*
+*Defined in [api/types.ts:4537](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4537)*
 
 ___
 <a id="tcp"></a>
@@ -41,7 +41,7 @@ ___
 
 **TCP**:  = "TCP"
 
-*Defined in [api/types.ts:4533](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4533)*
+*Defined in [api/types.ts:4533](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4533)*
 
 This value is deprecated.
 
@@ -52,7 +52,7 @@ ___
 
 **UDP**:  = "UDP"
 
-*Defined in [api/types.ts:4529](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4529)*
+*Defined in [api/types.ts:4529](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4529)*
 
 ___
 

--- a/docs/enums/_api_types_.userlevel.md
+++ b/docs/enums/_api_types_.userlevel.md
@@ -22,7 +22,7 @@
 
 **Administrator**:  = "Administrator"
 
-*Defined in [api/types.ts:4891](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4891)*
+*Defined in [api/types.ts:4891](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4891)*
 
 ___
 <a id="anonymous"></a>
@@ -31,7 +31,7 @@ ___
 
 **Anonymous**:  = "Anonymous"
 
-*Defined in [api/types.ts:4903](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4903)*
+*Defined in [api/types.ts:4903](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4903)*
 
 ___
 <a id="extended"></a>
@@ -40,7 +40,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4907](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4907)*
+*Defined in [api/types.ts:4907](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4907)*
 
 ___
 <a id="operator"></a>
@@ -49,7 +49,7 @@ ___
 
 **Operator**:  = "Operator"
 
-*Defined in [api/types.ts:4895](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4895)*
+*Defined in [api/types.ts:4895](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4895)*
 
 ___
 <a id="user"></a>
@@ -58,7 +58,7 @@ ___
 
 **User**:  = "User"
 
-*Defined in [api/types.ts:4899](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4899)*
+*Defined in [api/types.ts:4899](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4899)*
 
 ___
 

--- a/docs/enums/_api_types_.videoencoding.md
+++ b/docs/enums/_api_types_.videoencoding.md
@@ -20,7 +20,7 @@
 
 **H264**:  = "H264"
 
-*Defined in [api/types.ts:4359](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4359)*
+*Defined in [api/types.ts:4359](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4359)*
 
 ___
 <a id="jpeg"></a>
@@ -29,7 +29,7 @@ ___
 
 **JPEG**:  = "JPEG"
 
-*Defined in [api/types.ts:4351](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4351)*
+*Defined in [api/types.ts:4351](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4351)*
 
 ___
 <a id="mpeg4"></a>
@@ -38,7 +38,7 @@ ___
 
 **MPEG4**:  = "MPEG4"
 
-*Defined in [api/types.ts:4355](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4355)*
+*Defined in [api/types.ts:4355](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4355)*
 
 ___
 

--- a/docs/enums/_api_types_.videoencodingmimenames.md
+++ b/docs/enums/_api_types_.videoencodingmimenames.md
@@ -23,7 +23,7 @@ Video Media Subtypes as referenced by IANA (without the leading "video/" Video M
 
 **H264**:  = "H264"
 
-*Defined in [api/types.ts:4413](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4413)*
+*Defined in [api/types.ts:4413](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4413)*
 
 ___
 <a id="h265"></a>
@@ -32,7 +32,7 @@ ___
 
 **H265**:  = "H265"
 
-*Defined in [api/types.ts:4417](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4417)*
+*Defined in [api/types.ts:4417](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4417)*
 
 ___
 <a id="jpeg"></a>
@@ -41,7 +41,7 @@ ___
 
 **JPEG**:  = "JPEG"
 
-*Defined in [api/types.ts:4405](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4405)*
+*Defined in [api/types.ts:4405](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4405)*
 
 ___
 <a id="mpv4_es"></a>
@@ -50,7 +50,7 @@ ___
 
 **MPV4-ES**:  = "MPV4-ES"
 
-*Defined in [api/types.ts:4409](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4409)*
+*Defined in [api/types.ts:4409](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4409)*
 
 ___
 

--- a/docs/enums/_api_types_.videoencodingprofiles.md
+++ b/docs/enums/_api_types_.videoencodingprofiles.md
@@ -24,7 +24,7 @@
 
 **AdvancedSimple**:  = "AdvancedSimple"
 
-*Defined in [api/types.ts:4431](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4431)*
+*Defined in [api/types.ts:4431](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4431)*
 
 ___
 <a id="baseline"></a>
@@ -33,7 +33,7 @@ ___
 
 **Baseline**:  = "Baseline"
 
-*Defined in [api/types.ts:4435](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4435)*
+*Defined in [api/types.ts:4435](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4435)*
 
 ___
 <a id="extended"></a>
@@ -42,7 +42,7 @@ ___
 
 **Extended**:  = "Extended"
 
-*Defined in [api/types.ts:4447](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4447)*
+*Defined in [api/types.ts:4447](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4447)*
 
 ___
 <a id="high"></a>
@@ -51,7 +51,7 @@ ___
 
 **High**:  = "High"
 
-*Defined in [api/types.ts:4451](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4451)*
+*Defined in [api/types.ts:4451](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4451)*
 
 ___
 <a id="main"></a>
@@ -60,7 +60,7 @@ ___
 
 **Main**:  = "Main"
 
-*Defined in [api/types.ts:4439](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4439)*
+*Defined in [api/types.ts:4439](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4439)*
 
 ___
 <a id="main10"></a>
@@ -69,7 +69,7 @@ ___
 
 **Main10**:  = "Main10"
 
-*Defined in [api/types.ts:4443](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4443)*
+*Defined in [api/types.ts:4443](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4443)*
 
 ___
 <a id="simple"></a>
@@ -78,7 +78,7 @@ ___
 
 **Simple**:  = "Simple"
 
-*Defined in [api/types.ts:4427](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4427)*
+*Defined in [api/types.ts:4427](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4427)*
 
 ___
 

--- a/docs/enums/_api_types_.viewmodes.md
+++ b/docs/enums/_api_types_.viewmodes.md
@@ -27,7 +27,7 @@ Source view modes supported by device.
 
 **180Panorama**:  = "180Panorama"
 
-*Defined in [api/types.ts:4321](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4321)*
+*Defined in [api/types.ts:4321](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4321)*
 
 180 degree panoramic view.
 
@@ -38,7 +38,7 @@ ___
 
 **360Panorama**:  = "360Panorama"
 
-*Defined in [api/types.ts:4317](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4317)*
+*Defined in [api/types.ts:4317](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4317)*
 
 360 degree panoramic view.
 
@@ -49,7 +49,7 @@ ___
 
 **Dewarp**:  = "Dewarp"
 
-*Defined in [api/types.ts:4341](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4341)*
+*Defined in [api/types.ts:4341](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4341)*
 
 Dewarped view mode for device supporting fisheye lens.
 
@@ -60,7 +60,7 @@ ___
 
 **Fisheye**:  = "Fisheye"
 
-*Defined in [api/types.ts:4313](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4313)*
+*Defined in [api/types.ts:4313](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4313)*
 
 Undewarped viewmode from device supporting fisheye lens.
 
@@ -71,7 +71,7 @@ ___
 
 **LeftHalf**:  = "LeftHalf"
 
-*Defined in [api/types.ts:4333](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4333)*
+*Defined in [api/types.ts:4333](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4333)*
 
 Viewmode combining the left side sensors, applicable for devices supporting multiple sensors.
 
@@ -82,7 +82,7 @@ ___
 
 **Original**:  = "Original"
 
-*Defined in [api/types.ts:4329](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4329)*
+*Defined in [api/types.ts:4329](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4329)*
 
 Unaltered view from the sensor.
 
@@ -93,7 +93,7 @@ ___
 
 **Quad**:  = "Quad"
 
-*Defined in [api/types.ts:4325](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4325)*
+*Defined in [api/types.ts:4325](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4325)*
 
 View mode combining four streams in single Quad, eg., applicable for devices supporting four heads.
 
@@ -104,7 +104,7 @@ ___
 
 **RightHalf**:  = "RightHalf"
 
-*Defined in [api/types.ts:4337](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4337)*
+*Defined in [api/types.ts:4337](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4337)*
 
 Viewmode combining the right side sensors, applicable for devices supporting multiple sensors.
 

--- a/docs/enums/_api_types_.whitebalancemode.md
+++ b/docs/enums/_api_types_.whitebalancemode.md
@@ -19,7 +19,7 @@
 
 **AUTO**:  = "AUTO"
 
-*Defined in [api/types.ts:5159](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5159)*
+*Defined in [api/types.ts:5159](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5159)*
 
 ___
 <a id="manual"></a>
@@ -28,7 +28,7 @@ ___
 
 **MANUAL**:  = "MANUAL"
 
-*Defined in [api/types.ts:5163](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5163)*
+*Defined in [api/types.ts:5163](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5163)*
 
 ___
 

--- a/docs/enums/_api_types_.widedynamicmode.md
+++ b/docs/enums/_api_types_.widedynamicmode.md
@@ -19,7 +19,7 @@
 
 **OFF**:  = "OFF"
 
-*Defined in [api/types.ts:5089](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5089)*
+*Defined in [api/types.ts:5089](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5089)*
 
 ___
 <a id="on"></a>
@@ -28,7 +28,7 @@ ___
 
 **ON**:  = "ON"
 
-*Defined in [api/types.ts:5093](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L5093)*
+*Defined in [api/types.ts:5093](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L5093)*
 
 ___
 

--- a/docs/enums/_soap_request_.soap_node.md
+++ b/docs/enums/_soap_request_.soap_node.md
@@ -20,7 +20,7 @@
 
 **Body**:  = "S11:Body"
 
-*Defined in [soap/request.ts:65](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L65)*
+*Defined in [soap/request.ts:65](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L65)*
 
 ___
 <a id="envelope"></a>
@@ -29,7 +29,7 @@ ___
 
 **Envelope**:  = "S11:Envelope"
 
-*Defined in [soap/request.ts:64](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L64)*
+*Defined in [soap/request.ts:64](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L64)*
 
 ___
 <a id="header"></a>
@@ -38,7 +38,7 @@ ___
 
 **Header**:  = "S11:Header"
 
-*Defined in [soap/request.ts:63](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L63)*
+*Defined in [soap/request.ts:63](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L63)*
 
 ___
 

--- a/docs/enums/_soap_request_.xmlns.md
+++ b/docs/enums/_soap_request_.xmlns.md
@@ -50,7 +50,7 @@
 
 **S11**:  = "xmlns:S11="http://www.w3.org/2003/05/soap-envelope""
 
-*Defined in [soap/request.ts:9](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L9)*
+*Defined in [soap/request.ts:9](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L9)*
 
 ___
 <a id="ns1"></a>
@@ -59,7 +59,7 @@ ___
 
 **ns1**:  = "xmlns:ns1="http://www.onvif.org/ver10/accesscontrol/wsdl""
 
-*Defined in [soap/request.ts:17](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L17)*
+*Defined in [soap/request.ts:17](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L17)*
 
 ___
 <a id="ns2"></a>
@@ -68,7 +68,7 @@ ___
 
 **ns2**:  = "xmlns:ns2="http://www.onvif.org/ver10/pacs""
 
-*Defined in [soap/request.ts:40](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L40)*
+*Defined in [soap/request.ts:40](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L40)*
 
 ___
 <a id="ns3"></a>
@@ -77,7 +77,7 @@ ___
 
 **ns3**:  = "xmlns:ns3="http://www.onvif.org/ver10/actionengine/wsdl""
 
-*Defined in [soap/request.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L18)*
+*Defined in [soap/request.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L18)*
 
 ___
 <a id="tad"></a>
@@ -86,7 +86,7 @@ ___
 
 **tad**:  = "xmlns:tad="http://www.onvif.org/ver10/analyticsdevice/wsdl""
 
-*Defined in [soap/request.ts:19](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L19)*
+*Defined in [soap/request.ts:19](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L19)*
 
 ___
 <a id="tan"></a>
@@ -95,7 +95,7 @@ ___
 
 **tan**:  = "xmlns:tan="http://www.onvif.org/ver20/analytics/wsdl""
 
-*Defined in [soap/request.ts:37](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L37)*
+*Defined in [soap/request.ts:37](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L37)*
 
 ___
 <a id="tds"></a>
@@ -104,7 +104,7 @@ ___
 
 **tds**:  = "xmlns:tds="http://www.onvif.org/ver10/device/wsdl""
 
-*Defined in [soap/request.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L13)*
+*Defined in [soap/request.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L13)*
 
 ___
 <a id="ter"></a>
@@ -113,7 +113,7 @@ ___
 
 **ter**:  = "xmlns:ter="http://www.onvif.org/ver10/error""
 
-*Defined in [soap/request.ts:38](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L38)*
+*Defined in [soap/request.ts:38](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L38)*
 
 ___
 <a id="tev"></a>
@@ -122,7 +122,7 @@ ___
 
 **tev**:  = "xmlns:tev="http://www.onvif.org/ver10/events/wsdl""
 
-*Defined in [soap/request.ts:28](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L28)*
+*Defined in [soap/request.ts:28](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L28)*
 
 ___
 <a id="timg"></a>
@@ -131,7 +131,7 @@ ___
 
 **timg**:  = "xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl""
 
-*Defined in [soap/request.ts:20](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L20)*
+*Defined in [soap/request.ts:20](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L20)*
 
 ___
 <a id="tns1"></a>
@@ -140,7 +140,7 @@ ___
 
 **tns1**:  = "xmlns:tns1="http://www.onvif.org/ver10/topics""
 
-*Defined in [soap/request.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L39)*
+*Defined in [soap/request.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L39)*
 
 ___
 <a id="tptz"></a>
@@ -149,7 +149,7 @@ ___
 
 **tptz**:  = "xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl""
 
-*Defined in [soap/request.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L21)*
+*Defined in [soap/request.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L21)*
 
 ___
 <a id="trc"></a>
@@ -158,7 +158,7 @@ ___
 
 **trc**:  = "xmlns:trc="http://www.onvif.org/ver10/recording/wsdl""
 
-*Defined in [soap/request.ts:22](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L22)*
+*Defined in [soap/request.ts:22](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L22)*
 
 ___
 <a id="trt"></a>
@@ -167,7 +167,7 @@ ___
 
 **trt**:  = "xmlns:trt="http://www.onvif.org/ver10/media/wsdl""
 
-*Defined in [soap/request.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L14)*
+*Defined in [soap/request.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L14)*
 
 ___
 <a id="trv"></a>
@@ -176,7 +176,7 @@ ___
 
 **trv**:  = "xmlns:trv="http://www.onvif.org/ver10/receiver/wsdl""
 
-*Defined in [soap/request.ts:23](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L23)*
+*Defined in [soap/request.ts:23](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L23)*
 
 ___
 <a id="tse"></a>
@@ -185,7 +185,7 @@ ___
 
 **tse**:  = "xmlns:tse="http://www.onvif.org/ver10/search/wsdl""
 
-*Defined in [soap/request.ts:24](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L24)*
+*Defined in [soap/request.ts:24](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L24)*
 
 ___
 <a id="tt"></a>
@@ -194,7 +194,7 @@ ___
 
 **tt**:  = "xmlns:tt="http://www.onvif.org/ver10/schema""
 
-*Defined in [soap/request.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L12)*
+*Defined in [soap/request.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L12)*
 
 ___
 <a id="vifsvr"></a>
@@ -203,7 +203,7 @@ ___
 
 **vifsvr**:  = "xmlns:vifsvr="http://www.onvif.org/ver10/events/wsdl/PullPointSubscriptionBinding""
 
-*Defined in [soap/request.ts:25](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L25)*
+*Defined in [soap/request.ts:25](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L25)*
 
 ___
 <a id="vifsvr10"></a>
@@ -212,7 +212,7 @@ ___
 
 **vifsvr10**:  = "xmlns:vifsvr10="http://www.onvif.org/ver20/analytics/wsdl/AnalyticsEngineBinding""
 
-*Defined in [soap/request.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L26)*
+*Defined in [soap/request.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L26)*
 
 ___
 <a id="vifsvr2"></a>
@@ -221,7 +221,7 @@ ___
 
 **vifsvr2**:  = "xmlns:vifsvr2="http://www.onvif.org/ver10/events/wsdl/EventBinding""
 
-*Defined in [soap/request.ts:27](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L27)*
+*Defined in [soap/request.ts:27](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L27)*
 
 ___
 <a id="vifsvr3"></a>
@@ -230,7 +230,7 @@ ___
 
 **vifsvr3**:  = "xmlns:vifsvr3="http://www.onvif.org/ver10/events/wsdl/SubscriptionManagerBinding""
 
-*Defined in [soap/request.ts:29](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L29)*
+*Defined in [soap/request.ts:29](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L29)*
 
 ___
 <a id="vifsvr4"></a>
@@ -239,7 +239,7 @@ ___
 
 **vifsvr4**:  = "xmlns:vifsvr4="http://www.onvif.org/ver10/events/wsdl/NotificationProducerBinding""
 
-*Defined in [soap/request.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L30)*
+*Defined in [soap/request.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L30)*
 
 ___
 <a id="vifsvr5"></a>
@@ -248,7 +248,7 @@ ___
 
 **vifsvr5**:  = "xmlns:vifsvr5="http://www.onvif.org/ver10/events/wsdl/NotificationConsumerBinding""
 
-*Defined in [soap/request.ts:31](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L31)*
+*Defined in [soap/request.ts:31](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L31)*
 
 ___
 <a id="vifsvr6"></a>
@@ -257,7 +257,7 @@ ___
 
 **vifsvr6**:  = "xmlns:vifsvr6="http://www.onvif.org/ver10/events/wsdl/PullPointBinding""
 
-*Defined in [soap/request.ts:32](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L32)*
+*Defined in [soap/request.ts:32](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L32)*
 
 ___
 <a id="vifsvr7"></a>
@@ -266,7 +266,7 @@ ___
 
 **vifsvr7**:  = "xmlns:vifsvr7="http://www.onvif.org/ver10/events/wsdl/CreatePullPointBinding""
 
-*Defined in [soap/request.ts:33](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L33)*
+*Defined in [soap/request.ts:33](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L33)*
 
 ___
 <a id="vifsvr8"></a>
@@ -275,7 +275,7 @@ ___
 
 **vifsvr8**:  = "xmlns:vifsvr8="http://www.onvif.org/ver10/events/wsdl/PausableSubscriptionManagerBinding""
 
-*Defined in [soap/request.ts:34](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L34)*
+*Defined in [soap/request.ts:34](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L34)*
 
 ___
 <a id="vifsvr9"></a>
@@ -284,7 +284,7 @@ ___
 
 **vifsvr9**:  = "xmlns:vifsvr9="http://www.onvif.org/ver20/analytics/wsdl/RuleEngineBinding""
 
-*Defined in [soap/request.ts:36](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L36)*
+*Defined in [soap/request.ts:36](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L36)*
 
 ___
 <a id="wsa5"></a>
@@ -293,7 +293,7 @@ ___
 
 **wsa5**:  = "xmlns:wsa5="http://www.w3.org/2005/08/addressing""
 
-*Defined in [soap/request.ts:41](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L41)*
+*Defined in [soap/request.ts:41](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L41)*
 
 ___
 <a id="wsnt"></a>
@@ -302,7 +302,7 @@ ___
 
 **wsnt**:  = "xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2""
 
-*Defined in [soap/request.ts:35](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L35)*
+*Defined in [soap/request.ts:35](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L35)*
 
 ___
 <a id="wsse"></a>
@@ -311,7 +311,7 @@ ___
 
 **wsse**:  = "xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd""
 
-*Defined in [soap/request.ts:10](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L10)*
+*Defined in [soap/request.ts:10](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L10)*
 
 ___
 <a id="wsu"></a>
@@ -320,7 +320,7 @@ ___
 
 **wsu**:  = "xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd""
 
-*Defined in [soap/request.ts:11](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L11)*
+*Defined in [soap/request.ts:11](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L11)*
 
 ___
 <a id="xsd"></a>
@@ -329,7 +329,7 @@ ___
 
 **xsd**:  = "xmlns:xsd="http://www.w3.org/2001/XMLSchema""
 
-*Defined in [soap/request.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L16)*
+*Defined in [soap/request.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L16)*
 
 ___
 <a id="xsi"></a>
@@ -338,7 +338,7 @@ ___
 
 **xsi**:  = "xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance""
 
-*Defined in [soap/request.ts:15](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L15)*
+*Defined in [soap/request.ts:15](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L15)*
 
 ___
 

--- a/docs/interfaces/_api_types_.aacdecoptions.md
+++ b/docs/interfaces/_api_types_.aacdecoptions.md
@@ -25,7 +25,7 @@ List of supported bitrates in kbps
 
 **● Bitrate**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:962](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L962)*
+*Defined in [api/types.ts:962](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L962)*
 
 ___
 <a id="sampleraterange"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SampleRateRange**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:963](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L963)*
+*Defined in [api/types.ts:963](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L963)*
 
 ___
 

--- a/docs/interfaces/_api_types_.absolutefocus.md
+++ b/docs/interfaces/_api_types_.absolutefocus.md
@@ -27,7 +27,7 @@
 
 **● Position**: *`number`*
 
-*Defined in [api/types.ts:2599](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2599)*
+*Defined in [api/types.ts:2599](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2599)*
 
 ___
 <a id="speed"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Speed**: *`number`*
 
-*Defined in [api/types.ts:2600](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2600)*
+*Defined in [api/types.ts:2600](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2600)*
 
 ___
 

--- a/docs/interfaces/_api_types_.absolutefocusoptions.md
+++ b/docs/interfaces/_api_types_.absolutefocusoptions.md
@@ -27,7 +27,7 @@
 
 **● Position**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2637](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2637)*
+*Defined in [api/types.ts:2637](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2637)*
 
 ___
 <a id="speed"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Speed**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2638](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2638)*
+*Defined in [api/types.ts:2638](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2638)*
 
 ___
 

--- a/docs/interfaces/_api_types_.actionengineeventpayload.md
+++ b/docs/interfaces/_api_types_.actionengineeventpayload.md
@@ -27,7 +27,7 @@ Action Engine Event Payload data structure contains the information about the ON
 
 **● Extension**: *[ActionEngineEventPayloadExtension](_api_types_.actionengineeventpayloadextension.md)*
 
-*Defined in [api/types.ts:3904](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3904)*
+*Defined in [api/types.ts:3904](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3904)*
 
 ___
 <a id="fault"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Fault**: *[Fault](_api_types_.fault.md)*
 
-*Defined in [api/types.ts:3903](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3903)*
+*Defined in [api/types.ts:3903](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3903)*
 
 ___
 <a id="requestinfo"></a>
@@ -45,7 +45,7 @@ ___
 
 **● RequestInfo**: *[Envelope](_api_types_.envelope.md)*
 
-*Defined in [api/types.ts:3901](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3901)*
+*Defined in [api/types.ts:3901](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3901)*
 
 ___
 <a id="responseinfo"></a>
@@ -54,7 +54,7 @@ ___
 
 **● ResponseInfo**: *[Envelope](_api_types_.envelope.md)*
 
-*Defined in [api/types.ts:3902](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3902)*
+*Defined in [api/types.ts:3902](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3902)*
 
 ___
 

--- a/docs/interfaces/_api_types_.activeconnection.md
+++ b/docs/interfaces/_api_types_.activeconnection.md
@@ -23,7 +23,7 @@
 
 **● CurrentBitrate**: *`number`*
 
-*Defined in [api/types.ts:3939](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3939)*
+*Defined in [api/types.ts:3939](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3939)*
 
 ___
 <a id="currentfps"></a>
@@ -32,7 +32,7 @@ ___
 
 **● CurrentFps**: *`number`*
 
-*Defined in [api/types.ts:3940](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3940)*
+*Defined in [api/types.ts:3940](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3940)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticscapabilities.md
+++ b/docs/interfaces/_api_types_.analyticscapabilities.md
@@ -26,7 +26,7 @@ Analytics service URI.
 
 **● AnalyticsModuleSupport**: *`boolean`*
 
-*Defined in [api/types.ts:1473](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1473)*
+*Defined in [api/types.ts:1473](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1473)*
 
 ___
 <a id="rulesupport"></a>
@@ -35,7 +35,7 @@ ___
 
 **● RuleSupport**: *`boolean`*
 
-*Defined in [api/types.ts:1472](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1472)*
+*Defined in [api/types.ts:1472](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1472)*
 
 ___
 <a id="xaddr"></a>
@@ -44,7 +44,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1471](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1471)*
+*Defined in [api/types.ts:1471](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1471)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsdevicecapabilities.md
+++ b/docs/interfaces/_api_types_.analyticsdevicecapabilities.md
@@ -26,7 +26,7 @@ Obsolete property.
 
 **● Extension**: *[AnalyticsDeviceExtension](_api_types_.analyticsdeviceextension.md)*
 
-*Defined in [api/types.ts:1742](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1742)*
+*Defined in [api/types.ts:1742](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1742)*
 
 ___
 <a id="rulesupport"></a>
@@ -35,7 +35,7 @@ ___
 
 **● RuleSupport**: *`boolean`*
 
-*Defined in [api/types.ts:1741](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1741)*
+*Defined in [api/types.ts:1741](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1741)*
 
 ___
 <a id="xaddr"></a>
@@ -44,7 +44,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1740](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1740)*
+*Defined in [api/types.ts:1740](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1740)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsdeviceengineconfiguration.md
+++ b/docs/interfaces/_api_types_.analyticsdeviceengineconfiguration.md
@@ -23,7 +23,7 @@
 
 **● EngineConfiguration**: *[EngineConfiguration](_api_types_.engineconfiguration.md)*
 
-*Defined in [api/types.ts:3798](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3798)*
+*Defined in [api/types.ts:3798](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3798)*
 
 ___
 <a id="extension"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Extension**: *[AnalyticsDeviceEngineConfigurationExtension](_api_types_.analyticsdeviceengineconfigurationextension.md)*
 
-*Defined in [api/types.ts:3799](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3799)*
+*Defined in [api/types.ts:3799](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3799)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsengine.md
+++ b/docs/interfaces/_api_types_.analyticsengine.md
@@ -22,7 +22,7 @@
 
 **● AnalyticsEngineConfiguration**: *[AnalyticsDeviceEngineConfiguration](_api_types_.analyticsdeviceengineconfiguration.md)*
 
-*Defined in [api/types.ts:3791](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3791)*
+*Defined in [api/types.ts:3791](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3791)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsengineconfiguration.md
+++ b/docs/interfaces/_api_types_.analyticsengineconfiguration.md
@@ -23,7 +23,7 @@
 
 **● AnalyticsModule**: *[Config](_api_types_.config.md)*
 
-*Defined in [api/types.ts:3182](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3182)*
+*Defined in [api/types.ts:3182](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3182)*
 
 ___
 <a id="extension"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Extension**: *[AnalyticsEngineConfigurationExtension](_api_types_.analyticsengineconfigurationextension.md)*
 
-*Defined in [api/types.ts:3183](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3183)*
+*Defined in [api/types.ts:3183](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3183)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsenginecontrol.md
+++ b/docs/interfaces/_api_types_.analyticsenginecontrol.md
@@ -30,7 +30,7 @@ Token of the analytics engine (AnalyticsEngine) being controlled.
 
 **● EngineConfigToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3873](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3873)*
+*Defined in [api/types.ts:3873](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3873)*
 
 ___
 <a id="enginetoken"></a>
@@ -39,7 +39,7 @@ ___
 
 **● EngineToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3872](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3872)*
+*Defined in [api/types.ts:3872](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3872)*
 
 ___
 <a id="inputtoken"></a>
@@ -48,7 +48,7 @@ ___
 
 **● InputToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3874](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3874)*
+*Defined in [api/types.ts:3874](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3874)*
 
 ___
 <a id="mode"></a>
@@ -57,7 +57,7 @@ ___
 
 **● Mode**: *[ModeOfOperation](../enums/_api_types_.modeofoperation.md)*
 
-*Defined in [api/types.ts:3878](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3878)*
+*Defined in [api/types.ts:3878](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3878)*
 
 ___
 <a id="multicast"></a>
@@ -66,7 +66,7 @@ ___
 
 **● Multicast**: *[MulticastConfiguration](_api_types_.multicastconfiguration.md)*
 
-*Defined in [api/types.ts:3876](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3876)*
+*Defined in [api/types.ts:3876](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3876)*
 
 ___
 <a id="receivertoken"></a>
@@ -75,7 +75,7 @@ ___
 
 **● ReceiverToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3875](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3875)*
+*Defined in [api/types.ts:3875](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3875)*
 
 ___
 <a id="subscription"></a>
@@ -84,7 +84,7 @@ ___
 
 **● Subscription**: *[Config](_api_types_.config.md)*
 
-*Defined in [api/types.ts:3877](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3877)*
+*Defined in [api/types.ts:3877](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3877)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsengineinput.md
+++ b/docs/interfaces/_api_types_.analyticsengineinput.md
@@ -24,7 +24,7 @@
 
 **● MetadataInput**: *[MetadataInput](_api_types_.metadatainput.md)*
 
-*Defined in [api/types.ts:3836](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3836)*
+*Defined in [api/types.ts:3836](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3836)*
 
 ___
 <a id="sourceidentification"></a>
@@ -33,7 +33,7 @@ ___
 
 **● SourceIdentification**: *[SourceIdentification](_api_types_.sourceidentification.md)*
 
-*Defined in [api/types.ts:3834](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3834)*
+*Defined in [api/types.ts:3834](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3834)*
 
 ___
 <a id="videoinput"></a>
@@ -42,7 +42,7 @@ ___
 
 **● VideoInput**: *[VideoEncoderConfiguration](_api_types_.videoencoderconfiguration.md)*
 
-*Defined in [api/types.ts:3835](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3835)*
+*Defined in [api/types.ts:3835](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3835)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsengineinputinfo.md
+++ b/docs/interfaces/_api_types_.analyticsengineinputinfo.md
@@ -23,7 +23,7 @@
 
 **● Extension**: *[AnalyticsEngineInputInfoExtension](_api_types_.analyticsengineinputinfoextension.md)*
 
-*Defined in [api/types.ts:3821](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3821)*
+*Defined in [api/types.ts:3821](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3821)*
 
 ___
 <a id="inputinfo"></a>
@@ -32,7 +32,7 @@ ___
 
 **● InputInfo**: *[Config](_api_types_.config.md)*
 
-*Defined in [api/types.ts:3820](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3820)*
+*Defined in [api/types.ts:3820](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3820)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsstate.md
+++ b/docs/interfaces/_api_types_.analyticsstate.md
@@ -23,7 +23,7 @@
 
 **● Error**: *`string`*
 
-*Defined in [api/types.ts:3893](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3893)*
+*Defined in [api/types.ts:3893](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3893)*
 
 ___
 <a id="state"></a>
@@ -32,7 +32,7 @@ ___
 
 **● State**: *`string`*
 
-*Defined in [api/types.ts:3894](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3894)*
+*Defined in [api/types.ts:3894](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3894)*
 
 ___
 

--- a/docs/interfaces/_api_types_.analyticsstateinformation.md
+++ b/docs/interfaces/_api_types_.analyticsstateinformation.md
@@ -25,7 +25,7 @@ Token of the control object whose status is requested.
 
 **● AnalyticsEngineControlToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3885](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3885)*
+*Defined in [api/types.ts:3885](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3885)*
 
 ___
 <a id="state"></a>
@@ -34,7 +34,7 @@ ___
 
 **● State**: *[AnalyticsState](_api_types_.analyticsstate.md)*
 
-*Defined in [api/types.ts:3886](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3886)*
+*Defined in [api/types.ts:3886](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3886)*
 
 ___
 

--- a/docs/interfaces/_api_types_.arrayoffileprogress.md
+++ b/docs/interfaces/_api_types_.arrayoffileprogress.md
@@ -25,7 +25,7 @@ Exported file name and export progress information
 
 **● Extension**: *[ArrayOfFileProgressExtension](_api_types_.arrayoffileprogressextension.md)*
 
-*Defined in [api/types.ts:4156](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4156)*
+*Defined in [api/types.ts:4156](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4156)*
 
 ___
 <a id="fileprogress"></a>
@@ -34,7 +34,7 @@ ___
 
 **● FileProgress**: *[FileProgress](_api_types_.fileprogress.md)*
 
-*Defined in [api/types.ts:4155](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4155)*
+*Defined in [api/types.ts:4155](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4155)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audioattributes.md
+++ b/docs/interfaces/_api_types_.audioattributes.md
@@ -26,7 +26,7 @@ The bitrate in kbps.
 
 **● Bitrate**: *`number`*
 
-*Defined in [api/types.ts:3625](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3625)*
+*Defined in [api/types.ts:3625](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3625)*
 
 ___
 <a id="encoding"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Encoding**: *`string`*
 
-*Defined in [api/types.ts:3626](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3626)*
+*Defined in [api/types.ts:3626](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3626)*
 
 ___
 <a id="samplerate"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Samplerate**: *`number`*
 
-*Defined in [api/types.ts:3627](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3627)*
+*Defined in [api/types.ts:3627](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3627)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audioclasscandidate.md
+++ b/docs/interfaces/_api_types_.audioclasscandidate.md
@@ -25,7 +25,7 @@ Indicates audio class label
 
 **● Likelihood**: *`number`*
 
-*Defined in [api/types.ts:3918](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3918)*
+*Defined in [api/types.ts:3918](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3918)*
 
 ___
 <a id="type"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Type**: *[AudioClassType](../modules/_api_types_.md#audioclasstype)*
 
-*Defined in [api/types.ts:3917](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3917)*
+*Defined in [api/types.ts:3917](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3917)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audioclassdescriptor.md
+++ b/docs/interfaces/_api_types_.audioclassdescriptor.md
@@ -25,7 +25,7 @@ Array of audio class label and class probability
 
 **● ClassCandidate**: *[AudioClassCandidate](_api_types_.audioclasscandidate.md)*
 
-*Defined in [api/types.ts:3925](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3925)*
+*Defined in [api/types.ts:3925](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3925)*
 
 ___
 <a id="extension"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Extension**: *[AudioClassDescriptorExtension](_api_types_.audioclassdescriptorextension.md)*
 
-*Defined in [api/types.ts:3926](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3926)*
+*Defined in [api/types.ts:3926](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3926)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audiodecoderconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.audiodecoderconfigurationoptions.md
@@ -27,7 +27,7 @@ If the device is able to decode AAC encoded audio this section describes the sup
 
 **● AACDecOptions**: *[AACDecOptions](_api_types_.aacdecoptions.md)*
 
-*Defined in [api/types.ts:944](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L944)*
+*Defined in [api/types.ts:944](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L944)*
 
 ___
 <a id="extension"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Extension**: *[AudioDecoderConfigurationOptionsExtension](_api_types_.audiodecoderconfigurationoptionsextension.md)*
 
-*Defined in [api/types.ts:947](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L947)*
+*Defined in [api/types.ts:947](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L947)*
 
 ___
 <a id="g711decoptions"></a>
@@ -45,7 +45,7 @@ ___
 
 **● G711DecOptions**: *[G711DecOptions](_api_types_.g711decoptions.md)*
 
-*Defined in [api/types.ts:945](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L945)*
+*Defined in [api/types.ts:945](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L945)*
 
 ___
 <a id="g726decoptions"></a>
@@ -54,7 +54,7 @@ ___
 
 **● G726DecOptions**: *[G726DecOptions](_api_types_.g726decoptions.md)*
 
-*Defined in [api/types.ts:946](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L946)*
+*Defined in [api/types.ts:946](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L946)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audioencoder2configuration.md
+++ b/docs/interfaces/_api_types_.audioencoder2configuration.md
@@ -27,7 +27,7 @@ Audio Media Subtype for the audio format. For definitions see tt:AudioEncodingMi
 
 **● Bitrate**: *`number`*
 
-*Defined in [api/types.ts:739](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L739)*
+*Defined in [api/types.ts:739](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L739)*
 
 ___
 <a id="encoding"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Encoding**: *`string`*
 
-*Defined in [api/types.ts:737](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L737)*
+*Defined in [api/types.ts:737](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L737)*
 
 ___
 <a id="multicast"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Multicast**: *[MulticastConfiguration](_api_types_.multicastconfiguration.md)*
 
-*Defined in [api/types.ts:738](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L738)*
+*Defined in [api/types.ts:738](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L738)*
 
 ___
 <a id="samplerate"></a>
@@ -54,7 +54,7 @@ ___
 
 **● SampleRate**: *`number`*
 
-*Defined in [api/types.ts:740](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L740)*
+*Defined in [api/types.ts:740](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L740)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audioencoder2configurationoptions.md
+++ b/docs/interfaces/_api_types_.audioencoder2configurationoptions.md
@@ -26,7 +26,7 @@ Audio Media Subtype for the audio format. For definitions see tt:AudioEncodingMi
 
 **● BitrateList**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:748](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L748)*
+*Defined in [api/types.ts:748](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L748)*
 
 ___
 <a id="encoding"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Encoding**: *`string`*
 
-*Defined in [api/types.ts:747](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L747)*
+*Defined in [api/types.ts:747](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L747)*
 
 ___
 <a id="sampleratelist"></a>
@@ -44,7 +44,7 @@ ___
 
 **● SampleRateList**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:749](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L749)*
+*Defined in [api/types.ts:749](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L749)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audioencoderconfiguration.md
+++ b/docs/interfaces/_api_types_.audioencoderconfiguration.md
@@ -28,7 +28,7 @@ Audio codec used for encoding the audio input (either G.711, G.726 or AAC)
 
 **● Bitrate**: *`number`*
 
-*Defined in [api/types.ts:711](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L711)*
+*Defined in [api/types.ts:711](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L711)*
 
 ___
 <a id="encoding"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Encoding**: *[AudioEncoding](../enums/_api_types_.audioencoding.md)*
 
-*Defined in [api/types.ts:710](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L710)*
+*Defined in [api/types.ts:710](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L710)*
 
 ___
 <a id="multicast"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Multicast**: *[MulticastConfiguration](_api_types_.multicastconfiguration.md)*
 
-*Defined in [api/types.ts:713](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L713)*
+*Defined in [api/types.ts:713](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L713)*
 
 ___
 <a id="samplerate"></a>
@@ -55,7 +55,7 @@ ___
 
 **● SampleRate**: *`number`*
 
-*Defined in [api/types.ts:712](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L712)*
+*Defined in [api/types.ts:712](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L712)*
 
 ___
 <a id="sessiontimeout"></a>
@@ -64,7 +64,7 @@ ___
 
 **● SessionTimeout**: *`string`*
 
-*Defined in [api/types.ts:714](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L714)*
+*Defined in [api/types.ts:714](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L714)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audioencoderconfigurationoption.md
+++ b/docs/interfaces/_api_types_.audioencoderconfigurationoption.md
@@ -26,7 +26,7 @@ The enoding used for audio data (either G.711, G.726 or AAC)
 
 **● BitrateList**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:729](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L729)*
+*Defined in [api/types.ts:729](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L729)*
 
 ___
 <a id="encoding"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Encoding**: *[AudioEncoding](../enums/_api_types_.audioencoding.md)*
 
-*Defined in [api/types.ts:728](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L728)*
+*Defined in [api/types.ts:728](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L728)*
 
 ___
 <a id="sampleratelist"></a>
@@ -44,7 +44,7 @@ ___
 
 **● SampleRateList**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:730](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L730)*
+*Defined in [api/types.ts:730](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L730)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audioencoderconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.audioencoderconfigurationoptions.md
@@ -24,7 +24,7 @@ list of supported AudioEncoderConfigurations
 
 **● Options**: *[AudioEncoderConfigurationOption](_api_types_.audioencoderconfigurationoption.md)*
 
-*Defined in [api/types.ts:721](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L721)*
+*Defined in [api/types.ts:721](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L721)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audiooutputconfiguration.md
+++ b/docs/interfaces/_api_types_.audiooutputconfiguration.md
@@ -26,7 +26,7 @@ Token of the phsycial Audio output.
 
 **● OutputLevel**: *`number`*
 
-*Defined in [api/types.ts:921](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L921)*
+*Defined in [api/types.ts:921](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L921)*
 
 ___
 <a id="outputtoken"></a>
@@ -35,7 +35,7 @@ ___
 
 **● OutputToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:919](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L919)*
+*Defined in [api/types.ts:919](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L919)*
 
 ___
 <a id="sendprimacy"></a>
@@ -44,7 +44,7 @@ ___
 
 **● SendPrimacy**: *`string`*
 
-*Defined in [api/types.ts:920](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L920)*
+*Defined in [api/types.ts:920](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L920)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audiooutputconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.audiooutputconfigurationoptions.md
@@ -26,7 +26,7 @@ Tokens of the physical Audio outputs (typically one).
 
 **● OutputLevelRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:930](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L930)*
+*Defined in [api/types.ts:930](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L930)*
 
 ___
 <a id="outputtokensavailable"></a>
@@ -35,7 +35,7 @@ ___
 
 **● OutputTokensAvailable**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:928](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L928)*
+*Defined in [api/types.ts:928](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L928)*
 
 ___
 <a id="sendprimacyoptions"></a>
@@ -44,7 +44,7 @@ ___
 
 **● SendPrimacyOptions**: *`string`*
 
-*Defined in [api/types.ts:929](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L929)*
+*Defined in [api/types.ts:929](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L929)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audiosource.md
+++ b/docs/interfaces/_api_types_.audiosource.md
@@ -24,7 +24,7 @@ Representation of a physical audio input.
 
 **● Channels**: *`number`*
 
-*Defined in [api/types.ts:350](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L350)*
+*Defined in [api/types.ts:350](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L350)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audiosourceconfiguration.md
+++ b/docs/interfaces/_api_types_.audiosourceconfiguration.md
@@ -24,7 +24,7 @@ Token of the Audio Source the configuration applies to
 
 **● SourceToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:689](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L689)*
+*Defined in [api/types.ts:689](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L689)*
 
 ___
 

--- a/docs/interfaces/_api_types_.audiosourceconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.audiosourceconfigurationoptions.md
@@ -25,7 +25,7 @@ Tokens of the audio source the configuration can be used for.
 
 **● Extension**: *[AudioSourceOptionsExtension](_api_types_.audiosourceoptionsextension.md)*
 
-*Defined in [api/types.ts:697](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L697)*
+*Defined in [api/types.ts:697](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L697)*
 
 ___
 <a id="inputtokensavailable"></a>
@@ -34,7 +34,7 @@ ___
 
 **● InputTokensAvailable**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:696](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L696)*
+*Defined in [api/types.ts:696](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L696)*
 
 ___
 

--- a/docs/interfaces/_api_types_.backlightcompensation.md
+++ b/docs/interfaces/_api_types_.backlightcompensation.md
@@ -25,7 +25,7 @@ Backlight compensation mode (on/off).
 
 **● Level**: *`number`*
 
-*Defined in [api/types.ts:2511](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2511)*
+*Defined in [api/types.ts:2511](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2511)*
 
 ___
 <a id="mode"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Mode**: *[BacklightCompensationMode](../enums/_api_types_.backlightcompensationmode.md)*
 
-*Defined in [api/types.ts:2510](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2510)*
+*Defined in [api/types.ts:2510](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2510)*
 
 ___
 

--- a/docs/interfaces/_api_types_.backlightcompensation20.md
+++ b/docs/interfaces/_api_types_.backlightcompensation20.md
@@ -25,7 +25,7 @@ Type describing whether BLC mode is enabled or disabled (on/off).
 
 **● Level**: *`number`*
 
-*Defined in [api/types.ts:2796](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2796)*
+*Defined in [api/types.ts:2796](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2796)*
 
 ___
 <a id="mode"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Mode**: *[BacklightCompensationMode](../enums/_api_types_.backlightcompensationmode.md)*
 
-*Defined in [api/types.ts:2795](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2795)*
+*Defined in [api/types.ts:2795](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2795)*
 
 ___
 

--- a/docs/interfaces/_api_types_.backlightcompensationoptions.md
+++ b/docs/interfaces/_api_types_.backlightcompensationoptions.md
@@ -23,7 +23,7 @@
 
 **● Level**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2543](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2543)*
+*Defined in [api/types.ts:2543](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2543)*
 
 ___
 <a id="mode"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Mode**: *[WideDynamicMode](../enums/_api_types_.widedynamicmode.md)*
 
-*Defined in [api/types.ts:2542](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2542)*
+*Defined in [api/types.ts:2542](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2542)*
 
 ___
 

--- a/docs/interfaces/_api_types_.backlightcompensationoptions20.md
+++ b/docs/interfaces/_api_types_.backlightcompensationoptions20.md
@@ -27,7 +27,7 @@
 
 **● Level**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2951](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2951)*
+*Defined in [api/types.ts:2951](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2951)*
 
 ___
 <a id="mode"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Mode**: *[BacklightCompensationMode](../enums/_api_types_.backlightcompensationmode.md)*
 
-*Defined in [api/types.ts:2950](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2950)*
+*Defined in [api/types.ts:2950](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2950)*
 
 ___
 

--- a/docs/interfaces/_api_types_.backupfile.md
+++ b/docs/interfaces/_api_types_.backupfile.md
@@ -23,7 +23,7 @@
 
 **● Data**: *[AttachmentData](_api_types_.attachmentdata.md)*
 
-*Defined in [api/types.ts:1785](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1785)*
+*Defined in [api/types.ts:1785](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1785)*
 
 ___
 <a id="name"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Name**: *`string`*
 
-*Defined in [api/types.ts:1784](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1784)*
+*Defined in [api/types.ts:1784](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1784)*
 
 ___
 

--- a/docs/interfaces/_api_types_.binarydata.md
+++ b/docs/interfaces/_api_types_.binarydata.md
@@ -24,7 +24,7 @@ base64 encoded binary data.
 
 **● Data**: *`string`*
 
-*Defined in [api/types.ts:1771](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1771)*
+*Defined in [api/types.ts:1771](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1771)*
 
 ___
 

--- a/docs/interfaces/_api_types_.capabilities.md
+++ b/docs/interfaces/_api_types_.capabilities.md
@@ -30,7 +30,7 @@ Analytics capabilities
 
 **● Analytics**: *[AnalyticsCapabilities](_api_types_.analyticscapabilities.md)*
 
-*Defined in [api/types.ts:1438](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1438)*
+*Defined in [api/types.ts:1438](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1438)*
 
 ___
 <a id="device"></a>
@@ -39,7 +39,7 @@ ___
 
 **● Device**: *[DeviceCapabilities](_api_types_.devicecapabilities.md)*
 
-*Defined in [api/types.ts:1439](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1439)*
+*Defined in [api/types.ts:1439](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1439)*
 
 ___
 <a id="events"></a>
@@ -48,7 +48,7 @@ ___
 
 **● Events**: *[EventCapabilities](_api_types_.eventcapabilities.md)*
 
-*Defined in [api/types.ts:1440](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1440)*
+*Defined in [api/types.ts:1440](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1440)*
 
 ___
 <a id="extension"></a>
@@ -57,7 +57,7 @@ ___
 
 **● Extension**: *[CapabilitiesExtension](_api_types_.capabilitiesextension.md)*
 
-*Defined in [api/types.ts:1444](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1444)*
+*Defined in [api/types.ts:1444](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1444)*
 
 ___
 <a id="imaging"></a>
@@ -66,7 +66,7 @@ ___
 
 **● Imaging**: *[ImagingCapabilities](_api_types_.imagingcapabilities.md)*
 
-*Defined in [api/types.ts:1441](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1441)*
+*Defined in [api/types.ts:1441](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1441)*
 
 ___
 <a id="media"></a>
@@ -75,7 +75,7 @@ ___
 
 **● Media**: *[MediaCapabilities](_api_types_.mediacapabilities.md)*
 
-*Defined in [api/types.ts:1442](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1442)*
+*Defined in [api/types.ts:1442](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1442)*
 
 ___
 <a id="ptz"></a>
@@ -84,7 +84,7 @@ ___
 
 **● PTZ**: *[PTZCapabilities](_api_types_.ptzcapabilities.md)*
 
-*Defined in [api/types.ts:1443](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1443)*
+*Defined in [api/types.ts:1443](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1443)*
 
 ___
 

--- a/docs/interfaces/_api_types_.capabilitiesextension.md
+++ b/docs/interfaces/_api_types_.capabilitiesextension.md
@@ -29,7 +29,7 @@
 
 **● AnalyticsDevice**: *[AnalyticsDeviceCapabilities](_api_types_.analyticsdevicecapabilities.md)*
 
-*Defined in [api/types.ts:1457](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1457)*
+*Defined in [api/types.ts:1457](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1457)*
 
 ___
 <a id="deviceio"></a>
@@ -38,7 +38,7 @@ ___
 
 **● DeviceIO**: *[DeviceIOCapabilities](_api_types_.deviceiocapabilities.md)*
 
-*Defined in [api/types.ts:1451](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1451)*
+*Defined in [api/types.ts:1451](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1451)*
 
 ___
 <a id="display"></a>
@@ -47,7 +47,7 @@ ___
 
 **● Display**: *[DisplayCapabilities](_api_types_.displaycapabilities.md)*
 
-*Defined in [api/types.ts:1452](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1452)*
+*Defined in [api/types.ts:1452](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1452)*
 
 ___
 <a id="extensions"></a>
@@ -56,7 +56,7 @@ ___
 
 **● Extensions**: *[CapabilitiesExtension2](_api_types_.capabilitiesextension2.md)*
 
-*Defined in [api/types.ts:1458](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1458)*
+*Defined in [api/types.ts:1458](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1458)*
 
 ___
 <a id="receiver"></a>
@@ -65,7 +65,7 @@ ___
 
 **● Receiver**: *[ReceiverCapabilities](_api_types_.receivercapabilities.md)*
 
-*Defined in [api/types.ts:1456](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1456)*
+*Defined in [api/types.ts:1456](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1456)*
 
 ___
 <a id="recording"></a>
@@ -74,7 +74,7 @@ ___
 
 **● Recording**: *[RecordingCapabilities](_api_types_.recordingcapabilities.md)*
 
-*Defined in [api/types.ts:1453](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1453)*
+*Defined in [api/types.ts:1453](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1453)*
 
 ___
 <a id="replay"></a>
@@ -83,7 +83,7 @@ ___
 
 **● Replay**: *[ReplayCapabilities](_api_types_.replaycapabilities.md)*
 
-*Defined in [api/types.ts:1455](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1455)*
+*Defined in [api/types.ts:1455](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1455)*
 
 ___
 <a id="search"></a>
@@ -92,7 +92,7 @@ ___
 
 **● Search**: *[SearchCapabilities](_api_types_.searchcapabilities.md)*
 
-*Defined in [api/types.ts:1454](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1454)*
+*Defined in [api/types.ts:1454](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1454)*
 
 ___
 

--- a/docs/interfaces/_api_types_.celllayout.md
+++ b/docs/interfaces/_api_types_.celllayout.md
@@ -24,7 +24,7 @@ Mapping of the cell grid to the Video frame. The cell grid is starting from the 
 
 **● Transformation**: *[Transformation](_api_types_.transformation.md)*
 
-*Defined in [api/types.ts:3312](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3312)*
+*Defined in [api/types.ts:3312](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3312)*
 
 ___
 

--- a/docs/interfaces/_api_types_.certificate.md
+++ b/docs/interfaces/_api_types_.certificate.md
@@ -25,7 +25,7 @@ Certificate id.
 
 **● Certificate**: *[BinaryData](_api_types_.binarydata.md)*
 
-*Defined in [api/types.ts:1912](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1912)*
+*Defined in [api/types.ts:1912](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1912)*
 
 ___
 <a id="certificateid"></a>
@@ -34,7 +34,7 @@ ___
 
 **● CertificateID**: *`string`*
 
-*Defined in [api/types.ts:1911](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1911)*
+*Defined in [api/types.ts:1911](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1911)*
 
 ___
 

--- a/docs/interfaces/_api_types_.certificategenerationparameters.md
+++ b/docs/interfaces/_api_types_.certificategenerationparameters.md
@@ -26,7 +26,7 @@
 
 **● CertificateID**: *`string`*
 
-*Defined in [api/types.ts:1894](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1894)*
+*Defined in [api/types.ts:1894](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1894)*
 
 ___
 <a id="extension"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Extension**: *[CertificateGenerationParametersExtension](_api_types_.certificategenerationparametersextension.md)*
 
-*Defined in [api/types.ts:1898](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1898)*
+*Defined in [api/types.ts:1898](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1898)*
 
 ___
 <a id="subject"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Subject**: *`string`*
 
-*Defined in [api/types.ts:1895](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1895)*
+*Defined in [api/types.ts:1895](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1895)*
 
 ___
 <a id="validnotafter"></a>
@@ -53,7 +53,7 @@ ___
 
 **● ValidNotAfter**: *`string`*
 
-*Defined in [api/types.ts:1897](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1897)*
+*Defined in [api/types.ts:1897](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1897)*
 
 ___
 <a id="validnotbefore"></a>
@@ -62,7 +62,7 @@ ___
 
 **● ValidNotBefore**: *`string`*
 
-*Defined in [api/types.ts:1896](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1896)*
+*Defined in [api/types.ts:1896](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1896)*
 
 ___
 

--- a/docs/interfaces/_api_types_.certificateinformation.md
+++ b/docs/interfaces/_api_types_.certificateinformation.md
@@ -34,7 +34,7 @@ Validity Range is from "NotBefore" to "NotAfter"; the corresponding DateTimeRang
 
 **● CertificateID**: *`string`*
 
-*Defined in [api/types.ts:1936](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1936)*
+*Defined in [api/types.ts:1936](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1936)*
 
 ___
 <a id="extendedkeyusage"></a>
@@ -43,7 +43,7 @@ ___
 
 **● ExtendedKeyUsage**: *[CertificateUsage](_api_types_.certificateusage.md)*
 
-*Defined in [api/types.ts:1940](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1940)*
+*Defined in [api/types.ts:1940](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1940)*
 
 ___
 <a id="extension"></a>
@@ -52,7 +52,7 @@ ___
 
 **● Extension**: *[CertificateInformationExtension](_api_types_.certificateinformationextension.md)*
 
-*Defined in [api/types.ts:1946](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1946)*
+*Defined in [api/types.ts:1946](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1946)*
 
 ___
 <a id="issuerdn"></a>
@@ -61,7 +61,7 @@ ___
 
 **● IssuerDN**: *`string`*
 
-*Defined in [api/types.ts:1937](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1937)*
+*Defined in [api/types.ts:1937](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1937)*
 
 ___
 <a id="keylength"></a>
@@ -70,7 +70,7 @@ ___
 
 **● KeyLength**: *`number`*
 
-*Defined in [api/types.ts:1941](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1941)*
+*Defined in [api/types.ts:1941](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1941)*
 
 ___
 <a id="keyusage"></a>
@@ -79,7 +79,7 @@ ___
 
 **● KeyUsage**: *[CertificateUsage](_api_types_.certificateusage.md)*
 
-*Defined in [api/types.ts:1939](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1939)*
+*Defined in [api/types.ts:1939](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1939)*
 
 ___
 <a id="serialnum"></a>
@@ -88,7 +88,7 @@ ___
 
 **● SerialNum**: *`string`*
 
-*Defined in [api/types.ts:1943](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1943)*
+*Defined in [api/types.ts:1943](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1943)*
 
 ___
 <a id="signaturealgorithm"></a>
@@ -97,7 +97,7 @@ ___
 
 **● SignatureAlgorithm**: *`string`*
 
-*Defined in [api/types.ts:1944](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1944)*
+*Defined in [api/types.ts:1944](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1944)*
 
 ___
 <a id="subjectdn"></a>
@@ -106,7 +106,7 @@ ___
 
 **● SubjectDN**: *`string`*
 
-*Defined in [api/types.ts:1938](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1938)*
+*Defined in [api/types.ts:1938](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1938)*
 
 ___
 <a id="validity"></a>
@@ -115,7 +115,7 @@ ___
 
 **● Validity**: *[DateTimeRange](_api_types_.datetimerange.md)*
 
-*Defined in [api/types.ts:1945](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1945)*
+*Defined in [api/types.ts:1945](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1945)*
 
 ___
 <a id="version"></a>
@@ -124,7 +124,7 @@ ___
 
 **● Version**: *`string`*
 
-*Defined in [api/types.ts:1942](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1942)*
+*Defined in [api/types.ts:1942](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1942)*
 
 ___
 

--- a/docs/interfaces/_api_types_.certificatestatus.md
+++ b/docs/interfaces/_api_types_.certificatestatus.md
@@ -25,7 +25,7 @@ Certificate id.
 
 **● CertificateID**: *`string`*
 
-*Defined in [api/types.ts:1919](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1919)*
+*Defined in [api/types.ts:1919](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1919)*
 
 ___
 <a id="status"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Status**: *`boolean`*
 
-*Defined in [api/types.ts:1920](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1920)*
+*Defined in [api/types.ts:1920](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1920)*
 
 ___
 

--- a/docs/interfaces/_api_types_.certificatewithprivatekey.md
+++ b/docs/interfaces/_api_types_.certificatewithprivatekey.md
@@ -24,7 +24,7 @@
 
 **● Certificate**: *[BinaryData](_api_types_.binarydata.md)*
 
-*Defined in [api/types.ts:1928](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1928)*
+*Defined in [api/types.ts:1928](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1928)*
 
 ___
 <a id="certificateid"></a>
@@ -33,7 +33,7 @@ ___
 
 **● CertificateID**: *`string`*
 
-*Defined in [api/types.ts:1927](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1927)*
+*Defined in [api/types.ts:1927](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1927)*
 
 ___
 <a id="privatekey"></a>
@@ -42,7 +42,7 @@ ___
 
 **● PrivateKey**: *[BinaryData](_api_types_.binarydata.md)*
 
-*Defined in [api/types.ts:1929](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1929)*
+*Defined in [api/types.ts:1929](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1929)*
 
 ___
 

--- a/docs/interfaces/_api_types_.codingcapabilities.md
+++ b/docs/interfaces/_api_types_.codingcapabilities.md
@@ -26,7 +26,7 @@ This type contains the Audio and Video coding capabilities of a display service.
 
 **● AudioDecodingCapabilities**: *[AudioDecoderConfigurationOptions](_api_types_.audiodecoderconfigurationoptions.md)*
 
-*Defined in [api/types.ts:3354](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3354)*
+*Defined in [api/types.ts:3354](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3354)*
 
 ___
 <a id="audioencodingcapabilities"></a>
@@ -35,7 +35,7 @@ ___
 
 **● AudioEncodingCapabilities**: *[AudioEncoderConfigurationOptions](_api_types_.audioencoderconfigurationoptions.md)*
 
-*Defined in [api/types.ts:3353](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3353)*
+*Defined in [api/types.ts:3353](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3353)*
 
 ___
 <a id="videodecodingcapabilities"></a>
@@ -44,7 +44,7 @@ ___
 
 **● VideoDecodingCapabilities**: *[VideoDecoderConfigurationOptions](_api_types_.videodecoderconfigurationoptions.md)*
 
-*Defined in [api/types.ts:3355](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3355)*
+*Defined in [api/types.ts:3355](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3355)*
 
 ___
 

--- a/docs/interfaces/_api_types_.coloroptions.md
+++ b/docs/interfaces/_api_types_.coloroptions.md
@@ -25,7 +25,7 @@ Describe the option of the color supported. Either list each color or define the
 
 **● ColorList**: *[Color](_api_types_.color.md)*
 
-*Defined in [api/types.ts:4049](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4049)*
+*Defined in [api/types.ts:4049](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4049)*
 
 ___
 <a id="colorspacerange"></a>
@@ -34,7 +34,7 @@ ___
 
 **● ColorspaceRange**: *[ColorspaceRange](_api_types_.colorspacerange.md)*
 
-*Defined in [api/types.ts:4050](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4050)*
+*Defined in [api/types.ts:4050](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4050)*
 
 ___
 

--- a/docs/interfaces/_api_types_.colorspacerange.md
+++ b/docs/interfaces/_api_types_.colorspacerange.md
@@ -25,7 +25,7 @@
 
 **● Colorspace**: *`string`*
 
-*Defined in [api/types.ts:4038](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4038)*
+*Defined in [api/types.ts:4038](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4038)*
 
 ___
 <a id="x"></a>
@@ -34,7 +34,7 @@ ___
 
 **● X**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:4035](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4035)*
+*Defined in [api/types.ts:4035](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4035)*
 
 ___
 <a id="y"></a>
@@ -43,7 +43,7 @@ ___
 
 **● Y**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:4036](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4036)*
+*Defined in [api/types.ts:4036](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4036)*
 
 ___
 <a id="z"></a>
@@ -52,7 +52,7 @@ ___
 
 **● Z**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:4037](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4037)*
+*Defined in [api/types.ts:4037](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4037)*
 
 ___
 

--- a/docs/interfaces/_api_types_.config.md
+++ b/docs/interfaces/_api_types_.config.md
@@ -24,7 +24,7 @@ List of configuration parameters as defined in the correspding description.
 
 **● Parameters**: *[ItemList](_api_types_.itemlist.md)*
 
-*Defined in [api/types.ts:3210](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3210)*
+*Defined in [api/types.ts:3210](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3210)*
 
 ___
 

--- a/docs/interfaces/_api_types_.configdescription.md
+++ b/docs/interfaces/_api_types_.configdescription.md
@@ -31,7 +31,7 @@
 
 **● Extension**: *[ConfigDescriptionExtension](_api_types_.configdescriptionextension.md)*
 
-*Defined in [api/types.ts:3224](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3224)*
+*Defined in [api/types.ts:3224](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3224)*
 
 ___
 <a id="messages"></a>
@@ -40,7 +40,7 @@ ___
 
 **● Messages**: *`any`*
 
-*Defined in [api/types.ts:3222](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3222)*
+*Defined in [api/types.ts:3222](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3222)*
 
 ___
 <a id="parameters"></a>
@@ -49,7 +49,7 @@ ___
 
 **● Parameters**: *[ItemListDescription](_api_types_.itemlistdescription.md)*
 
-*Defined in [api/types.ts:3221](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3221)*
+*Defined in [api/types.ts:3221](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3221)*
 
 ___
 <a id="parenttopic"></a>
@@ -58,7 +58,7 @@ ___
 
 **● ParentTopic**: *`string`*
 
-*Defined in [api/types.ts:3223](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3223)*
+*Defined in [api/types.ts:3223](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3223)*
 
 ___
 

--- a/docs/interfaces/_api_types_.configurationentity.md
+++ b/docs/interfaces/_api_types_.configurationentity.md
@@ -25,7 +25,7 @@ Base type defining the common properties of a configuration.
 
 **● Name**: *[Name](_api_types_.configurationentity.md#name)*
 
-*Defined in [api/types.ts:396](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L396)*
+*Defined in [api/types.ts:396](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L396)*
 
 ___
 <a id="usecount"></a>
@@ -34,7 +34,7 @@ ___
 
 **● UseCount**: *`number`*
 
-*Defined in [api/types.ts:397](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L397)*
+*Defined in [api/types.ts:397](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L397)*
 
 ___
 

--- a/docs/interfaces/_api_types_.continuousfocus.md
+++ b/docs/interfaces/_api_types_.continuousfocus.md
@@ -26,7 +26,7 @@
 
 **● Speed**: *`number`*
 
-*Defined in [api/types.ts:2619](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2619)*
+*Defined in [api/types.ts:2619](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2619)*
 
 ___
 

--- a/docs/interfaces/_api_types_.continuousfocusoptions.md
+++ b/docs/interfaces/_api_types_.continuousfocusoptions.md
@@ -26,7 +26,7 @@
 
 **● Speed**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2657](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2657)*
+*Defined in [api/types.ts:2657](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2657)*
 
 ___
 

--- a/docs/interfaces/_api_types_.date.md
+++ b/docs/interfaces/_api_types_.date.md
@@ -26,7 +26,7 @@ Range is 1 to 12.
 
 **● Day**: *`number`*
 
-*Defined in [api/types.ts:1835](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1835)*
+*Defined in [api/types.ts:1835](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1835)*
 
 ___
 <a id="month"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Month**: *`number`*
 
-*Defined in [api/types.ts:1834](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1834)*
+*Defined in [api/types.ts:1834](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1834)*
 
 ___
 <a id="year"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Year**: *`number`*
 
-*Defined in [api/types.ts:1833](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1833)*
+*Defined in [api/types.ts:1833](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1833)*
 
 ___
 

--- a/docs/interfaces/_api_types_.datetime.md
+++ b/docs/interfaces/_api_types_.datetime.md
@@ -23,7 +23,7 @@
 
 **● Date**: *[Date](_api_types_.date.md)*
 
-*Defined in [api/types.ts:1826](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1826)*
+*Defined in [api/types.ts:1826](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1826)*
 
 ___
 <a id="time"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Time**: *[Time](_api_types_.time.md)*
 
-*Defined in [api/types.ts:1825](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1825)*
+*Defined in [api/types.ts:1825](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1825)*
 
 ___
 

--- a/docs/interfaces/_api_types_.datetimerange.md
+++ b/docs/interfaces/_api_types_.datetimerange.md
@@ -23,7 +23,7 @@
 
 **● From**: *`string`*
 
-*Defined in [api/types.ts:3428](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3428)*
+*Defined in [api/types.ts:3428](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3428)*
 
 ___
 <a id="until"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Until**: *`string`*
 
-*Defined in [api/types.ts:3429](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3429)*
+*Defined in [api/types.ts:3429](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3429)*
 
 ___
 

--- a/docs/interfaces/_api_types_.defogging.md
+++ b/docs/interfaces/_api_types_.defogging.md
@@ -26,7 +26,7 @@ Parameter to enable/disable or automatic Defogging feature. Its options shall be
 
 **● Extension**: *[DefoggingExtension](_api_types_.defoggingextension.md)*
 
-*Defined in [api/types.ts:2838](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2838)*
+*Defined in [api/types.ts:2838](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2838)*
 
 ___
 <a id="level"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Level**: *`number`*
 
-*Defined in [api/types.ts:2837](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2837)*
+*Defined in [api/types.ts:2837](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2837)*
 
 ___
 <a id="mode"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Mode**: *`string`*
 
-*Defined in [api/types.ts:2836](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2836)*
+*Defined in [api/types.ts:2836](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2836)*
 
 ___
 

--- a/docs/interfaces/_api_types_.defoggingoptions.md
+++ b/docs/interfaces/_api_types_.defoggingoptions.md
@@ -25,7 +25,7 @@ Supported options for Defogging mode. Its options shall be chosen from tt:Defogg
 
 **● Level**: *`boolean`*
 
-*Defined in [api/types.ts:3098](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3098)*
+*Defined in [api/types.ts:3098](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3098)*
 
 ___
 <a id="mode"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Mode**: *`string`*
 
-*Defined in [api/types.ts:3097](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3097)*
+*Defined in [api/types.ts:3097](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3097)*
 
 ___
 

--- a/docs/interfaces/_api_types_.devicecapabilities.md
+++ b/docs/interfaces/_api_types_.devicecapabilities.md
@@ -29,7 +29,7 @@ Device service URI.
 
 **● Extension**: *[DeviceCapabilitiesExtension](_api_types_.devicecapabilitiesextension.md)*
 
-*Defined in [api/types.ts:1485](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1485)*
+*Defined in [api/types.ts:1485](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1485)*
 
 ___
 <a id="io"></a>
@@ -38,7 +38,7 @@ ___
 
 **● IO**: *[IOCapabilities](_api_types_.iocapabilities.md)*
 
-*Defined in [api/types.ts:1483](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1483)*
+*Defined in [api/types.ts:1483](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1483)*
 
 ___
 <a id="network"></a>
@@ -47,7 +47,7 @@ ___
 
 **● Network**: *[NetworkCapabilities](_api_types_.networkcapabilities.md)*
 
-*Defined in [api/types.ts:1481](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1481)*
+*Defined in [api/types.ts:1481](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1481)*
 
 ___
 <a id="security"></a>
@@ -56,7 +56,7 @@ ___
 
 **● Security**: *[SecurityCapabilities](_api_types_.securitycapabilities.md)*
 
-*Defined in [api/types.ts:1484](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1484)*
+*Defined in [api/types.ts:1484](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1484)*
 
 ___
 <a id="system"></a>
@@ -65,7 +65,7 @@ ___
 
 **● System**: *[SystemCapabilities](_api_types_.systemcapabilities.md)*
 
-*Defined in [api/types.ts:1482](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1482)*
+*Defined in [api/types.ts:1482](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1482)*
 
 ___
 <a id="xaddr"></a>
@@ -74,7 +74,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1480](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1480)*
+*Defined in [api/types.ts:1480](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1480)*
 
 ___
 

--- a/docs/interfaces/_api_types_.deviceiocapabilities.md
+++ b/docs/interfaces/_api_types_.deviceiocapabilities.md
@@ -27,7 +27,7 @@
 
 **● AudioOutputs**: *`number`*
 
-*Defined in [api/types.ts:1685](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1685)*
+*Defined in [api/types.ts:1685](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1685)*
 
 ___
 <a id="audiosources"></a>
@@ -36,7 +36,7 @@ ___
 
 **● AudioSources**: *`number`*
 
-*Defined in [api/types.ts:1684](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1684)*
+*Defined in [api/types.ts:1684](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1684)*
 
 ___
 <a id="relayoutputs"></a>
@@ -45,7 +45,7 @@ ___
 
 **● RelayOutputs**: *`number`*
 
-*Defined in [api/types.ts:1686](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1686)*
+*Defined in [api/types.ts:1686](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1686)*
 
 ___
 <a id="videooutputs"></a>
@@ -54,7 +54,7 @@ ___
 
 **● VideoOutputs**: *`number`*
 
-*Defined in [api/types.ts:1683](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1683)*
+*Defined in [api/types.ts:1683](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1683)*
 
 ___
 <a id="videosources"></a>
@@ -63,7 +63,7 @@ ___
 
 **● VideoSources**: *`number`*
 
-*Defined in [api/types.ts:1682](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1682)*
+*Defined in [api/types.ts:1682](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1682)*
 
 ___
 <a id="xaddr"></a>
@@ -72,7 +72,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1681](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1681)*
+*Defined in [api/types.ts:1681](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1681)*
 
 ___
 

--- a/docs/interfaces/_api_types_.displaycapabilities.md
+++ b/docs/interfaces/_api_types_.displaycapabilities.md
@@ -25,7 +25,7 @@ Indication that the SetLayout command supports only predefined layouts.
 
 **● FixedLayout**: *`boolean`*
 
-*Defined in [api/types.ts:1694](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1694)*
+*Defined in [api/types.ts:1694](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1694)*
 
 ___
 <a id="xaddr"></a>
@@ -34,7 +34,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1693](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1693)*
+*Defined in [api/types.ts:1693](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1693)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dnsinformation.md
+++ b/docs/interfaces/_api_types_.dnsinformation.md
@@ -28,7 +28,7 @@ Indicates whether or not DNS information is retrieved from DHCP.
 
 **● DNSFromDHCP**: *[IPAddress](_api_types_.ipaddress.md)*
 
-*Defined in [api/types.ts:1209](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1209)*
+*Defined in [api/types.ts:1209](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1209)*
 
 ___
 <a id="dnsmanual"></a>
@@ -37,7 +37,7 @@ ___
 
 **● DNSManual**: *[IPAddress](_api_types_.ipaddress.md)*
 
-*Defined in [api/types.ts:1210](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1210)*
+*Defined in [api/types.ts:1210](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1210)*
 
 ___
 <a id="extension"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Extension**: *[DNSInformationExtension](_api_types_.dnsinformationextension.md)*
 
-*Defined in [api/types.ts:1211](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1211)*
+*Defined in [api/types.ts:1211](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1211)*
 
 ___
 <a id="fromdhcp"></a>
@@ -55,7 +55,7 @@ ___
 
 **● FromDHCP**: *`boolean`*
 
-*Defined in [api/types.ts:1207](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1207)*
+*Defined in [api/types.ts:1207](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1207)*
 
 ___
 <a id="searchdomain"></a>
@@ -64,7 +64,7 @@ ___
 
 **● SearchDomain**: *`string`*
 
-*Defined in [api/types.ts:1208](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1208)*
+*Defined in [api/types.ts:1208](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1208)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dot11availablenetworks.md
+++ b/docs/interfaces/_api_types_.dot11availablenetworks.md
@@ -30,7 +30,7 @@ See IEEE802.11 7.3.2.25.2 for details.
 
 **● AuthAndMangementSuite**: *[Dot11AuthAndMangementSuite](../enums/_api_types_.dot11authandmangementsuite.md)*
 
-*Defined in [api/types.ts:1421](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1421)*
+*Defined in [api/types.ts:1421](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1421)*
 
 ___
 <a id="bssid"></a>
@@ -39,7 +39,7 @@ ___
 
 **● BSSID**: *`string`*
 
-*Defined in [api/types.ts:1420](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1420)*
+*Defined in [api/types.ts:1420](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1420)*
 
 ___
 <a id="extension"></a>
@@ -48,7 +48,7 @@ ___
 
 **● Extension**: *[Dot11AvailableNetworksExtension](_api_types_.dot11availablenetworksextension.md)*
 
-*Defined in [api/types.ts:1425](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1425)*
+*Defined in [api/types.ts:1425](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1425)*
 
 ___
 <a id="groupcipher"></a>
@@ -57,7 +57,7 @@ ___
 
 **● GroupCipher**: *[Dot11Cipher](../enums/_api_types_.dot11cipher.md)*
 
-*Defined in [api/types.ts:1423](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1423)*
+*Defined in [api/types.ts:1423](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1423)*
 
 ___
 <a id="paircipher"></a>
@@ -66,7 +66,7 @@ ___
 
 **● PairCipher**: *[Dot11Cipher](../enums/_api_types_.dot11cipher.md)*
 
-*Defined in [api/types.ts:1422](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1422)*
+*Defined in [api/types.ts:1422](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1422)*
 
 ___
 <a id="ssid"></a>
@@ -75,7 +75,7 @@ ___
 
 **● SSID**: *[Dot11SSIDType](../modules/_api_types_.md#dot11ssidtype)*
 
-*Defined in [api/types.ts:1419](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1419)*
+*Defined in [api/types.ts:1419](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1419)*
 
 ___
 <a id="signalstrength"></a>
@@ -84,7 +84,7 @@ ___
 
 **● SignalStrength**: *[Dot11SignalStrength](../enums/_api_types_.dot11signalstrength.md)*
 
-*Defined in [api/types.ts:1424](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1424)*
+*Defined in [api/types.ts:1424](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1424)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dot11capabilities.md
+++ b/docs/interfaces/_api_types_.dot11capabilities.md
@@ -26,7 +26,7 @@
 
 **● AdHocStationMode**: *`boolean`*
 
-*Defined in [api/types.ts:1399](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1399)*
+*Defined in [api/types.ts:1399](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1399)*
 
 ___
 <a id="multipleconfiguration"></a>
@@ -35,7 +35,7 @@ ___
 
 **● MultipleConfiguration**: *`boolean`*
 
-*Defined in [api/types.ts:1398](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1398)*
+*Defined in [api/types.ts:1398](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1398)*
 
 ___
 <a id="scanavailablenetworks"></a>
@@ -44,7 +44,7 @@ ___
 
 **● ScanAvailableNetworks**: *`boolean`*
 
-*Defined in [api/types.ts:1397](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1397)*
+*Defined in [api/types.ts:1397](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1397)*
 
 ___
 <a id="tkip"></a>
@@ -53,7 +53,7 @@ ___
 
 **● TKIP**: *`boolean`*
 
-*Defined in [api/types.ts:1396](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1396)*
+*Defined in [api/types.ts:1396](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1396)*
 
 ___
 <a id="wep"></a>
@@ -62,7 +62,7 @@ ___
 
 **● WEP**: *`boolean`*
 
-*Defined in [api/types.ts:1400](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1400)*
+*Defined in [api/types.ts:1400](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1400)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dot11configuration.md
+++ b/docs/interfaces/_api_types_.dot11configuration.md
@@ -26,7 +26,7 @@
 
 **● Alias**: *[Name](../modules/_api_types_.md#name)*
 
-*Defined in [api/types.ts:1346](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1346)*
+*Defined in [api/types.ts:1346](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1346)*
 
 ___
 <a id="mode"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Mode**: *[Dot11StationMode](../enums/_api_types_.dot11stationmode.md)*
 
-*Defined in [api/types.ts:1345](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1345)*
+*Defined in [api/types.ts:1345](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1345)*
 
 ___
 <a id="priority"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Priority**: *[NetworkInterfaceConfigPriority](../modules/_api_types_.md#networkinterfaceconfigpriority)*
 
-*Defined in [api/types.ts:1347](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1347)*
+*Defined in [api/types.ts:1347](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1347)*
 
 ___
 <a id="ssid"></a>
@@ -53,7 +53,7 @@ ___
 
 **● SSID**: *[Dot11SSIDType](../modules/_api_types_.md#dot11ssidtype)*
 
-*Defined in [api/types.ts:1344](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1344)*
+*Defined in [api/types.ts:1344](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1344)*
 
 ___
 <a id="security"></a>
@@ -62,7 +62,7 @@ ___
 
 **● Security**: *[Dot11SecurityConfiguration](_api_types_.dot11securityconfiguration.md)*
 
-*Defined in [api/types.ts:1348](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1348)*
+*Defined in [api/types.ts:1348](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1348)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dot11pskset.md
+++ b/docs/interfaces/_api_types_.dot11pskset.md
@@ -29,7 +29,7 @@
 
 **● Extension**: *[Dot11PSKSetExtension](_api_types_.dot11psksetextension.md)*
 
-*Defined in [api/types.ts:1377](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1377)*
+*Defined in [api/types.ts:1377](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1377)*
 
 ___
 <a id="key"></a>
@@ -38,7 +38,7 @@ ___
 
 **● Key**: *[Dot11PSK](../modules/_api_types_.md#dot11psk)*
 
-*Defined in [api/types.ts:1375](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1375)*
+*Defined in [api/types.ts:1375](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1375)*
 
 ___
 <a id="passphrase"></a>
@@ -47,7 +47,7 @@ ___
 
 **● Passphrase**: *[Dot11PSKPassphrase](../modules/_api_types_.md#dot11pskpassphrase)*
 
-*Defined in [api/types.ts:1376](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1376)*
+*Defined in [api/types.ts:1376](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1376)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dot11securityconfiguration.md
+++ b/docs/interfaces/_api_types_.dot11securityconfiguration.md
@@ -26,7 +26,7 @@
 
 **● Algorithm**: *[Dot11Cipher](../enums/_api_types_.dot11cipher.md)*
 
-*Defined in [api/types.ts:1356](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1356)*
+*Defined in [api/types.ts:1356](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1356)*
 
 ___
 <a id="dot1x"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Dot1X**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:1358](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1358)*
+*Defined in [api/types.ts:1358](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1358)*
 
 ___
 <a id="extension"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Extension**: *[Dot11SecurityConfigurationExtension](_api_types_.dot11securityconfigurationextension.md)*
 
-*Defined in [api/types.ts:1359](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1359)*
+*Defined in [api/types.ts:1359](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1359)*
 
 ___
 <a id="mode"></a>
@@ -53,7 +53,7 @@ ___
 
 **● Mode**: *[Dot11SecurityMode](../enums/_api_types_.dot11securitymode.md)*
 
-*Defined in [api/types.ts:1355](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1355)*
+*Defined in [api/types.ts:1355](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1355)*
 
 ___
 <a id="psk"></a>
@@ -62,7 +62,7 @@ ___
 
 **● PSK**: *[Dot11PSKSet](_api_types_.dot11pskset.md)*
 
-*Defined in [api/types.ts:1357](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1357)*
+*Defined in [api/types.ts:1357](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1357)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dot11status.md
+++ b/docs/interfaces/_api_types_.dot11status.md
@@ -27,7 +27,7 @@
 
 **● ActiveConfigAlias**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:1412](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1412)*
+*Defined in [api/types.ts:1412](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1412)*
 
 ___
 <a id="bssid"></a>
@@ -36,7 +36,7 @@ ___
 
 **● BSSID**: *`string`*
 
-*Defined in [api/types.ts:1408](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1408)*
+*Defined in [api/types.ts:1408](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1408)*
 
 ___
 <a id="groupcipher"></a>
@@ -45,7 +45,7 @@ ___
 
 **● GroupCipher**: *[Dot11Cipher](../enums/_api_types_.dot11cipher.md)*
 
-*Defined in [api/types.ts:1410](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1410)*
+*Defined in [api/types.ts:1410](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1410)*
 
 ___
 <a id="paircipher"></a>
@@ -54,7 +54,7 @@ ___
 
 **● PairCipher**: *[Dot11Cipher](../enums/_api_types_.dot11cipher.md)*
 
-*Defined in [api/types.ts:1409](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1409)*
+*Defined in [api/types.ts:1409](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1409)*
 
 ___
 <a id="ssid"></a>
@@ -63,7 +63,7 @@ ___
 
 **● SSID**: *[Dot11SSIDType](../modules/_api_types_.md#dot11ssidtype)*
 
-*Defined in [api/types.ts:1407](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1407)*
+*Defined in [api/types.ts:1407](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1407)*
 
 ___
 <a id="signalstrength"></a>
@@ -72,7 +72,7 @@ ___
 
 **● SignalStrength**: *[Dot11SignalStrength](../enums/_api_types_.dot11signalstrength.md)*
 
-*Defined in [api/types.ts:1411](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1411)*
+*Defined in [api/types.ts:1411](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1411)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dot1xconfiguration.md
+++ b/docs/interfaces/_api_types_.dot1xconfiguration.md
@@ -32,7 +32,7 @@
 
 **● AnonymousID**: *`string`*
 
-*Defined in [api/types.ts:1969](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1969)*
+*Defined in [api/types.ts:1969](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1969)*
 
 ___
 <a id="cacertificateid"></a>
@@ -41,7 +41,7 @@ ___
 
 **● CACertificateID**: *`string`*
 
-*Defined in [api/types.ts:1971](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1971)*
+*Defined in [api/types.ts:1971](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1971)*
 
 ___
 <a id="dot1xconfigurationtoken"></a>
@@ -50,7 +50,7 @@ ___
 
 **● Dot1XConfigurationToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:1967](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1967)*
+*Defined in [api/types.ts:1967](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1967)*
 
 ___
 <a id="eapmethod"></a>
@@ -59,7 +59,7 @@ ___
 
 **● EAPMethod**: *`number`*
 
-*Defined in [api/types.ts:1970](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1970)*
+*Defined in [api/types.ts:1970](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1970)*
 
 ___
 <a id="eapmethodconfiguration"></a>
@@ -68,7 +68,7 @@ ___
 
 **● EAPMethodConfiguration**: *[EAPMethodConfiguration](_api_types_.eapmethodconfiguration.md)*
 
-*Defined in [api/types.ts:1972](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1972)*
+*Defined in [api/types.ts:1972](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1972)*
 
 ___
 <a id="extension"></a>
@@ -77,7 +77,7 @@ ___
 
 **● Extension**: *[Dot1XConfigurationExtension](_api_types_.dot1xconfigurationextension.md)*
 
-*Defined in [api/types.ts:1973](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1973)*
+*Defined in [api/types.ts:1973](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1973)*
 
 ___
 <a id="identity"></a>
@@ -86,7 +86,7 @@ ___
 
 **● Identity**: *`string`*
 
-*Defined in [api/types.ts:1968](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1968)*
+*Defined in [api/types.ts:1968](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1968)*
 
 ___
 

--- a/docs/interfaces/_api_types_.durationrange.md
+++ b/docs/interfaces/_api_types_.durationrange.md
@@ -25,7 +25,7 @@ Range of duration greater equal Min duration and less equal Max duration.
 
 **● Max**: *`string`*
 
-*Defined in [api/types.ts:299](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L299)*
+*Defined in [api/types.ts:299](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L299)*
 
 ___
 <a id="min"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Min**: *`string`*
 
-*Defined in [api/types.ts:298](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L298)*
+*Defined in [api/types.ts:298](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L298)*
 
 ___
 

--- a/docs/interfaces/_api_types_.dynamicdnsinformation.md
+++ b/docs/interfaces/_api_types_.dynamicdnsinformation.md
@@ -27,7 +27,7 @@ Dynamic DNS type.
 
 **● Extension**: *[DynamicDNSInformationExtension](_api_types_.dynamicdnsinformationextension.md)*
 
-*Defined in [api/types.ts:1243](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1243)*
+*Defined in [api/types.ts:1243](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1243)*
 
 ___
 <a id="name"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Name**: *[DNSName](../modules/_api_types_.md#dnsname)*
 
-*Defined in [api/types.ts:1241](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1241)*
+*Defined in [api/types.ts:1241](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1241)*
 
 ___
 <a id="ttl"></a>
@@ -45,7 +45,7 @@ ___
 
 **● TTL**: *`string`*
 
-*Defined in [api/types.ts:1242](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1242)*
+*Defined in [api/types.ts:1242](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1242)*
 
 ___
 <a id="type"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Type**: *[DynamicDNSType](../enums/_api_types_.dynamicdnstype.md)*
 
-*Defined in [api/types.ts:1240](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1240)*
+*Defined in [api/types.ts:1240](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1240)*
 
 ___
 

--- a/docs/interfaces/_api_types_.eapmethodconfiguration.md
+++ b/docs/interfaces/_api_types_.eapmethodconfiguration.md
@@ -26,7 +26,7 @@ Confgiuration information for TLS Method.
 
 **● Extension**: *[EapMethodExtension](_api_types_.eapmethodextension.md)*
 
-*Defined in [api/types.ts:1988](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1988)*
+*Defined in [api/types.ts:1988](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1988)*
 
 ___
 <a id="password"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Password**: *`string`*
 
-*Defined in [api/types.ts:1987](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1987)*
+*Defined in [api/types.ts:1987](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1987)*
 
 ___
 <a id="tlsconfiguration"></a>
@@ -44,7 +44,7 @@ ___
 
 **● TLSConfiguration**: *[TLSConfiguration](_api_types_.tlsconfiguration.md)*
 
-*Defined in [api/types.ts:1986](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1986)*
+*Defined in [api/types.ts:1986](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1986)*
 
 ___
 

--- a/docs/interfaces/_api_types_.eflip.md
+++ b/docs/interfaces/_api_types_.eflip.md
@@ -24,7 +24,7 @@ Parameter to enable/disable E-Flip feature.
 
 **● Mode**: *[EFlipMode](../enums/_api_types_.eflipmode.md)*
 
-*Defined in [api/types.ts:2138](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2138)*
+*Defined in [api/types.ts:2138](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2138)*
 
 ___
 

--- a/docs/interfaces/_api_types_.eflipoptions.md
+++ b/docs/interfaces/_api_types_.eflipoptions.md
@@ -25,7 +25,7 @@ Options of EFlip mode parameter.
 
 **● Extension**: *[EFlipOptionsExtension](_api_types_.eflipoptionsextension.md)*
 
-*Defined in [api/types.ts:2186](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2186)*
+*Defined in [api/types.ts:2186](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2186)*
 
 ___
 <a id="mode"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Mode**: *[EFlipMode](../enums/_api_types_.eflipmode.md)*
 
-*Defined in [api/types.ts:2185](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2185)*
+*Defined in [api/types.ts:2185](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2185)*
 
 ___
 

--- a/docs/interfaces/_api_types_.engineconfiguration.md
+++ b/docs/interfaces/_api_types_.engineconfiguration.md
@@ -23,7 +23,7 @@
 
 **● AnalyticsEngineInputInfo**: *[AnalyticsEngineInputInfo](_api_types_.analyticsengineinputinfo.md)*
 
-*Defined in [api/types.ts:3813](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3813)*
+*Defined in [api/types.ts:3813](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3813)*
 
 ___
 <a id="videoanalyticsconfiguration"></a>
@@ -32,7 +32,7 @@ ___
 
 **● VideoAnalyticsConfiguration**: *[VideoAnalyticsConfiguration](_api_types_.videoanalyticsconfiguration.md)*
 
-*Defined in [api/types.ts:3812](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3812)*
+*Defined in [api/types.ts:3812](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3812)*
 
 ___
 

--- a/docs/interfaces/_api_types_.eventcapabilities.md
+++ b/docs/interfaces/_api_types_.eventcapabilities.md
@@ -27,7 +27,7 @@ Event service URI.
 
 **● WSPausableSubscriptionManagerInterfaceSupport**: *`boolean`*
 
-*Defined in [api/types.ts:1501](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1501)*
+*Defined in [api/types.ts:1501](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1501)*
 
 ___
 <a id="wspullpointsupport"></a>
@@ -36,7 +36,7 @@ ___
 
 **● WSPullPointSupport**: *`boolean`*
 
-*Defined in [api/types.ts:1500](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1500)*
+*Defined in [api/types.ts:1500](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1500)*
 
 ___
 <a id="wssubscriptionpolicysupport"></a>
@@ -45,7 +45,7 @@ ___
 
 **● WSSubscriptionPolicySupport**: *`boolean`*
 
-*Defined in [api/types.ts:1499](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1499)*
+*Defined in [api/types.ts:1499](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1499)*
 
 ___
 <a id="xaddr"></a>
@@ -54,7 +54,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1498](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1498)*
+*Defined in [api/types.ts:1498](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1498)*
 
 ___
 

--- a/docs/interfaces/_api_types_.eventsubscription.md
+++ b/docs/interfaces/_api_types_.eventsubscription.md
@@ -25,7 +25,7 @@ Subcription handling in the same way as base notification subscription.
 
 **● Filter**: *`any`*
 
-*Defined in [api/types.ts:791](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L791)*
+*Defined in [api/types.ts:791](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L791)*
 
 ___
 <a id="subscriptionpolicy"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SubscriptionPolicy**: *`any`*
 
-*Defined in [api/types.ts:792](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L792)*
+*Defined in [api/types.ts:792](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L792)*
 
 ___
 

--- a/docs/interfaces/_api_types_.exposure.md
+++ b/docs/interfaces/_api_types_.exposure.md
@@ -42,7 +42,7 @@
 
 **● ExposureTime**: *`number`*
 
-*Defined in [api/types.ts:2491](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2491)*
+*Defined in [api/types.ts:2491](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2491)*
 
 ___
 <a id="gain"></a>
@@ -51,7 +51,7 @@ ___
 
 **● Gain**: *`number`*
 
-*Defined in [api/types.ts:2492](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2492)*
+*Defined in [api/types.ts:2492](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2492)*
 
 ___
 <a id="iris"></a>
@@ -60,7 +60,7 @@ ___
 
 **● Iris**: *`number`*
 
-*Defined in [api/types.ts:2493](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2493)*
+*Defined in [api/types.ts:2493](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2493)*
 
 ___
 <a id="maxexposuretime"></a>
@@ -69,7 +69,7 @@ ___
 
 **● MaxExposureTime**: *`number`*
 
-*Defined in [api/types.ts:2486](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2486)*
+*Defined in [api/types.ts:2486](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2486)*
 
 ___
 <a id="maxgain"></a>
@@ -78,7 +78,7 @@ ___
 
 **● MaxGain**: *`number`*
 
-*Defined in [api/types.ts:2488](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2488)*
+*Defined in [api/types.ts:2488](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2488)*
 
 ___
 <a id="maxiris"></a>
@@ -87,7 +87,7 @@ ___
 
 **● MaxIris**: *`number`*
 
-*Defined in [api/types.ts:2490](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2490)*
+*Defined in [api/types.ts:2490](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2490)*
 
 ___
 <a id="minexposuretime"></a>
@@ -96,7 +96,7 @@ ___
 
 **● MinExposureTime**: *`number`*
 
-*Defined in [api/types.ts:2485](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2485)*
+*Defined in [api/types.ts:2485](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2485)*
 
 ___
 <a id="mingain"></a>
@@ -105,7 +105,7 @@ ___
 
 **● MinGain**: *`number`*
 
-*Defined in [api/types.ts:2487](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2487)*
+*Defined in [api/types.ts:2487](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2487)*
 
 ___
 <a id="miniris"></a>
@@ -114,7 +114,7 @@ ___
 
 **● MinIris**: *`number`*
 
-*Defined in [api/types.ts:2489](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2489)*
+*Defined in [api/types.ts:2489](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2489)*
 
 ___
 <a id="mode"></a>
@@ -123,7 +123,7 @@ ___
 
 **● Mode**: *[ExposureMode](../enums/_api_types_.exposuremode.md)*
 
-*Defined in [api/types.ts:2482](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2482)*
+*Defined in [api/types.ts:2482](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2482)*
 
 ___
 <a id="priority"></a>
@@ -132,7 +132,7 @@ ___
 
 **● Priority**: *[ExposurePriority](../enums/_api_types_.exposurepriority.md)*
 
-*Defined in [api/types.ts:2483](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2483)*
+*Defined in [api/types.ts:2483](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2483)*
 
 ___
 <a id="window"></a>
@@ -141,7 +141,7 @@ ___
 
 **● Window**: *[Rectangle](_api_types_.rectangle.md)*
 
-*Defined in [api/types.ts:2484](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2484)*
+*Defined in [api/types.ts:2484](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2484)*
 
 ___
 

--- a/docs/interfaces/_api_types_.exposure20.md
+++ b/docs/interfaces/_api_types_.exposure20.md
@@ -35,7 +35,7 @@ Type describing the exposure settings.
 
 **● ExposureTime**: *`number`*
 
-*Defined in [api/types.ts:2812](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2812)*
+*Defined in [api/types.ts:2812](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2812)*
 
 ___
 <a id="gain"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Gain**: *`number`*
 
-*Defined in [api/types.ts:2813](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2813)*
+*Defined in [api/types.ts:2813](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2813)*
 
 ___
 <a id="iris"></a>
@@ -53,7 +53,7 @@ ___
 
 **● Iris**: *`number`*
 
-*Defined in [api/types.ts:2814](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2814)*
+*Defined in [api/types.ts:2814](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2814)*
 
 ___
 <a id="maxexposuretime"></a>
@@ -62,7 +62,7 @@ ___
 
 **● MaxExposureTime**: *`number`*
 
-*Defined in [api/types.ts:2807](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2807)*
+*Defined in [api/types.ts:2807](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2807)*
 
 ___
 <a id="maxgain"></a>
@@ -71,7 +71,7 @@ ___
 
 **● MaxGain**: *`number`*
 
-*Defined in [api/types.ts:2809](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2809)*
+*Defined in [api/types.ts:2809](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2809)*
 
 ___
 <a id="maxiris"></a>
@@ -80,7 +80,7 @@ ___
 
 **● MaxIris**: *`number`*
 
-*Defined in [api/types.ts:2811](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2811)*
+*Defined in [api/types.ts:2811](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2811)*
 
 ___
 <a id="minexposuretime"></a>
@@ -89,7 +89,7 @@ ___
 
 **● MinExposureTime**: *`number`*
 
-*Defined in [api/types.ts:2806](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2806)*
+*Defined in [api/types.ts:2806](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2806)*
 
 ___
 <a id="mingain"></a>
@@ -98,7 +98,7 @@ ___
 
 **● MinGain**: *`number`*
 
-*Defined in [api/types.ts:2808](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2808)*
+*Defined in [api/types.ts:2808](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2808)*
 
 ___
 <a id="miniris"></a>
@@ -107,7 +107,7 @@ ___
 
 **● MinIris**: *`number`*
 
-*Defined in [api/types.ts:2810](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2810)*
+*Defined in [api/types.ts:2810](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2810)*
 
 ___
 <a id="mode"></a>
@@ -116,7 +116,7 @@ ___
 
 **● Mode**: *[ExposureMode](../enums/_api_types_.exposuremode.md)*
 
-*Defined in [api/types.ts:2803](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2803)*
+*Defined in [api/types.ts:2803](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2803)*
 
 ___
 <a id="priority"></a>
@@ -125,7 +125,7 @@ ___
 
 **● Priority**: *[ExposurePriority](../enums/_api_types_.exposurepriority.md)*
 
-*Defined in [api/types.ts:2804](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2804)*
+*Defined in [api/types.ts:2804](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2804)*
 
 ___
 <a id="window"></a>
@@ -134,7 +134,7 @@ ___
 
 **● Window**: *[Rectangle](_api_types_.rectangle.md)*
 
-*Defined in [api/types.ts:2805](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2805)*
+*Defined in [api/types.ts:2805](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2805)*
 
 ___
 

--- a/docs/interfaces/_api_types_.exposureoptions.md
+++ b/docs/interfaces/_api_types_.exposureoptions.md
@@ -32,7 +32,7 @@
 
 **● ExposureTime**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2568](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2568)*
+*Defined in [api/types.ts:2568](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2568)*
 
 ___
 <a id="gain"></a>
@@ -41,7 +41,7 @@ ___
 
 **● Gain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2569](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2569)*
+*Defined in [api/types.ts:2569](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2569)*
 
 ___
 <a id="iris"></a>
@@ -50,7 +50,7 @@ ___
 
 **● Iris**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2570](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2570)*
+*Defined in [api/types.ts:2570](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2570)*
 
 ___
 <a id="maxexposuretime"></a>
@@ -59,7 +59,7 @@ ___
 
 **● MaxExposureTime**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2563](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2563)*
+*Defined in [api/types.ts:2563](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2563)*
 
 ___
 <a id="maxgain"></a>
@@ -68,7 +68,7 @@ ___
 
 **● MaxGain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2565](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2565)*
+*Defined in [api/types.ts:2565](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2565)*
 
 ___
 <a id="maxiris"></a>
@@ -77,7 +77,7 @@ ___
 
 **● MaxIris**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2567](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2567)*
+*Defined in [api/types.ts:2567](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2567)*
 
 ___
 <a id="minexposuretime"></a>
@@ -86,7 +86,7 @@ ___
 
 **● MinExposureTime**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2562](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2562)*
+*Defined in [api/types.ts:2562](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2562)*
 
 ___
 <a id="mingain"></a>
@@ -95,7 +95,7 @@ ___
 
 **● MinGain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2564](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2564)*
+*Defined in [api/types.ts:2564](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2564)*
 
 ___
 <a id="miniris"></a>
@@ -104,7 +104,7 @@ ___
 
 **● MinIris**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2566](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2566)*
+*Defined in [api/types.ts:2566](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2566)*
 
 ___
 <a id="mode"></a>
@@ -113,7 +113,7 @@ ___
 
 **● Mode**: *[ExposureMode](../enums/_api_types_.exposuremode.md)*
 
-*Defined in [api/types.ts:2560](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2560)*
+*Defined in [api/types.ts:2560](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2560)*
 
 ___
 <a id="priority"></a>
@@ -122,7 +122,7 @@ ___
 
 **● Priority**: *[ExposurePriority](../enums/_api_types_.exposurepriority.md)*
 
-*Defined in [api/types.ts:2561](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2561)*
+*Defined in [api/types.ts:2561](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2561)*
 
 ___
 

--- a/docs/interfaces/_api_types_.exposureoptions20.md
+++ b/docs/interfaces/_api_types_.exposureoptions20.md
@@ -41,7 +41,7 @@
 
 **● ExposureTime**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2972](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2972)*
+*Defined in [api/types.ts:2972](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2972)*
 
 ___
 <a id="gain"></a>
@@ -50,7 +50,7 @@ ___
 
 **● Gain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2973](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2973)*
+*Defined in [api/types.ts:2973](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2973)*
 
 ___
 <a id="iris"></a>
@@ -59,7 +59,7 @@ ___
 
 **● Iris**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2974](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2974)*
+*Defined in [api/types.ts:2974](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2974)*
 
 ___
 <a id="maxexposuretime"></a>
@@ -68,7 +68,7 @@ ___
 
 **● MaxExposureTime**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2967](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2967)*
+*Defined in [api/types.ts:2967](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2967)*
 
 ___
 <a id="maxgain"></a>
@@ -77,7 +77,7 @@ ___
 
 **● MaxGain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2969](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2969)*
+*Defined in [api/types.ts:2969](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2969)*
 
 ___
 <a id="maxiris"></a>
@@ -86,7 +86,7 @@ ___
 
 **● MaxIris**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2971](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2971)*
+*Defined in [api/types.ts:2971](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2971)*
 
 ___
 <a id="minexposuretime"></a>
@@ -95,7 +95,7 @@ ___
 
 **● MinExposureTime**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2966](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2966)*
+*Defined in [api/types.ts:2966](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2966)*
 
 ___
 <a id="mingain"></a>
@@ -104,7 +104,7 @@ ___
 
 **● MinGain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2968](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2968)*
+*Defined in [api/types.ts:2968](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2968)*
 
 ___
 <a id="miniris"></a>
@@ -113,7 +113,7 @@ ___
 
 **● MinIris**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2970](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2970)*
+*Defined in [api/types.ts:2970](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2970)*
 
 ___
 <a id="mode"></a>
@@ -122,7 +122,7 @@ ___
 
 **● Mode**: *[ExposureMode](../enums/_api_types_.exposuremode.md)*
 
-*Defined in [api/types.ts:2964](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2964)*
+*Defined in [api/types.ts:2964](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2964)*
 
 ___
 <a id="priority"></a>
@@ -131,7 +131,7 @@ ___
 
 **● Priority**: *[ExposurePriority](../enums/_api_types_.exposurepriority.md)*
 
-*Defined in [api/types.ts:2965](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2965)*
+*Defined in [api/types.ts:2965](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2965)*
 
 ___
 

--- a/docs/interfaces/_api_types_.fault.md
+++ b/docs/interfaces/_api_types_.fault.md
@@ -29,7 +29,7 @@
 
 **● detail**: *[detail](_api_types_.detail.md)*
 
-*Defined in [api/types.ts:4209](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4209)*
+*Defined in [api/types.ts:4209](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4209)*
 
 ___
 <a id="faultactor"></a>
@@ -38,7 +38,7 @@ ___
 
 **● faultactor**: *`string`*
 
-*Defined in [api/types.ts:4208](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4208)*
+*Defined in [api/types.ts:4208](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4208)*
 
 ___
 <a id="faultcode"></a>
@@ -47,7 +47,7 @@ ___
 
 **● faultcode**: *`any`*
 
-*Defined in [api/types.ts:4206](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4206)*
+*Defined in [api/types.ts:4206](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4206)*
 
 ___
 <a id="faultstring"></a>
@@ -56,7 +56,7 @@ ___
 
 **● faultstring**: *`string`*
 
-*Defined in [api/types.ts:4207](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4207)*
+*Defined in [api/types.ts:4207](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4207)*
 
 ___
 

--- a/docs/interfaces/_api_types_.fileprogress.md
+++ b/docs/interfaces/_api_types_.fileprogress.md
@@ -25,7 +25,7 @@ Exported file name
 
 **● FileName**: *`string`*
 
-*Defined in [api/types.ts:4147](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4147)*
+*Defined in [api/types.ts:4147](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4147)*
 
 ___
 <a id="progress"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Progress**: *`number`*
 
-*Defined in [api/types.ts:4148](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4148)*
+*Defined in [api/types.ts:4148](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4148)*
 
 ___
 

--- a/docs/interfaces/_api_types_.findeventresult.md
+++ b/docs/interfaces/_api_types_.findeventresult.md
@@ -28,7 +28,7 @@ The recording where this event was found. Empty string if no recording is associ
 
 **● Event**: *`any`*
 
-*Defined in [api/types.ts:3502](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3502)*
+*Defined in [api/types.ts:3502](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3502)*
 
 ___
 <a id="recordingtoken"></a>
@@ -37,7 +37,7 @@ ___
 
 **● RecordingToken**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3499](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3499)*
+*Defined in [api/types.ts:3499](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3499)*
 
 ___
 <a id="startstateevent"></a>
@@ -46,7 +46,7 @@ ___
 
 **● StartStateEvent**: *`boolean`*
 
-*Defined in [api/types.ts:3503](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3503)*
+*Defined in [api/types.ts:3503](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3503)*
 
 ___
 <a id="time"></a>
@@ -55,7 +55,7 @@ ___
 
 **● Time**: *`string`*
 
-*Defined in [api/types.ts:3501](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3501)*
+*Defined in [api/types.ts:3501](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3501)*
 
 ___
 <a id="tracktoken"></a>
@@ -64,7 +64,7 @@ ___
 
 **● TrackToken**: *[TrackReference](../modules/_api_types_.md#trackreference)*
 
-*Defined in [api/types.ts:3500](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3500)*
+*Defined in [api/types.ts:3500](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3500)*
 
 ___
 

--- a/docs/interfaces/_api_types_.findeventresultlist.md
+++ b/docs/interfaces/_api_types_.findeventresultlist.md
@@ -25,7 +25,7 @@ The state of the search when the result is returned. Indicates if there can be m
 
 **● Result**: *[FindEventResult](_api_types_.findeventresult.md)*
 
-*Defined in [api/types.ts:3492](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3492)*
+*Defined in [api/types.ts:3492](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3492)*
 
 ___
 <a id="searchstate"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SearchState**: *[SearchState](../enums/_api_types_.searchstate.md)*
 
-*Defined in [api/types.ts:3491](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3491)*
+*Defined in [api/types.ts:3491](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3491)*
 
 ___
 

--- a/docs/interfaces/_api_types_.findmetadataresult.md
+++ b/docs/interfaces/_api_types_.findmetadataresult.md
@@ -26,7 +26,7 @@ A reference to the recording containing the metadata.
 
 **● RecordingToken**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3536](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3536)*
+*Defined in [api/types.ts:3536](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3536)*
 
 ___
 <a id="time"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Time**: *`string`*
 
-*Defined in [api/types.ts:3538](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3538)*
+*Defined in [api/types.ts:3538](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3538)*
 
 ___
 <a id="tracktoken"></a>
@@ -44,7 +44,7 @@ ___
 
 **● TrackToken**: *[TrackReference](../modules/_api_types_.md#trackreference)*
 
-*Defined in [api/types.ts:3537](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3537)*
+*Defined in [api/types.ts:3537](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3537)*
 
 ___
 

--- a/docs/interfaces/_api_types_.findmetadataresultlist.md
+++ b/docs/interfaces/_api_types_.findmetadataresultlist.md
@@ -25,7 +25,7 @@ The state of the search when the result is returned. Indicates if there can be m
 
 **● Result**: *[FindMetadataResult](_api_types_.findmetadataresult.md)*
 
-*Defined in [api/types.ts:3529](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3529)*
+*Defined in [api/types.ts:3529](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3529)*
 
 ___
 <a id="searchstate"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SearchState**: *[SearchState](../enums/_api_types_.searchstate.md)*
 
-*Defined in [api/types.ts:3528](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3528)*
+*Defined in [api/types.ts:3528](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3528)*
 
 ___
 

--- a/docs/interfaces/_api_types_.findptzpositionresult.md
+++ b/docs/interfaces/_api_types_.findptzpositionresult.md
@@ -27,7 +27,7 @@ A reference to the recording containing the PTZ position.
 
 **● Position**: *[PTZVector](_api_types_.ptzvector.md)*
 
-*Defined in [api/types.ts:3521](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3521)*
+*Defined in [api/types.ts:3521](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3521)*
 
 ___
 <a id="recordingtoken"></a>
@@ -36,7 +36,7 @@ ___
 
 **● RecordingToken**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3518](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3518)*
+*Defined in [api/types.ts:3518](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3518)*
 
 ___
 <a id="time"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Time**: *`string`*
 
-*Defined in [api/types.ts:3520](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3520)*
+*Defined in [api/types.ts:3520](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3520)*
 
 ___
 <a id="tracktoken"></a>
@@ -54,7 +54,7 @@ ___
 
 **● TrackToken**: *[TrackReference](../modules/_api_types_.md#trackreference)*
 
-*Defined in [api/types.ts:3519](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3519)*
+*Defined in [api/types.ts:3519](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3519)*
 
 ___
 

--- a/docs/interfaces/_api_types_.findptzpositionresultlist.md
+++ b/docs/interfaces/_api_types_.findptzpositionresultlist.md
@@ -25,7 +25,7 @@ The state of the search when the result is returned. Indicates if there can be m
 
 **● Result**: *[FindPTZPositionResult](_api_types_.findptzpositionresult.md)*
 
-*Defined in [api/types.ts:3511](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3511)*
+*Defined in [api/types.ts:3511](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3511)*
 
 ___
 <a id="searchstate"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SearchState**: *[SearchState](../enums/_api_types_.searchstate.md)*
 
-*Defined in [api/types.ts:3510](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3510)*
+*Defined in [api/types.ts:3510](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3510)*
 
 ___
 

--- a/docs/interfaces/_api_types_.findrecordingresultlist.md
+++ b/docs/interfaces/_api_types_.findrecordingresultlist.md
@@ -25,7 +25,7 @@ The state of the search when the result is returned. Indicates if there can be m
 
 **● RecordingInformation**: *[RecordingInformation](_api_types_.recordinginformation.md)*
 
-*Defined in [api/types.ts:3484](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3484)*
+*Defined in [api/types.ts:3484](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3484)*
 
 ___
 <a id="searchstate"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SearchState**: *[SearchState](../enums/_api_types_.searchstate.md)*
 
-*Defined in [api/types.ts:3483](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3483)*
+*Defined in [api/types.ts:3483](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3483)*
 
 ___
 

--- a/docs/interfaces/_api_types_.floatlist.md
+++ b/docs/interfaces/_api_types_.floatlist.md
@@ -22,7 +22,7 @@
 
 **● Items**: *`number`*
 
-*Defined in [api/types.ts:313](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L313)*
+*Defined in [api/types.ts:313](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L313)*
 
 ___
 

--- a/docs/interfaces/_api_types_.floatrange.md
+++ b/docs/interfaces/_api_types_.floatrange.md
@@ -25,7 +25,7 @@ Range of values greater equal Min value and less equal Max value.
 
 **● Max**: *`number`*
 
-*Defined in [api/types.ts:291](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L291)*
+*Defined in [api/types.ts:291](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L291)*
 
 ___
 <a id="min"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Min**: *`number`*
 
-*Defined in [api/types.ts:290](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L290)*
+*Defined in [api/types.ts:290](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L290)*
 
 ___
 

--- a/docs/interfaces/_api_types_.focusconfiguration.md
+++ b/docs/interfaces/_api_types_.focusconfiguration.md
@@ -27,7 +27,7 @@ Parameter to set autofocus near limit (unit: meter).
 
 **● AutoFocusMode**: *[AutoFocusMode](../enums/_api_types_.autofocusmode.md)*
 
-*Defined in [api/types.ts:2443](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2443)*
+*Defined in [api/types.ts:2443](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2443)*
 
 ___
 <a id="defaultspeed"></a>
@@ -36,7 +36,7 @@ ___
 
 **● DefaultSpeed**: *`number`*
 
-*Defined in [api/types.ts:2444](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2444)*
+*Defined in [api/types.ts:2444](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2444)*
 
 ___
 <a id="farlimit"></a>
@@ -45,7 +45,7 @@ ___
 
 **● FarLimit**: *`number`*
 
-*Defined in [api/types.ts:2446](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2446)*
+*Defined in [api/types.ts:2446](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2446)*
 
 ___
 <a id="nearlimit"></a>
@@ -54,7 +54,7 @@ ___
 
 **● NearLimit**: *`number`*
 
-*Defined in [api/types.ts:2445](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2445)*
+*Defined in [api/types.ts:2445](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2445)*
 
 ___
 

--- a/docs/interfaces/_api_types_.focusconfiguration20.md
+++ b/docs/interfaces/_api_types_.focusconfiguration20.md
@@ -37,7 +37,7 @@
 
 **● AutoFocusMode**: *[AutoFocusMode](../enums/_api_types_.autofocusmode.md)*
 
-*Defined in [api/types.ts:3027](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3027)*
+*Defined in [api/types.ts:3027](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3027)*
 
 ___
 <a id="defaultspeed"></a>
@@ -46,7 +46,7 @@ ___
 
 **● DefaultSpeed**: *`number`*
 
-*Defined in [api/types.ts:3028](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3028)*
+*Defined in [api/types.ts:3028](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3028)*
 
 ___
 <a id="extension"></a>
@@ -55,7 +55,7 @@ ___
 
 **● Extension**: *[FocusConfiguration20Extension](_api_types_.focusconfiguration20extension.md)*
 
-*Defined in [api/types.ts:3031](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3031)*
+*Defined in [api/types.ts:3031](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3031)*
 
 ___
 <a id="farlimit"></a>
@@ -64,7 +64,7 @@ ___
 
 **● FarLimit**: *`number`*
 
-*Defined in [api/types.ts:3030](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3030)*
+*Defined in [api/types.ts:3030](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3030)*
 
 ___
 <a id="nearlimit"></a>
@@ -73,7 +73,7 @@ ___
 
 **● NearLimit**: *`number`*
 
-*Defined in [api/types.ts:3029](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3029)*
+*Defined in [api/types.ts:3029](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3029)*
 
 ___
 

--- a/docs/interfaces/_api_types_.focusmove.md
+++ b/docs/interfaces/_api_types_.focusmove.md
@@ -28,7 +28,7 @@
 
 **● Absolute**: *[AbsoluteFocus](_api_types_.absolutefocus.md)*
 
-*Defined in [api/types.ts:2588](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2588)*
+*Defined in [api/types.ts:2588](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2588)*
 
 ___
 <a id="continuous"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Continuous**: *[ContinuousFocus](_api_types_.continuousfocus.md)*
 
-*Defined in [api/types.ts:2590](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2590)*
+*Defined in [api/types.ts:2590](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2590)*
 
 ___
 <a id="relative"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Relative**: *[RelativeFocus](_api_types_.relativefocus.md)*
 
-*Defined in [api/types.ts:2589](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2589)*
+*Defined in [api/types.ts:2589](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2589)*
 
 ___
 

--- a/docs/interfaces/_api_types_.focusoptions.md
+++ b/docs/interfaces/_api_types_.focusoptions.md
@@ -25,7 +25,7 @@
 
 **● AutoFocusModes**: *[AutoFocusMode](../enums/_api_types_.autofocusmode.md)*
 
-*Defined in [api/types.ts:2550](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2550)*
+*Defined in [api/types.ts:2550](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2550)*
 
 ___
 <a id="defaultspeed"></a>
@@ -34,7 +34,7 @@ ___
 
 **● DefaultSpeed**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2551](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2551)*
+*Defined in [api/types.ts:2551](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2551)*
 
 ___
 <a id="farlimit"></a>
@@ -43,7 +43,7 @@ ___
 
 **● FarLimit**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2553](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2553)*
+*Defined in [api/types.ts:2553](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2553)*
 
 ___
 <a id="nearlimit"></a>
@@ -52,7 +52,7 @@ ___
 
 **● NearLimit**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2552](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2552)*
+*Defined in [api/types.ts:2552](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2552)*
 
 ___
 

--- a/docs/interfaces/_api_types_.focusoptions20.md
+++ b/docs/interfaces/_api_types_.focusoptions20.md
@@ -35,7 +35,7 @@
 
 **● AutoFocusModes**: *[AutoFocusMode](../enums/_api_types_.autofocusmode.md)*
 
-*Defined in [api/types.ts:3072](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3072)*
+*Defined in [api/types.ts:3072](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3072)*
 
 ___
 <a id="defaultspeed"></a>
@@ -44,7 +44,7 @@ ___
 
 **● DefaultSpeed**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:3073](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3073)*
+*Defined in [api/types.ts:3073](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3073)*
 
 ___
 <a id="extension"></a>
@@ -53,7 +53,7 @@ ___
 
 **● Extension**: *[FocusOptions20Extension](_api_types_.focusoptions20extension.md)*
 
-*Defined in [api/types.ts:3076](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3076)*
+*Defined in [api/types.ts:3076](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3076)*
 
 ___
 <a id="farlimit"></a>
@@ -62,7 +62,7 @@ ___
 
 **● FarLimit**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:3075](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3075)*
+*Defined in [api/types.ts:3075](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3075)*
 
 ___
 <a id="nearlimit"></a>
@@ -71,7 +71,7 @@ ___
 
 **● NearLimit**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:3074](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3074)*
+*Defined in [api/types.ts:3074](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3074)*
 
 ___
 

--- a/docs/interfaces/_api_types_.focusstatus.md
+++ b/docs/interfaces/_api_types_.focusstatus.md
@@ -28,7 +28,7 @@
 
 **● Error**: *`string`*
 
-*Defined in [api/types.ts:2436](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2436)*
+*Defined in [api/types.ts:2436](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2436)*
 
 ___
 <a id="movestatus"></a>
@@ -37,7 +37,7 @@ ___
 
 **● MoveStatus**: *[MoveStatus](../enums/_api_types_.movestatus.md)*
 
-*Defined in [api/types.ts:2435](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2435)*
+*Defined in [api/types.ts:2435](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2435)*
 
 ___
 <a id="position"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Position**: *`number`*
 
-*Defined in [api/types.ts:2434](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2434)*
+*Defined in [api/types.ts:2434](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2434)*
 
 ___
 

--- a/docs/interfaces/_api_types_.focusstatus20.md
+++ b/docs/interfaces/_api_types_.focusstatus20.md
@@ -29,7 +29,7 @@
 
 **● Error**: *`string`*
 
-*Defined in [api/types.ts:2693](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2693)*
+*Defined in [api/types.ts:2693](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2693)*
 
 ___
 <a id="extension"></a>
@@ -38,7 +38,7 @@ ___
 
 **● Extension**: *[FocusStatus20Extension](_api_types_.focusstatus20extension.md)*
 
-*Defined in [api/types.ts:2694](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2694)*
+*Defined in [api/types.ts:2694](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2694)*
 
 ___
 <a id="movestatus"></a>
@@ -47,7 +47,7 @@ ___
 
 **● MoveStatus**: *[MoveStatus](../enums/_api_types_.movestatus.md)*
 
-*Defined in [api/types.ts:2692](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2692)*
+*Defined in [api/types.ts:2692](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2692)*
 
 ___
 <a id="position"></a>
@@ -56,7 +56,7 @@ ___
 
 **● Position**: *`number`*
 
-*Defined in [api/types.ts:2691](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2691)*
+*Defined in [api/types.ts:2691](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2691)*
 
 ___
 

--- a/docs/interfaces/_api_types_.g711decoptions.md
+++ b/docs/interfaces/_api_types_.g711decoptions.md
@@ -25,7 +25,7 @@ List of supported bitrates in kbps
 
 **● Bitrate**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:954](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L954)*
+*Defined in [api/types.ts:954](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L954)*
 
 ___
 <a id="sampleraterange"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SampleRateRange**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:955](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L955)*
+*Defined in [api/types.ts:955](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L955)*
 
 ___
 

--- a/docs/interfaces/_api_types_.g726decoptions.md
+++ b/docs/interfaces/_api_types_.g726decoptions.md
@@ -25,7 +25,7 @@ List of supported bitrates in kbps
 
 **● Bitrate**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:970](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L970)*
+*Defined in [api/types.ts:970](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L970)*
 
 ___
 <a id="sampleraterange"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SampleRateRange**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:971](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L971)*
+*Defined in [api/types.ts:971](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L971)*
 
 ___
 

--- a/docs/interfaces/_api_types_.getrecordingjobsresponseitem.md
+++ b/docs/interfaces/_api_types_.getrecordingjobsresponseitem.md
@@ -23,7 +23,7 @@
 
 **● JobConfiguration**: *[RecordingJobConfiguration](_api_types_.recordingjobconfiguration.md)*
 
-*Defined in [api/types.ts:3775](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3775)*
+*Defined in [api/types.ts:3775](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3775)*
 
 ___
 <a id="jobtoken"></a>
@@ -32,7 +32,7 @@ ___
 
 **● JobToken**: *[RecordingJobReference](../modules/_api_types_.md#recordingjobreference)*
 
-*Defined in [api/types.ts:3774](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3774)*
+*Defined in [api/types.ts:3774](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3774)*
 
 ___
 

--- a/docs/interfaces/_api_types_.getrecordingsresponseitem.md
+++ b/docs/interfaces/_api_types_.getrecordingsresponseitem.md
@@ -26,7 +26,7 @@ Token of the recording.
 
 **● Configuration**: *[RecordingConfiguration](_api_types_.recordingconfiguration.md)*
 
-*Defined in [api/types.ts:3662](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3662)*
+*Defined in [api/types.ts:3662](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3662)*
 
 ___
 <a id="recordingtoken"></a>
@@ -35,7 +35,7 @@ ___
 
 **● RecordingToken**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3661](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3661)*
+*Defined in [api/types.ts:3661](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3661)*
 
 ___
 <a id="tracks"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Tracks**: *[GetTracksResponseList](_api_types_.gettracksresponselist.md)*
 
-*Defined in [api/types.ts:3663](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3663)*
+*Defined in [api/types.ts:3663](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3663)*
 
 ___
 

--- a/docs/interfaces/_api_types_.gettracksresponseitem.md
+++ b/docs/interfaces/_api_types_.gettracksresponseitem.md
@@ -25,7 +25,7 @@ Token of the track.
 
 **● Configuration**: *[TrackConfiguration](_api_types_.trackconfiguration.md)*
 
-*Defined in [api/types.ts:3678](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3678)*
+*Defined in [api/types.ts:3678](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3678)*
 
 ___
 <a id="tracktoken"></a>
@@ -34,7 +34,7 @@ ___
 
 **● TrackToken**: *[TrackReference](../modules/_api_types_.md#trackreference)*
 
-*Defined in [api/types.ts:3677](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3677)*
+*Defined in [api/types.ts:3677](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3677)*
 
 ___
 

--- a/docs/interfaces/_api_types_.gettracksresponselist.md
+++ b/docs/interfaces/_api_types_.gettracksresponselist.md
@@ -24,7 +24,7 @@ Configuration of a track.
 
 **● Track**: *[GetTracksResponseItem](_api_types_.gettracksresponseitem.md)*
 
-*Defined in [api/types.ts:3670](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3670)*
+*Defined in [api/types.ts:3670](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3670)*
 
 ___
 

--- a/docs/interfaces/_api_types_.h264configuration.md
+++ b/docs/interfaces/_api_types_.h264configuration.md
@@ -25,7 +25,7 @@ Group of Video frames length. Determines typically the interval in which the I-F
 
 **● GovLength**: *`number`*
 
-*Defined in [api/types.ts:565](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L565)*
+*Defined in [api/types.ts:565](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L565)*
 
 ___
 <a id="h264profile"></a>
@@ -34,7 +34,7 @@ ___
 
 **● H264Profile**: *[H264Profile](../enums/_api_types_.h264profile.md)*
 
-*Defined in [api/types.ts:566](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L566)*
+*Defined in [api/types.ts:566](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L566)*
 
 ___
 

--- a/docs/interfaces/_api_types_.h264decoptions.md
+++ b/docs/interfaces/_api_types_.h264decoptions.md
@@ -27,7 +27,7 @@ List of supported H.264 Video Resolutions
 
 **● ResolutionsAvailable**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:878](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L878)*
+*Defined in [api/types.ts:878](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L878)*
 
 ___
 <a id="supportedframerate"></a>
@@ -36,7 +36,7 @@ ___
 
 **● SupportedFrameRate**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:881](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L881)*
+*Defined in [api/types.ts:881](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L881)*
 
 ___
 <a id="supportedh264profiles"></a>
@@ -45,7 +45,7 @@ ___
 
 **● SupportedH264Profiles**: *[H264Profile](../enums/_api_types_.h264profile.md)*
 
-*Defined in [api/types.ts:879](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L879)*
+*Defined in [api/types.ts:879](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L879)*
 
 ___
 <a id="supportedinputbitrate"></a>
@@ -54,7 +54,7 @@ ___
 
 **● SupportedInputBitrate**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:880](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L880)*
+*Defined in [api/types.ts:880](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L880)*
 
 ___
 

--- a/docs/interfaces/_api_types_.h264options.md
+++ b/docs/interfaces/_api_types_.h264options.md
@@ -28,7 +28,7 @@ List of supported image sizes.
 
 **● EncodingIntervalRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:637](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L637)*
+*Defined in [api/types.ts:637](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L637)*
 
 ___
 <a id="frameraterange"></a>
@@ -37,7 +37,7 @@ ___
 
 **● FrameRateRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:636](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L636)*
+*Defined in [api/types.ts:636](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L636)*
 
 ___
 <a id="govlengthrange"></a>
@@ -46,7 +46,7 @@ ___
 
 **● GovLengthRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:635](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L635)*
+*Defined in [api/types.ts:635](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L635)*
 
 ___
 <a id="h264profilessupported"></a>
@@ -55,7 +55,7 @@ ___
 
 **● H264ProfilesSupported**: *[H264Profile](../enums/_api_types_.h264profile.md)*
 
-*Defined in [api/types.ts:638](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L638)*
+*Defined in [api/types.ts:638](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L638)*
 
 ___
 <a id="resolutionsavailable"></a>
@@ -64,7 +64,7 @@ ___
 
 **● ResolutionsAvailable**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:634](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L634)*
+*Defined in [api/types.ts:634](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L634)*
 
 ___
 

--- a/docs/interfaces/_api_types_.h264options2.md
+++ b/docs/interfaces/_api_types_.h264options2.md
@@ -24,7 +24,7 @@ Supported range of encoded bitrate in kbps.
 
 **● BitrateRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:645](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L645)*
+*Defined in [api/types.ts:645](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L645)*
 
 ___
 

--- a/docs/interfaces/_api_types_.hostnameinformation.md
+++ b/docs/interfaces/_api_types_.hostnameinformation.md
@@ -26,7 +26,7 @@ Indicates whether the hostname is obtained from DHCP or not.
 
 **● Extension**: *[HostnameInformationExtension](_api_types_.hostnameinformationextension.md)*
 
-*Defined in [api/types.ts:1194](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1194)*
+*Defined in [api/types.ts:1194](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1194)*
 
 ___
 <a id="fromdhcp"></a>
@@ -35,7 +35,7 @@ ___
 
 **● FromDHCP**: *`boolean`*
 
-*Defined in [api/types.ts:1192](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1192)*
+*Defined in [api/types.ts:1192](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1192)*
 
 ___
 <a id="name"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Name**: *`string`*
 
-*Defined in [api/types.ts:1193](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1193)*
+*Defined in [api/types.ts:1193](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1193)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagestabilization.md
+++ b/docs/interfaces/_api_types_.imagestabilization.md
@@ -26,7 +26,7 @@ Parameter to enable/disable Image Stabilization feature.
 
 **● Extension**: *[ImageStabilizationExtension](_api_types_.imagestabilizationextension.md)*
 
-*Defined in [api/types.ts:2758](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2758)*
+*Defined in [api/types.ts:2758](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2758)*
 
 ___
 <a id="level"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Level**: *`number`*
 
-*Defined in [api/types.ts:2757](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2757)*
+*Defined in [api/types.ts:2757](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2757)*
 
 ___
 <a id="mode"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Mode**: *[ImageStabilizationMode](../enums/_api_types_.imagestabilizationmode.md)*
 
-*Defined in [api/types.ts:2756](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2756)*
+*Defined in [api/types.ts:2756](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2756)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagestabilizationoptions.md
+++ b/docs/interfaces/_api_types_.imagestabilizationoptions.md
@@ -26,7 +26,7 @@ Supported options of Image Stabilization mode parameter.
 
 **● Extension**: *[ImageStabilizationOptionsExtension](_api_types_.imagestabilizationoptionsextension.md)*
 
-*Defined in [api/types.ts:2911](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2911)*
+*Defined in [api/types.ts:2911](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2911)*
 
 ___
 <a id="level"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Level**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2910](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2910)*
+*Defined in [api/types.ts:2910](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2910)*
 
 ___
 <a id="mode"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Mode**: *[ImageStabilizationMode](../enums/_api_types_.imagestabilizationmode.md)*
 
-*Defined in [api/types.ts:2909](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2909)*
+*Defined in [api/types.ts:2909](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2909)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingcapabilities.md
+++ b/docs/interfaces/_api_types_.imagingcapabilities.md
@@ -24,7 +24,7 @@ Imaging service URI.
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1667](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1667)*
+*Defined in [api/types.ts:1667](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1667)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingoptions.md
+++ b/docs/interfaces/_api_types_.imagingoptions.md
@@ -31,7 +31,7 @@
 
 **● BacklightCompensation**: *[BacklightCompensationOptions](_api_types_.backlightcompensationoptions.md)*
 
-*Defined in [api/types.ts:2518](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2518)*
+*Defined in [api/types.ts:2518](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2518)*
 
 ___
 <a id="brightness"></a>
@@ -40,7 +40,7 @@ ___
 
 **● Brightness**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2519](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2519)*
+*Defined in [api/types.ts:2519](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2519)*
 
 ___
 <a id="colorsaturation"></a>
@@ -49,7 +49,7 @@ ___
 
 **● ColorSaturation**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2520](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2520)*
+*Defined in [api/types.ts:2520](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2520)*
 
 ___
 <a id="contrast"></a>
@@ -58,7 +58,7 @@ ___
 
 **● Contrast**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2521](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2521)*
+*Defined in [api/types.ts:2521](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2521)*
 
 ___
 <a id="exposure"></a>
@@ -67,7 +67,7 @@ ___
 
 **● Exposure**: *[ExposureOptions](_api_types_.exposureoptions.md)*
 
-*Defined in [api/types.ts:2522](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2522)*
+*Defined in [api/types.ts:2522](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2522)*
 
 ___
 <a id="focus"></a>
@@ -76,7 +76,7 @@ ___
 
 **● Focus**: *[FocusOptions](_api_types_.focusoptions.md)*
 
-*Defined in [api/types.ts:2523](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2523)*
+*Defined in [api/types.ts:2523](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2523)*
 
 ___
 <a id="ircutfiltermodes"></a>
@@ -85,7 +85,7 @@ ___
 
 **● IrCutFilterModes**: *[IrCutFilterMode](../enums/_api_types_.ircutfiltermode.md)*
 
-*Defined in [api/types.ts:2524](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2524)*
+*Defined in [api/types.ts:2524](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2524)*
 
 ___
 <a id="sharpness"></a>
@@ -94,7 +94,7 @@ ___
 
 **● Sharpness**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2525](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2525)*
+*Defined in [api/types.ts:2525](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2525)*
 
 ___
 <a id="whitebalance"></a>
@@ -103,7 +103,7 @@ ___
 
 **● WhiteBalance**: *[WhiteBalanceOptions](_api_types_.whitebalanceoptions.md)*
 
-*Defined in [api/types.ts:2527](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2527)*
+*Defined in [api/types.ts:2527](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2527)*
 
 ___
 <a id="widedynamicrange"></a>
@@ -112,7 +112,7 @@ ___
 
 **● WideDynamicRange**: *[WideDynamicRangeOptions](_api_types_.widedynamicrangeoptions.md)*
 
-*Defined in [api/types.ts:2526](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2526)*
+*Defined in [api/types.ts:2526](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2526)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingoptions20.md
+++ b/docs/interfaces/_api_types_.imagingoptions20.md
@@ -36,7 +36,7 @@
 
 **● BacklightCompensation**: *[BacklightCompensationOptions20](_api_types_.backlightcompensationoptions20.md)*
 
-*Defined in [api/types.ts:2860](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2860)*
+*Defined in [api/types.ts:2860](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2860)*
 
 ___
 <a id="brightness"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Brightness**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2861](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2861)*
+*Defined in [api/types.ts:2861](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2861)*
 
 ___
 <a id="colorsaturation"></a>
@@ -54,7 +54,7 @@ ___
 
 **● ColorSaturation**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2862](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2862)*
+*Defined in [api/types.ts:2862](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2862)*
 
 ___
 <a id="contrast"></a>
@@ -63,7 +63,7 @@ ___
 
 **● Contrast**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2863](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2863)*
+*Defined in [api/types.ts:2863](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2863)*
 
 ___
 <a id="exposure"></a>
@@ -72,7 +72,7 @@ ___
 
 **● Exposure**: *[ExposureOptions20](_api_types_.exposureoptions20.md)*
 
-*Defined in [api/types.ts:2864](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2864)*
+*Defined in [api/types.ts:2864](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2864)*
 
 ___
 <a id="extension"></a>
@@ -81,7 +81,7 @@ ___
 
 **● Extension**: *[ImagingOptions20Extension](_api_types_.imagingoptions20extension.md)*
 
-*Defined in [api/types.ts:2870](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2870)*
+*Defined in [api/types.ts:2870](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2870)*
 
 ___
 <a id="focus"></a>
@@ -90,7 +90,7 @@ ___
 
 **● Focus**: *[FocusOptions20](_api_types_.focusoptions20.md)*
 
-*Defined in [api/types.ts:2865](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2865)*
+*Defined in [api/types.ts:2865](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2865)*
 
 ___
 <a id="ircutfiltermodes"></a>
@@ -99,7 +99,7 @@ ___
 
 **● IrCutFilterModes**: *[IrCutFilterMode](../enums/_api_types_.ircutfiltermode.md)*
 
-*Defined in [api/types.ts:2866](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2866)*
+*Defined in [api/types.ts:2866](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2866)*
 
 ___
 <a id="sharpness"></a>
@@ -108,7 +108,7 @@ ___
 
 **● Sharpness**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2867](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2867)*
+*Defined in [api/types.ts:2867](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2867)*
 
 ___
 <a id="whitebalance"></a>
@@ -117,7 +117,7 @@ ___
 
 **● WhiteBalance**: *[WhiteBalanceOptions20](_api_types_.whitebalanceoptions20.md)*
 
-*Defined in [api/types.ts:2869](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2869)*
+*Defined in [api/types.ts:2869](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2869)*
 
 ___
 <a id="widedynamicrange"></a>
@@ -126,7 +126,7 @@ ___
 
 **● WideDynamicRange**: *[WideDynamicRangeOptions20](_api_types_.widedynamicrangeoptions20.md)*
 
-*Defined in [api/types.ts:2868](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2868)*
+*Defined in [api/types.ts:2868](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2868)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingoptions20extension.md
+++ b/docs/interfaces/_api_types_.imagingoptions20extension.md
@@ -25,7 +25,7 @@ Options of parameters for Image Stabilization feature.
 
 **● Extension**: *[ImagingOptions20Extension2](_api_types_.imagingoptions20extension2.md)*
 
-*Defined in [api/types.ts:2878](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2878)*
+*Defined in [api/types.ts:2878](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2878)*
 
 ___
 <a id="imagestabilization"></a>
@@ -34,7 +34,7 @@ ___
 
 **● ImageStabilization**: *[ImageStabilizationOptions](_api_types_.imagestabilizationoptions.md)*
 
-*Defined in [api/types.ts:2877](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2877)*
+*Defined in [api/types.ts:2877](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2877)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingoptions20extension2.md
+++ b/docs/interfaces/_api_types_.imagingoptions20extension2.md
@@ -25,7 +25,7 @@ Options of parameters for adjustment of Ir cut filter auto mode.
 
 **● Extension**: *[ImagingOptions20Extension3](_api_types_.imagingoptions20extension3.md)*
 
-*Defined in [api/types.ts:2886](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2886)*
+*Defined in [api/types.ts:2886](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2886)*
 
 ___
 <a id="ircutfilterautoadjustment"></a>
@@ -34,7 +34,7 @@ ___
 
 **● IrCutFilterAutoAdjustment**: *[IrCutFilterAutoAdjustmentOptions](_api_types_.ircutfilterautoadjustmentoptions.md)*
 
-*Defined in [api/types.ts:2885](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2885)*
+*Defined in [api/types.ts:2885](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2885)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingoptions20extension3.md
+++ b/docs/interfaces/_api_types_.imagingoptions20extension3.md
@@ -27,7 +27,7 @@ Options of parameters for Tone Compensation feature.
 
 **● DefoggingOptions**: *[DefoggingOptions](_api_types_.defoggingoptions.md)*
 
-*Defined in [api/types.ts:2894](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2894)*
+*Defined in [api/types.ts:2894](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2894)*
 
 ___
 <a id="extension"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Extension**: *[ImagingOptions20Extension4](_api_types_.imagingoptions20extension4.md)*
 
-*Defined in [api/types.ts:2896](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2896)*
+*Defined in [api/types.ts:2896](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2896)*
 
 ___
 <a id="noisereductionoptions"></a>
@@ -45,7 +45,7 @@ ___
 
 **● NoiseReductionOptions**: *[NoiseReductionOptions](_api_types_.noisereductionoptions.md)*
 
-*Defined in [api/types.ts:2895](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2895)*
+*Defined in [api/types.ts:2895](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2895)*
 
 ___
 <a id="tonecompensationoptions"></a>
@@ -54,7 +54,7 @@ ___
 
 **● ToneCompensationOptions**: *[ToneCompensationOptions](_api_types_.tonecompensationoptions.md)*
 
-*Defined in [api/types.ts:2893](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2893)*
+*Defined in [api/types.ts:2893](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2893)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingsettings.md
+++ b/docs/interfaces/_api_types_.imagingsettings.md
@@ -34,7 +34,7 @@ Enabled/disabled BLC mode (on/off).
 
 **● BacklightCompensation**: *[BacklightCompensation](_api_types_.backlightcompensation.md)*
 
-*Defined in [api/types.ts:2453](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2453)*
+*Defined in [api/types.ts:2453](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2453)*
 
 ___
 <a id="brightness"></a>
@@ -43,7 +43,7 @@ ___
 
 **● Brightness**: *`number`*
 
-*Defined in [api/types.ts:2454](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2454)*
+*Defined in [api/types.ts:2454](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2454)*
 
 ___
 <a id="colorsaturation"></a>
@@ -52,7 +52,7 @@ ___
 
 **● ColorSaturation**: *`number`*
 
-*Defined in [api/types.ts:2455](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2455)*
+*Defined in [api/types.ts:2455](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2455)*
 
 ___
 <a id="contrast"></a>
@@ -61,7 +61,7 @@ ___
 
 **● Contrast**: *`number`*
 
-*Defined in [api/types.ts:2456](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2456)*
+*Defined in [api/types.ts:2456](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2456)*
 
 ___
 <a id="exposure"></a>
@@ -70,7 +70,7 @@ ___
 
 **● Exposure**: *[Exposure](_api_types_.exposure.md)*
 
-*Defined in [api/types.ts:2457](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2457)*
+*Defined in [api/types.ts:2457](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2457)*
 
 ___
 <a id="extension"></a>
@@ -79,7 +79,7 @@ ___
 
 **● Extension**: *[ImagingSettingsExtension](_api_types_.imagingsettingsextension.md)*
 
-*Defined in [api/types.ts:2463](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2463)*
+*Defined in [api/types.ts:2463](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2463)*
 
 ___
 <a id="focus"></a>
@@ -88,7 +88,7 @@ ___
 
 **● Focus**: *[FocusConfiguration](_api_types_.focusconfiguration.md)*
 
-*Defined in [api/types.ts:2458](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2458)*
+*Defined in [api/types.ts:2458](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2458)*
 
 ___
 <a id="ircutfilter"></a>
@@ -97,7 +97,7 @@ ___
 
 **● IrCutFilter**: *[IrCutFilterMode](../enums/_api_types_.ircutfiltermode.md)*
 
-*Defined in [api/types.ts:2459](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2459)*
+*Defined in [api/types.ts:2459](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2459)*
 
 ___
 <a id="sharpness"></a>
@@ -106,7 +106,7 @@ ___
 
 **● Sharpness**: *`number`*
 
-*Defined in [api/types.ts:2460](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2460)*
+*Defined in [api/types.ts:2460](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2460)*
 
 ___
 <a id="whitebalance"></a>
@@ -115,7 +115,7 @@ ___
 
 **● WhiteBalance**: *[WhiteBalance](_api_types_.whitebalance.md)*
 
-*Defined in [api/types.ts:2462](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2462)*
+*Defined in [api/types.ts:2462](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2462)*
 
 ___
 <a id="widedynamicrange"></a>
@@ -124,7 +124,7 @@ ___
 
 **● WideDynamicRange**: *[WideDynamicRange](_api_types_.widedynamicrange.md)*
 
-*Defined in [api/types.ts:2461](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2461)*
+*Defined in [api/types.ts:2461](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2461)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingsettings20.md
+++ b/docs/interfaces/_api_types_.imagingsettings20.md
@@ -34,7 +34,7 @@ Type describing the ImagingSettings of a VideoSource. The supported options and 
 
 **● BacklightCompensation**: *[BacklightCompensation20](_api_types_.backlightcompensation20.md)*
 
-*Defined in [api/types.ts:2707](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2707)*
+*Defined in [api/types.ts:2707](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2707)*
 
 ___
 <a id="brightness"></a>
@@ -43,7 +43,7 @@ ___
 
 **● Brightness**: *`number`*
 
-*Defined in [api/types.ts:2708](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2708)*
+*Defined in [api/types.ts:2708](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2708)*
 
 ___
 <a id="colorsaturation"></a>
@@ -52,7 +52,7 @@ ___
 
 **● ColorSaturation**: *`number`*
 
-*Defined in [api/types.ts:2709](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2709)*
+*Defined in [api/types.ts:2709](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2709)*
 
 ___
 <a id="contrast"></a>
@@ -61,7 +61,7 @@ ___
 
 **● Contrast**: *`number`*
 
-*Defined in [api/types.ts:2710](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2710)*
+*Defined in [api/types.ts:2710](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2710)*
 
 ___
 <a id="exposure"></a>
@@ -70,7 +70,7 @@ ___
 
 **● Exposure**: *[Exposure20](_api_types_.exposure20.md)*
 
-*Defined in [api/types.ts:2711](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2711)*
+*Defined in [api/types.ts:2711](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2711)*
 
 ___
 <a id="extension"></a>
@@ -79,7 +79,7 @@ ___
 
 **● Extension**: *[ImagingSettingsExtension20](_api_types_.imagingsettingsextension20.md)*
 
-*Defined in [api/types.ts:2717](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2717)*
+*Defined in [api/types.ts:2717](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2717)*
 
 ___
 <a id="focus"></a>
@@ -88,7 +88,7 @@ ___
 
 **● Focus**: *[FocusConfiguration20](_api_types_.focusconfiguration20.md)*
 
-*Defined in [api/types.ts:2712](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2712)*
+*Defined in [api/types.ts:2712](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2712)*
 
 ___
 <a id="ircutfilter"></a>
@@ -97,7 +97,7 @@ ___
 
 **● IrCutFilter**: *[IrCutFilterMode](../enums/_api_types_.ircutfiltermode.md)*
 
-*Defined in [api/types.ts:2713](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2713)*
+*Defined in [api/types.ts:2713](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2713)*
 
 ___
 <a id="sharpness"></a>
@@ -106,7 +106,7 @@ ___
 
 **● Sharpness**: *`number`*
 
-*Defined in [api/types.ts:2714](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2714)*
+*Defined in [api/types.ts:2714](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2714)*
 
 ___
 <a id="whitebalance"></a>
@@ -115,7 +115,7 @@ ___
 
 **● WhiteBalance**: *[WhiteBalance20](_api_types_.whitebalance20.md)*
 
-*Defined in [api/types.ts:2716](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2716)*
+*Defined in [api/types.ts:2716](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2716)*
 
 ___
 <a id="widedynamicrange"></a>
@@ -124,7 +124,7 @@ ___
 
 **● WideDynamicRange**: *[WideDynamicRange20](_api_types_.widedynamicrange20.md)*
 
-*Defined in [api/types.ts:2715](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2715)*
+*Defined in [api/types.ts:2715](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2715)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingsettingsextension20.md
+++ b/docs/interfaces/_api_types_.imagingsettingsextension20.md
@@ -25,7 +25,7 @@ Optional element to configure Image Stabilization feature.
 
 **● Extension**: *[ImagingSettingsExtension202](_api_types_.imagingsettingsextension202.md)*
 
-*Defined in [api/types.ts:2725](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2725)*
+*Defined in [api/types.ts:2725](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2725)*
 
 ___
 <a id="imagestabilization"></a>
@@ -34,7 +34,7 @@ ___
 
 **● ImageStabilization**: *[ImageStabilization](_api_types_.imagestabilization.md)*
 
-*Defined in [api/types.ts:2724](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2724)*
+*Defined in [api/types.ts:2724](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2724)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingsettingsextension202.md
+++ b/docs/interfaces/_api_types_.imagingsettingsextension202.md
@@ -25,7 +25,7 @@ An optional parameter applied to only auto mode to adjust timing of toggling Ir 
 
 **● Extension**: *[ImagingSettingsExtension203](_api_types_.imagingsettingsextension203.md)*
 
-*Defined in [api/types.ts:2733](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2733)*
+*Defined in [api/types.ts:2733](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2733)*
 
 ___
 <a id="ircutfilterautoadjustment"></a>
@@ -34,7 +34,7 @@ ___
 
 **● IrCutFilterAutoAdjustment**: *[IrCutFilterAutoAdjustment](_api_types_.ircutfilterautoadjustment.md)*
 
-*Defined in [api/types.ts:2732](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2732)*
+*Defined in [api/types.ts:2732](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2732)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingsettingsextension203.md
+++ b/docs/interfaces/_api_types_.imagingsettingsextension203.md
@@ -27,7 +27,7 @@ Optional element to configure Image Contrast Compensation.
 
 **● Defogging**: *[Defogging](_api_types_.defogging.md)*
 
-*Defined in [api/types.ts:2741](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2741)*
+*Defined in [api/types.ts:2741](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2741)*
 
 ___
 <a id="extension"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Extension**: *[ImagingSettingsExtension204](_api_types_.imagingsettingsextension204.md)*
 
-*Defined in [api/types.ts:2743](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2743)*
+*Defined in [api/types.ts:2743](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2743)*
 
 ___
 <a id="noisereduction"></a>
@@ -45,7 +45,7 @@ ___
 
 **● NoiseReduction**: *[NoiseReduction](_api_types_.noisereduction.md)*
 
-*Defined in [api/types.ts:2742](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2742)*
+*Defined in [api/types.ts:2742](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2742)*
 
 ___
 <a id="tonecompensation"></a>
@@ -54,7 +54,7 @@ ___
 
 **● ToneCompensation**: *[ToneCompensation](_api_types_.tonecompensation.md)*
 
-*Defined in [api/types.ts:2740](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2740)*
+*Defined in [api/types.ts:2740](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2740)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingstatus.md
+++ b/docs/interfaces/_api_types_.imagingstatus.md
@@ -22,7 +22,7 @@
 
 **● FocusStatus**: *[FocusStatus](_api_types_.focusstatus.md)*
 
-*Defined in [api/types.ts:2425](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2425)*
+*Defined in [api/types.ts:2425](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2425)*
 
 ___
 

--- a/docs/interfaces/_api_types_.imagingstatus20.md
+++ b/docs/interfaces/_api_types_.imagingstatus20.md
@@ -27,7 +27,7 @@
 
 **● Extension**: *[ImagingStatus20Extension](_api_types_.imagingstatus20extension.md)*
 
-*Defined in [api/types.ts:2676](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2676)*
+*Defined in [api/types.ts:2676](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2676)*
 
 ___
 <a id="focusstatus20"></a>
@@ -36,7 +36,7 @@ ___
 
 **● FocusStatus20**: *[FocusStatus20](_api_types_.focusstatus20.md)*
 
-*Defined in [api/types.ts:2675](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2675)*
+*Defined in [api/types.ts:2675](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2675)*
 
 ___
 

--- a/docs/interfaces/_api_types_.intlist.md
+++ b/docs/interfaces/_api_types_.intlist.md
@@ -24,7 +24,7 @@ List of values.
 
 **● Items**: *`number`*
 
-*Defined in [api/types.ts:306](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L306)*
+*Defined in [api/types.ts:306](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L306)*
 
 ___
 

--- a/docs/interfaces/_api_types_.intrange.md
+++ b/docs/interfaces/_api_types_.intrange.md
@@ -25,7 +25,7 @@ Range of values greater equal Min value and less equal Max value.
 
 **● Max**: *`number`*
 
-*Defined in [api/types.ts:283](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L283)*
+*Defined in [api/types.ts:283](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L283)*
 
 ___
 <a id="min"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Min**: *`number`*
 
-*Defined in [api/types.ts:282](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L282)*
+*Defined in [api/types.ts:282](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L282)*
 
 ___
 

--- a/docs/interfaces/_api_types_.intrectanglerange.md
+++ b/docs/interfaces/_api_types_.intrectanglerange.md
@@ -27,7 +27,7 @@ Range of a rectangle. The rectangle itself is defined by lower left corner posit
 
 **● HeightRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:275](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L275)*
+*Defined in [api/types.ts:275](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L275)*
 
 ___
 <a id="widthrange"></a>
@@ -36,7 +36,7 @@ ___
 
 **● WidthRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:274](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L274)*
+*Defined in [api/types.ts:274](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L274)*
 
 ___
 <a id="xrange"></a>
@@ -45,7 +45,7 @@ ___
 
 **● XRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:272](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L272)*
+*Defined in [api/types.ts:272](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L272)*
 
 ___
 <a id="yrange"></a>
@@ -54,7 +54,7 @@ ___
 
 **● YRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:273](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L273)*
+*Defined in [api/types.ts:273](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L273)*
 
 ___
 

--- a/docs/interfaces/_api_types_.iocapabilities.md
+++ b/docs/interfaces/_api_types_.iocapabilities.md
@@ -26,7 +26,7 @@ Number of input connectors.
 
 **● Extension**: *[IOCapabilitiesExtension](_api_types_.iocapabilitiesextension.md)*
 
-*Defined in [api/types.ts:1510](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1510)*
+*Defined in [api/types.ts:1510](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1510)*
 
 ___
 <a id="inputconnectors"></a>
@@ -35,7 +35,7 @@ ___
 
 **● InputConnectors**: *`number`*
 
-*Defined in [api/types.ts:1508](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1508)*
+*Defined in [api/types.ts:1508](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1508)*
 
 ___
 <a id="relayoutputs"></a>
@@ -44,7 +44,7 @@ ___
 
 **● RelayOutputs**: *`number`*
 
-*Defined in [api/types.ts:1509](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1509)*
+*Defined in [api/types.ts:1509](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1509)*
 
 ___
 

--- a/docs/interfaces/_api_types_.iocapabilitiesextension.md
+++ b/docs/interfaces/_api_types_.iocapabilitiesextension.md
@@ -24,7 +24,7 @@
 
 **● Auxiliary**: *`boolean`*
 
-*Defined in [api/types.ts:1517](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1517)*
+*Defined in [api/types.ts:1517](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1517)*
 
 ___
 <a id="auxiliarycommands"></a>
@@ -33,7 +33,7 @@ ___
 
 **● AuxiliaryCommands**: *[AuxiliaryData](../modules/_api_types_.md#auxiliarydata)*
 
-*Defined in [api/types.ts:1518](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1518)*
+*Defined in [api/types.ts:1518](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1518)*
 
 ___
 <a id="extension"></a>
@@ -42,7 +42,7 @@ ___
 
 **● Extension**: *[IOCapabilitiesExtension2](_api_types_.iocapabilitiesextension2.md)*
 
-*Defined in [api/types.ts:1519](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1519)*
+*Defined in [api/types.ts:1519](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1519)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ipaddress.md
+++ b/docs/interfaces/_api_types_.ipaddress.md
@@ -26,7 +26,7 @@ Indicates if the address is an IPv4 or IPv6 address.
 
 **● IPv4Address**: *[IPv4Address](_api_types_.ipaddress.md#ipv4address)*
 
-*Defined in [api/types.ts:1168](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1168)*
+*Defined in [api/types.ts:1168](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1168)*
 
 ___
 <a id="ipv6address"></a>
@@ -35,7 +35,7 @@ ___
 
 **● IPv6Address**: *[IPv6Address](_api_types_.ipaddress.md#ipv6address)*
 
-*Defined in [api/types.ts:1169](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1169)*
+*Defined in [api/types.ts:1169](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1169)*
 
 ___
 <a id="type"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Type**: *[IPType](../enums/_api_types_.iptype.md)*
 
-*Defined in [api/types.ts:1167](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1167)*
+*Defined in [api/types.ts:1167](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1167)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ipaddressfilter.md
+++ b/docs/interfaces/_api_types_.ipaddressfilter.md
@@ -25,7 +25,7 @@
 
 **● Extension**: *[IPAddressFilterExtension](_api_types_.ipaddressfilterextension.md)*
 
-*Defined in [api/types.ts:1331](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1331)*
+*Defined in [api/types.ts:1331](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1331)*
 
 ___
 <a id="ipv4address"></a>
@@ -34,7 +34,7 @@ ___
 
 **● IPv4Address**: *[PrefixedIPv4Address](_api_types_.prefixedipv4address.md)*
 
-*Defined in [api/types.ts:1329](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1329)*
+*Defined in [api/types.ts:1329](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1329)*
 
 ___
 <a id="ipv6address"></a>
@@ -43,7 +43,7 @@ ___
 
 **● IPv6Address**: *[PrefixedIPv6Address](_api_types_.prefixedipv6address.md)*
 
-*Defined in [api/types.ts:1330](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1330)*
+*Defined in [api/types.ts:1330](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1330)*
 
 ___
 <a id="type"></a>
@@ -52,7 +52,7 @@ ___
 
 **● Type**: *[IPAddressFilterType](../enums/_api_types_.ipaddressfiltertype.md)*
 
-*Defined in [api/types.ts:1328](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1328)*
+*Defined in [api/types.ts:1328](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1328)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ipv4configuration.md
+++ b/docs/interfaces/_api_types_.ipv4configuration.md
@@ -27,7 +27,7 @@ List of manually added IPv4 addresses.
 
 **● DHCP**: *`boolean`*
 
-*Defined in [api/types.ts:1108](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1108)*
+*Defined in [api/types.ts:1108](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1108)*
 
 ___
 <a id="fromdhcp"></a>
@@ -36,7 +36,7 @@ ___
 
 **● FromDHCP**: *[PrefixedIPv4Address](_api_types_.prefixedipv4address.md)*
 
-*Defined in [api/types.ts:1107](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1107)*
+*Defined in [api/types.ts:1107](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1107)*
 
 ___
 <a id="linklocal"></a>
@@ -45,7 +45,7 @@ ___
 
 **● LinkLocal**: *[PrefixedIPv4Address](_api_types_.prefixedipv4address.md)*
 
-*Defined in [api/types.ts:1106](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1106)*
+*Defined in [api/types.ts:1106](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1106)*
 
 ___
 <a id="manual"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Manual**: *[PrefixedIPv4Address](_api_types_.prefixedipv4address.md)*
 
-*Defined in [api/types.ts:1105](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1105)*
+*Defined in [api/types.ts:1105](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1105)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ipv4networkinterface.md
+++ b/docs/interfaces/_api_types_.ipv4networkinterface.md
@@ -25,7 +25,7 @@ Indicates whether or not IPv4 is enabled.
 
 **● Config**: *[IPv4Configuration](_api_types_.ipv4configuration.md)*
 
-*Defined in [api/types.ts:1098](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1098)*
+*Defined in [api/types.ts:1098](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1098)*
 
 ___
 <a id="enabled"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Enabled**: *`boolean`*
 
-*Defined in [api/types.ts:1097](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1097)*
+*Defined in [api/types.ts:1097](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1097)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ipv4networkinterfacesetconfiguration.md
+++ b/docs/interfaces/_api_types_.ipv4networkinterfacesetconfiguration.md
@@ -26,7 +26,7 @@ Indicates whether or not IPv4 is enabled.
 
 **● DHCP**: *`boolean`*
 
-*Defined in [api/types.ts:1289](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1289)*
+*Defined in [api/types.ts:1289](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1289)*
 
 ___
 <a id="enabled"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Enabled**: *`boolean`*
 
-*Defined in [api/types.ts:1287](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1287)*
+*Defined in [api/types.ts:1287](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1287)*
 
 ___
 <a id="manual"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Manual**: *[PrefixedIPv4Address](_api_types_.prefixedipv4address.md)*
 
-*Defined in [api/types.ts:1288](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1288)*
+*Defined in [api/types.ts:1288](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1288)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ipv6configuration.md
+++ b/docs/interfaces/_api_types_.ipv6configuration.md
@@ -30,7 +30,7 @@ Indicates whether router advertisment is used.
 
 **● AcceptRouterAdvert**: *`boolean`*
 
-*Defined in [api/types.ts:1115](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1115)*
+*Defined in [api/types.ts:1115](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1115)*
 
 ___
 <a id="dhcp"></a>
@@ -39,7 +39,7 @@ ___
 
 **● DHCP**: *[IPv6DHCPConfiguration](../enums/_api_types_.ipv6dhcpconfiguration.md)*
 
-*Defined in [api/types.ts:1116](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1116)*
+*Defined in [api/types.ts:1116](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1116)*
 
 ___
 <a id="extension"></a>
@@ -48,7 +48,7 @@ ___
 
 **● Extension**: *[IPv6ConfigurationExtension](_api_types_.ipv6configurationextension.md)*
 
-*Defined in [api/types.ts:1121](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1121)*
+*Defined in [api/types.ts:1121](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1121)*
 
 ___
 <a id="fromdhcp"></a>
@@ -57,7 +57,7 @@ ___
 
 **● FromDHCP**: *[PrefixedIPv6Address](_api_types_.prefixedipv6address.md)*
 
-*Defined in [api/types.ts:1119](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1119)*
+*Defined in [api/types.ts:1119](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1119)*
 
 ___
 <a id="fromra"></a>
@@ -66,7 +66,7 @@ ___
 
 **● FromRA**: *[PrefixedIPv6Address](_api_types_.prefixedipv6address.md)*
 
-*Defined in [api/types.ts:1120](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1120)*
+*Defined in [api/types.ts:1120](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1120)*
 
 ___
 <a id="linklocal"></a>
@@ -75,7 +75,7 @@ ___
 
 **● LinkLocal**: *[PrefixedIPv6Address](_api_types_.prefixedipv6address.md)*
 
-*Defined in [api/types.ts:1118](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1118)*
+*Defined in [api/types.ts:1118](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1118)*
 
 ___
 <a id="manual"></a>
@@ -84,7 +84,7 @@ ___
 
 **● Manual**: *[PrefixedIPv6Address](_api_types_.prefixedipv6address.md)*
 
-*Defined in [api/types.ts:1117](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1117)*
+*Defined in [api/types.ts:1117](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1117)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ipv6networkinterface.md
+++ b/docs/interfaces/_api_types_.ipv6networkinterface.md
@@ -25,7 +25,7 @@ Indicates whether or not IPv6 is enabled.
 
 **● Config**: *[IPv6Configuration](_api_types_.ipv6configuration.md)*
 
-*Defined in [api/types.ts:1090](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1090)*
+*Defined in [api/types.ts:1090](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1090)*
 
 ___
 <a id="enabled"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Enabled**: *`boolean`*
 
-*Defined in [api/types.ts:1089](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1089)*
+*Defined in [api/types.ts:1089](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1089)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ipv6networkinterfacesetconfiguration.md
+++ b/docs/interfaces/_api_types_.ipv6networkinterfacesetconfiguration.md
@@ -27,7 +27,7 @@ Indicates whether or not IPv6 is enabled.
 
 **● AcceptRouterAdvert**: *`boolean`*
 
-*Defined in [api/types.ts:1278](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1278)*
+*Defined in [api/types.ts:1278](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1278)*
 
 ___
 <a id="dhcp"></a>
@@ -36,7 +36,7 @@ ___
 
 **● DHCP**: *[IPv6DHCPConfiguration](../enums/_api_types_.ipv6dhcpconfiguration.md)*
 
-*Defined in [api/types.ts:1280](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1280)*
+*Defined in [api/types.ts:1280](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1280)*
 
 ___
 <a id="enabled"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Enabled**: *`boolean`*
 
-*Defined in [api/types.ts:1277](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1277)*
+*Defined in [api/types.ts:1277](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1277)*
 
 ___
 <a id="manual"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Manual**: *[PrefixedIPv6Address](_api_types_.prefixedipv6address.md)*
 
-*Defined in [api/types.ts:1279](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1279)*
+*Defined in [api/types.ts:1279](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1279)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ircutfilterautoadjustment.md
+++ b/docs/interfaces/_api_types_.ircutfilterautoadjustment.md
@@ -27,7 +27,7 @@ Specifies which boundaries to automatically toggle Ir cut filter following param
 
 **● BoundaryOffset**: *`number`*
 
-*Defined in [api/types.ts:2772](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2772)*
+*Defined in [api/types.ts:2772](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2772)*
 
 ___
 <a id="boundarytype"></a>
@@ -36,7 +36,7 @@ ___
 
 **● BoundaryType**: *`string`*
 
-*Defined in [api/types.ts:2771](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2771)*
+*Defined in [api/types.ts:2771](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2771)*
 
 ___
 <a id="extension"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Extension**: *[IrCutFilterAutoAdjustmentExtension](_api_types_.ircutfilterautoadjustmentextension.md)*
 
-*Defined in [api/types.ts:2774](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2774)*
+*Defined in [api/types.ts:2774](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2774)*
 
 ___
 <a id="responsetime"></a>
@@ -54,7 +54,7 @@ ___
 
 **● ResponseTime**: *`string`*
 
-*Defined in [api/types.ts:2773](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2773)*
+*Defined in [api/types.ts:2773](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2773)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ircutfilterautoadjustmentoptions.md
+++ b/docs/interfaces/_api_types_.ircutfilterautoadjustmentoptions.md
@@ -27,7 +27,7 @@ Supported options of boundary types for adjustment of Ir cut filter auto mode. T
 
 **● BoundaryOffset**: *`boolean`*
 
-*Defined in [api/types.ts:2925](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2925)*
+*Defined in [api/types.ts:2925](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2925)*
 
 ___
 <a id="boundarytype"></a>
@@ -36,7 +36,7 @@ ___
 
 **● BoundaryType**: *`string`*
 
-*Defined in [api/types.ts:2924](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2924)*
+*Defined in [api/types.ts:2924](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2924)*
 
 ___
 <a id="extension"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Extension**: *[IrCutFilterAutoAdjustmentOptionsExtension](_api_types_.ircutfilterautoadjustmentoptionsextension.md)*
 
-*Defined in [api/types.ts:2927](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2927)*
+*Defined in [api/types.ts:2927](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2927)*
 
 ___
 <a id="responsetimerange"></a>
@@ -54,7 +54,7 @@ ___
 
 **● ResponseTimeRange**: *[DurationRange](_api_types_.durationrange.md)*
 
-*Defined in [api/types.ts:2926](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2926)*
+*Defined in [api/types.ts:2926](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2926)*
 
 ___
 

--- a/docs/interfaces/_api_types_.itemlist.md
+++ b/docs/interfaces/_api_types_.itemlist.md
@@ -29,7 +29,7 @@
 
 **● ElementItem**: *`any`*
 
-*Defined in [api/types.ts:3122](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3122)*
+*Defined in [api/types.ts:3122](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3122)*
 
 ___
 <a id="extension"></a>
@@ -38,7 +38,7 @@ ___
 
 **● Extension**: *[ItemListExtension](_api_types_.itemlistextension.md)*
 
-*Defined in [api/types.ts:3123](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3123)*
+*Defined in [api/types.ts:3123](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3123)*
 
 ___
 <a id="simpleitem"></a>
@@ -47,7 +47,7 @@ ___
 
 **● SimpleItem**: *`any`*
 
-*Defined in [api/types.ts:3121](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3121)*
+*Defined in [api/types.ts:3121](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3121)*
 
 ___
 

--- a/docs/interfaces/_api_types_.itemlistdescription.md
+++ b/docs/interfaces/_api_types_.itemlistdescription.md
@@ -30,7 +30,7 @@
 
 **● ElementItemDescription**: *`any`*
 
-*Defined in [api/types.ts:3161](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3161)*
+*Defined in [api/types.ts:3161](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3161)*
 
 ___
 <a id="extension"></a>
@@ -39,7 +39,7 @@ ___
 
 **● Extension**: *[ItemListDescriptionExtension](_api_types_.itemlistdescriptionextension.md)*
 
-*Defined in [api/types.ts:3162](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3162)*
+*Defined in [api/types.ts:3162](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3162)*
 
 ___
 <a id="simpleitemdescription"></a>
@@ -48,7 +48,7 @@ ___
 
 **● SimpleItemDescription**: *`any`*
 
-*Defined in [api/types.ts:3160](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3160)*
+*Defined in [api/types.ts:3160](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3160)*
 
 ___
 

--- a/docs/interfaces/_api_types_.jpegdecoptions.md
+++ b/docs/interfaces/_api_types_.jpegdecoptions.md
@@ -26,7 +26,7 @@ List of supported Jpeg Video Resolutions
 
 **● ResolutionsAvailable**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:888](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L888)*
+*Defined in [api/types.ts:888](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L888)*
 
 ___
 <a id="supportedframerate"></a>
@@ -35,7 +35,7 @@ ___
 
 **● SupportedFrameRate**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:890](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L890)*
+*Defined in [api/types.ts:890](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L890)*
 
 ___
 <a id="supportedinputbitrate"></a>
@@ -44,7 +44,7 @@ ___
 
 **● SupportedInputBitrate**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:889](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L889)*
+*Defined in [api/types.ts:889](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L889)*
 
 ___
 

--- a/docs/interfaces/_api_types_.jpegoptions.md
+++ b/docs/interfaces/_api_types_.jpegoptions.md
@@ -26,7 +26,7 @@ List of supported image sizes.
 
 **● EncodingIntervalRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:602](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L602)*
+*Defined in [api/types.ts:602](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L602)*
 
 ___
 <a id="frameraterange"></a>
@@ -35,7 +35,7 @@ ___
 
 **● FrameRateRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:601](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L601)*
+*Defined in [api/types.ts:601](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L601)*
 
 ___
 <a id="resolutionsavailable"></a>
@@ -44,7 +44,7 @@ ___
 
 **● ResolutionsAvailable**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:600](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L600)*
+*Defined in [api/types.ts:600](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L600)*
 
 ___
 

--- a/docs/interfaces/_api_types_.jpegoptions2.md
+++ b/docs/interfaces/_api_types_.jpegoptions2.md
@@ -24,7 +24,7 @@ Supported range of encoded bitrate in kbps.
 
 **● BitrateRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:609](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L609)*
+*Defined in [api/types.ts:609](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L609)*
 
 ___
 

--- a/docs/interfaces/_api_types_.layout.md
+++ b/docs/interfaces/_api_types_.layout.md
@@ -25,7 +25,7 @@ A layout describes a set of Video windows that are displayed simultaniously on a
 
 **● Extension**: *[LayoutExtension](_api_types_.layoutextension.md)*
 
-*Defined in [api/types.ts:3340](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3340)*
+*Defined in [api/types.ts:3340](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3340)*
 
 ___
 <a id="panelayout"></a>
@@ -34,7 +34,7 @@ ___
 
 **● PaneLayout**: *[PaneLayout](_api_types_.panelayout.md)*
 
-*Defined in [api/types.ts:3339](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3339)*
+*Defined in [api/types.ts:3339](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3339)*
 
 ___
 

--- a/docs/interfaces/_api_types_.layoutoptions.md
+++ b/docs/interfaces/_api_types_.layoutoptions.md
@@ -25,7 +25,7 @@ The options supported for a display layout.
 
 **● Extension**: *[LayoutOptionsExtension](_api_types_.layoutoptionsextension.md)*
 
-*Defined in [api/types.ts:3363](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3363)*
+*Defined in [api/types.ts:3363](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3363)*
 
 ___
 <a id="panelayoutoptions"></a>
@@ -34,7 +34,7 @@ ___
 
 **● PaneLayoutOptions**: *[PaneLayoutOptions](_api_types_.panelayoutoptions.md)*
 
-*Defined in [api/types.ts:3362](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3362)*
+*Defined in [api/types.ts:3362](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3362)*
 
 ___
 

--- a/docs/interfaces/_api_types_.lensdescription.md
+++ b/docs/interfaces/_api_types_.lensdescription.md
@@ -26,7 +26,7 @@ Offset of the lens center to the imager center in normalized coordinates.
 
 **● Offset**: *[LensOffset](_api_types_.lensoffset.md)*
 
-*Defined in [api/types.ts:464](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L464)*
+*Defined in [api/types.ts:464](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L464)*
 
 ___
 <a id="projection"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Projection**: *[LensProjection](_api_types_.lensprojection.md)*
 
-*Defined in [api/types.ts:465](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L465)*
+*Defined in [api/types.ts:465](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L465)*
 
 ___
 <a id="xfactor"></a>
@@ -44,7 +44,7 @@ ___
 
 **● XFactor**: *`number`*
 
-*Defined in [api/types.ts:466](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L466)*
+*Defined in [api/types.ts:466](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L466)*
 
 ___
 

--- a/docs/interfaces/_api_types_.lensprojection.md
+++ b/docs/interfaces/_api_types_.lensprojection.md
@@ -26,7 +26,7 @@ Angle of incidence.
 
 **● Angle**: *`number`*
 
-*Defined in [api/types.ts:449](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L449)*
+*Defined in [api/types.ts:449](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L449)*
 
 ___
 <a id="radius"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Radius**: *`number`*
 
-*Defined in [api/types.ts:450](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L450)*
+*Defined in [api/types.ts:450](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L450)*
 
 ___
 <a id="transmittance"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Transmittance**: *`number`*
 
-*Defined in [api/types.ts:451](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L451)*
+*Defined in [api/types.ts:451](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L451)*
 
 ___
 

--- a/docs/interfaces/_api_types_.locationentity.md
+++ b/docs/interfaces/_api_types_.locationentity.md
@@ -27,7 +27,7 @@ Location on earth.
 
 **● GeoLocation**: *[GeoLocation](_api_types_.geolocation.md)*
 
-*Defined in [api/types.ts:250](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L250)*
+*Defined in [api/types.ts:250](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L250)*
 
 ___
 <a id="geoorientation"></a>
@@ -36,7 +36,7 @@ ___
 
 **● GeoOrientation**: *[GeoOrientation](_api_types_.geoorientation.md)*
 
-*Defined in [api/types.ts:251](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L251)*
+*Defined in [api/types.ts:251](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L251)*
 
 ___
 <a id="locallocation"></a>
@@ -45,7 +45,7 @@ ___
 
 **● LocalLocation**: *[LocalLocation](_api_types_.locallocation.md)*
 
-*Defined in [api/types.ts:252](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L252)*
+*Defined in [api/types.ts:252](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L252)*
 
 ___
 <a id="localorientation"></a>
@@ -54,7 +54,7 @@ ___
 
 **● LocalOrientation**: *[LocalOrientation](_api_types_.localorientation.md)*
 
-*Defined in [api/types.ts:253](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L253)*
+*Defined in [api/types.ts:253](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L253)*
 
 ___
 

--- a/docs/interfaces/_api_types_.mediaattributes.md
+++ b/docs/interfaces/_api_types_.mediaattributes.md
@@ -27,7 +27,7 @@ A set of media attributes valid for a recording at a point in time or for a time
 
 **● From**: *`string`*
 
-*Defined in [api/types.ts:3589](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3589)*
+*Defined in [api/types.ts:3589](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3589)*
 
 ___
 <a id="recordingtoken"></a>
@@ -36,7 +36,7 @@ ___
 
 **● RecordingToken**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3587](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3587)*
+*Defined in [api/types.ts:3587](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3587)*
 
 ___
 <a id="trackattributes"></a>
@@ -45,7 +45,7 @@ ___
 
 **● TrackAttributes**: *[TrackAttributes](_api_types_.trackattributes.md)*
 
-*Defined in [api/types.ts:3588](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3588)*
+*Defined in [api/types.ts:3588](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3588)*
 
 ___
 <a id="until"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Until**: *`string`*
 
-*Defined in [api/types.ts:3590](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3590)*
+*Defined in [api/types.ts:3590](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3590)*
 
 ___
 

--- a/docs/interfaces/_api_types_.mediacapabilities.md
+++ b/docs/interfaces/_api_types_.mediacapabilities.md
@@ -26,7 +26,7 @@ Media service URI.
 
 **● Extension**: *[MediaCapabilitiesExtension](_api_types_.mediacapabilitiesextension.md)*
 
-*Defined in [api/types.ts:1534](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1534)*
+*Defined in [api/types.ts:1534](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1534)*
 
 ___
 <a id="streamingcapabilities"></a>
@@ -35,7 +35,7 @@ ___
 
 **● StreamingCapabilities**: *[RealTimeStreamingCapabilities](_api_types_.realtimestreamingcapabilities.md)*
 
-*Defined in [api/types.ts:1533](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1533)*
+*Defined in [api/types.ts:1533](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1533)*
 
 ___
 <a id="xaddr"></a>
@@ -44,7 +44,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1532](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1532)*
+*Defined in [api/types.ts:1532](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1532)*
 
 ___
 

--- a/docs/interfaces/_api_types_.mediacapabilitiesextension.md
+++ b/docs/interfaces/_api_types_.mediacapabilitiesextension.md
@@ -22,7 +22,7 @@
 
 **● ProfileCapabilities**: *[ProfileCapabilities](_api_types_.profilecapabilities.md)*
 
-*Defined in [api/types.ts:1541](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1541)*
+*Defined in [api/types.ts:1541](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1541)*
 
 ___
 

--- a/docs/interfaces/_api_types_.mediauri.md
+++ b/docs/interfaces/_api_types_.mediauri.md
@@ -27,7 +27,7 @@ Stable Uri to be used for requesting the media stream
 
 **● InvalidAfterConnect**: *`boolean`*
 
-*Defined in [api/types.ts:1011](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1011)*
+*Defined in [api/types.ts:1011](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1011)*
 
 ___
 <a id="invalidafterreboot"></a>
@@ -36,7 +36,7 @@ ___
 
 **● InvalidAfterReboot**: *`boolean`*
 
-*Defined in [api/types.ts:1012](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1012)*
+*Defined in [api/types.ts:1012](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1012)*
 
 ___
 <a id="timeout"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Timeout**: *`string`*
 
-*Defined in [api/types.ts:1013](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1013)*
+*Defined in [api/types.ts:1013](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1013)*
 
 ___
 <a id="uri"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Uri**: *`string`*
 
-*Defined in [api/types.ts:1010](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1010)*
+*Defined in [api/types.ts:1010](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1010)*
 
 ___
 

--- a/docs/interfaces/_api_types_.messagedescription.md
+++ b/docs/interfaces/_api_types_.messagedescription.md
@@ -27,7 +27,7 @@ Set of tokens producing this message. The list may only contain SimpleItemDescri
 
 **● Data**: *[ItemListDescription](_api_types_.itemlistdescription.md)*
 
-*Defined in [api/types.ts:3142](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3142)*
+*Defined in [api/types.ts:3142](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3142)*
 
 ___
 <a id="extension"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Extension**: *[MessageDescriptionExtension](_api_types_.messagedescriptionextension.md)*
 
-*Defined in [api/types.ts:3143](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3143)*
+*Defined in [api/types.ts:3143](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3143)*
 
 ___
 <a id="key"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Key**: *[ItemListDescription](_api_types_.itemlistdescription.md)*
 
-*Defined in [api/types.ts:3141](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3141)*
+*Defined in [api/types.ts:3141](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3141)*
 
 ___
 <a id="source"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Source**: *[ItemListDescription](_api_types_.itemlistdescription.md)*
 
-*Defined in [api/types.ts:3140](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3140)*
+*Defined in [api/types.ts:3140](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3140)*
 
 ___
 

--- a/docs/interfaces/_api_types_.metadataattributes.md
+++ b/docs/interfaces/_api_types_.metadataattributes.md
@@ -26,7 +26,7 @@ Indicates that there can be PTZ data in the metadata track in the specified time
 
 **● CanContainAnalytics**: *`boolean`*
 
-*Defined in [api/types.ts:3635](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3635)*
+*Defined in [api/types.ts:3635](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3635)*
 
 ___
 <a id="cancontainnotifications"></a>
@@ -35,7 +35,7 @@ ___
 
 **● CanContainNotifications**: *`boolean`*
 
-*Defined in [api/types.ts:3636](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3636)*
+*Defined in [api/types.ts:3636](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3636)*
 
 ___
 <a id="cancontainptz"></a>
@@ -44,7 +44,7 @@ ___
 
 **● CanContainPTZ**: *`boolean`*
 
-*Defined in [api/types.ts:3634](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3634)*
+*Defined in [api/types.ts:3634](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3634)*
 
 ___
 

--- a/docs/interfaces/_api_types_.metadataconfiguration.md
+++ b/docs/interfaces/_api_types_.metadataconfiguration.md
@@ -30,7 +30,7 @@ optional element to configure which PTZ related data is to include in the metada
 
 **● Analytics**: *`boolean`*
 
-*Defined in [api/types.ts:766](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L766)*
+*Defined in [api/types.ts:766](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L766)*
 
 ___
 <a id="analyticsengineconfiguration"></a>
@@ -39,7 +39,7 @@ ___
 
 **● AnalyticsEngineConfiguration**: *[AnalyticsEngineConfiguration](_api_types_.analyticsengineconfiguration.md)*
 
-*Defined in [api/types.ts:769](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L769)*
+*Defined in [api/types.ts:769](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L769)*
 
 ___
 <a id="events"></a>
@@ -48,7 +48,7 @@ ___
 
 **● Events**: *[EventSubscription](_api_types_.eventsubscription.md)*
 
-*Defined in [api/types.ts:765](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L765)*
+*Defined in [api/types.ts:765](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L765)*
 
 ___
 <a id="extension"></a>
@@ -57,7 +57,7 @@ ___
 
 **● Extension**: *[MetadataConfigurationExtension](_api_types_.metadataconfigurationextension.md)*
 
-*Defined in [api/types.ts:770](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L770)*
+*Defined in [api/types.ts:770](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L770)*
 
 ___
 <a id="multicast"></a>
@@ -66,7 +66,7 @@ ___
 
 **● Multicast**: *[MulticastConfiguration](_api_types_.multicastconfiguration.md)*
 
-*Defined in [api/types.ts:767](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L767)*
+*Defined in [api/types.ts:767](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L767)*
 
 ___
 <a id="ptzstatus"></a>
@@ -75,7 +75,7 @@ ___
 
 **● PTZStatus**: *[PTZFilter](_api_types_.ptzfilter.md)*
 
-*Defined in [api/types.ts:764](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L764)*
+*Defined in [api/types.ts:764](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L764)*
 
 ___
 <a id="sessiontimeout"></a>
@@ -84,7 +84,7 @@ ___
 
 **● SessionTimeout**: *`string`*
 
-*Defined in [api/types.ts:768](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L768)*
+*Defined in [api/types.ts:768](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L768)*
 
 ___
 

--- a/docs/interfaces/_api_types_.metadataconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.metadataconfigurationoptions.md
@@ -25,7 +25,7 @@ True if the device is able to stream the Geo Located positions of each target.
 
 **● Extension**: *[MetadataConfigurationOptionsExtension](_api_types_.metadataconfigurationoptionsextension.md)*
 
-*Defined in [api/types.ts:800](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L800)*
+*Defined in [api/types.ts:800](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L800)*
 
 ___
 <a id="ptzstatusfilteroptions"></a>
@@ -34,7 +34,7 @@ ___
 
 **● PTZStatusFilterOptions**: *[PTZStatusFilterOptions](_api_types_.ptzstatusfilteroptions.md)*
 
-*Defined in [api/types.ts:799](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L799)*
+*Defined in [api/types.ts:799](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L799)*
 
 ___
 

--- a/docs/interfaces/_api_types_.metadataconfigurationoptionsextension.md
+++ b/docs/interfaces/_api_types_.metadataconfigurationoptionsextension.md
@@ -25,7 +25,7 @@ List of supported metadata compression type. Its options shall be chosen from tt
 
 **● CompressionType**: *`string`*
 
-*Defined in [api/types.ts:807](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L807)*
+*Defined in [api/types.ts:807](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L807)*
 
 ___
 <a id="extension"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Extension**: *[MetadataConfigurationOptionsExtension2](_api_types_.metadataconfigurationoptionsextension2.md)*
 
-*Defined in [api/types.ts:808](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L808)*
+*Defined in [api/types.ts:808](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L808)*
 
 ___
 

--- a/docs/interfaces/_api_types_.metadatafilter.md
+++ b/docs/interfaces/_api_types_.metadatafilter.md
@@ -22,7 +22,7 @@
 
 **● MetadataStreamFilter**: *[XPathExpression](../modules/_api_types_.md#xpathexpression)*
 
-*Defined in [api/types.ts:3476](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3476)*
+*Defined in [api/types.ts:3476](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3476)*
 
 ___
 

--- a/docs/interfaces/_api_types_.metadatainput.md
+++ b/docs/interfaces/_api_types_.metadatainput.md
@@ -23,7 +23,7 @@
 
 **● Extension**: *[MetadataInputExtension](_api_types_.metadatainputextension.md)*
 
-*Defined in [api/types.ts:3859](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3859)*
+*Defined in [api/types.ts:3859](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3859)*
 
 ___
 <a id="metadataconfig"></a>
@@ -32,7 +32,7 @@ ___
 
 **● MetadataConfig**: *[Config](_api_types_.config.md)*
 
-*Defined in [api/types.ts:3858](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3858)*
+*Defined in [api/types.ts:3858](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3858)*
 
 ___
 

--- a/docs/interfaces/_api_types_.motionexpression.md
+++ b/docs/interfaces/_api_types_.motionexpression.md
@@ -24,7 +24,7 @@ Motion Expression data structure contains motion expression which is based on Sc
 
 **● Expression**: *`string`*
 
-*Defined in [api/types.ts:3298](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3298)*
+*Defined in [api/types.ts:3298](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3298)*
 
 ___
 

--- a/docs/interfaces/_api_types_.motionexpressionconfiguration.md
+++ b/docs/interfaces/_api_types_.motionexpressionconfiguration.md
@@ -24,7 +24,7 @@ Contains Rule MotionExpression configuration
 
 **● MotionExpression**: *[MotionExpression](_api_types_.motionexpression.md)*
 
-*Defined in [api/types.ts:3305](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3305)*
+*Defined in [api/types.ts:3305](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3305)*
 
 ___
 

--- a/docs/interfaces/_api_types_.moveoptions.md
+++ b/docs/interfaces/_api_types_.moveoptions.md
@@ -24,7 +24,7 @@
 
 **● Absolute**: *[AbsoluteFocusOptions](_api_types_.absolutefocusoptions.md)*
 
-*Defined in [api/types.ts:2626](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2626)*
+*Defined in [api/types.ts:2626](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2626)*
 
 ___
 <a id="continuous"></a>
@@ -33,7 +33,7 @@ ___
 
 **● Continuous**: *[ContinuousFocusOptions](_api_types_.continuousfocusoptions.md)*
 
-*Defined in [api/types.ts:2628](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2628)*
+*Defined in [api/types.ts:2628](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2628)*
 
 ___
 <a id="relative"></a>
@@ -42,7 +42,7 @@ ___
 
 **● Relative**: *[RelativeFocusOptions](_api_types_.relativefocusoptions.md)*
 
-*Defined in [api/types.ts:2627](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2627)*
+*Defined in [api/types.ts:2627](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2627)*
 
 ___
 

--- a/docs/interfaces/_api_types_.moveoptions20.md
+++ b/docs/interfaces/_api_types_.moveoptions20.md
@@ -28,7 +28,7 @@
 
 **● Absolute**: *[AbsoluteFocusOptions](_api_types_.absolutefocusoptions.md)*
 
-*Defined in [api/types.ts:2983](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2983)*
+*Defined in [api/types.ts:2983](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2983)*
 
 ___
 <a id="continuous"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Continuous**: *[ContinuousFocusOptions](_api_types_.continuousfocusoptions.md)*
 
-*Defined in [api/types.ts:2985](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2985)*
+*Defined in [api/types.ts:2985](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2985)*
 
 ___
 <a id="relative"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Relative**: *[RelativeFocusOptions20](_api_types_.relativefocusoptions20.md)*
 
-*Defined in [api/types.ts:2984](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2984)*
+*Defined in [api/types.ts:2984](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2984)*
 
 ___
 

--- a/docs/interfaces/_api_types_.mpeg4configuration.md
+++ b/docs/interfaces/_api_types_.mpeg4configuration.md
@@ -25,7 +25,7 @@ Determines the interval in which the I-Frames will be coded. An entry of 1 indic
 
 **● GovLength**: *`number`*
 
-*Defined in [api/types.ts:557](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L557)*
+*Defined in [api/types.ts:557](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L557)*
 
 ___
 <a id="mpeg4profile"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Mpeg4Profile**: *[Mpeg4Profile](../enums/_api_types_.mpeg4profile.md)*
 
-*Defined in [api/types.ts:558](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L558)*
+*Defined in [api/types.ts:558](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L558)*
 
 ___
 

--- a/docs/interfaces/_api_types_.mpeg4decoptions.md
+++ b/docs/interfaces/_api_types_.mpeg4decoptions.md
@@ -27,7 +27,7 @@ List of supported Mpeg4 Video Resolutions
 
 **● ResolutionsAvailable**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:897](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L897)*
+*Defined in [api/types.ts:897](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L897)*
 
 ___
 <a id="supportedframerate"></a>
@@ -36,7 +36,7 @@ ___
 
 **● SupportedFrameRate**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:900](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L900)*
+*Defined in [api/types.ts:900](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L900)*
 
 ___
 <a id="supportedinputbitrate"></a>
@@ -45,7 +45,7 @@ ___
 
 **● SupportedInputBitrate**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:899](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L899)*
+*Defined in [api/types.ts:899](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L899)*
 
 ___
 <a id="supportedmpeg4profiles"></a>
@@ -54,7 +54,7 @@ ___
 
 **● SupportedMpeg4Profiles**: *[Mpeg4Profile](../enums/_api_types_.mpeg4profile.md)*
 
-*Defined in [api/types.ts:898](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L898)*
+*Defined in [api/types.ts:898](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L898)*
 
 ___
 

--- a/docs/interfaces/_api_types_.mpeg4options.md
+++ b/docs/interfaces/_api_types_.mpeg4options.md
@@ -28,7 +28,7 @@ List of supported image sizes.
 
 **● EncodingIntervalRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:619](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L619)*
+*Defined in [api/types.ts:619](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L619)*
 
 ___
 <a id="frameraterange"></a>
@@ -37,7 +37,7 @@ ___
 
 **● FrameRateRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:618](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L618)*
+*Defined in [api/types.ts:618](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L618)*
 
 ___
 <a id="govlengthrange"></a>
@@ -46,7 +46,7 @@ ___
 
 **● GovLengthRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:617](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L617)*
+*Defined in [api/types.ts:617](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L617)*
 
 ___
 <a id="mpeg4profilessupported"></a>
@@ -55,7 +55,7 @@ ___
 
 **● Mpeg4ProfilesSupported**: *[Mpeg4Profile](../enums/_api_types_.mpeg4profile.md)*
 
-*Defined in [api/types.ts:620](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L620)*
+*Defined in [api/types.ts:620](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L620)*
 
 ___
 <a id="resolutionsavailable"></a>
@@ -64,7 +64,7 @@ ___
 
 **● ResolutionsAvailable**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:616](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L616)*
+*Defined in [api/types.ts:616](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L616)*
 
 ___
 

--- a/docs/interfaces/_api_types_.mpeg4options2.md
+++ b/docs/interfaces/_api_types_.mpeg4options2.md
@@ -24,7 +24,7 @@ Supported range of encoded bitrate in kbps.
 
 **● BitrateRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:627](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L627)*
+*Defined in [api/types.ts:627](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L627)*
 
 ___
 

--- a/docs/interfaces/_api_types_.multicastconfiguration.md
+++ b/docs/interfaces/_api_types_.multicastconfiguration.md
@@ -27,7 +27,7 @@ The multicast address (if this address is set to 0 no multicast streaming is ena
 
 **● Address**: *[IPAddress](_api_types_.ipaddress.md)*
 
-*Defined in [api/types.ts:984](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L984)*
+*Defined in [api/types.ts:984](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L984)*
 
 ___
 <a id="autostart"></a>
@@ -36,7 +36,7 @@ ___
 
 **● AutoStart**: *`boolean`*
 
-*Defined in [api/types.ts:987](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L987)*
+*Defined in [api/types.ts:987](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L987)*
 
 ___
 <a id="port"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Port**: *`number`*
 
-*Defined in [api/types.ts:985](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L985)*
+*Defined in [api/types.ts:985](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L985)*
 
 ___
 <a id="ttl"></a>
@@ -54,7 +54,7 @@ ___
 
 **● TTL**: *`number`*
 
-*Defined in [api/types.ts:986](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L986)*
+*Defined in [api/types.ts:986](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L986)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkcapabilities.md
+++ b/docs/interfaces/_api_types_.networkcapabilities.md
@@ -28,7 +28,7 @@ Indicates whether or not IP filtering is supported.
 
 **● DynDNS**: *`boolean`*
 
-*Defined in [api/types.ts:1574](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1574)*
+*Defined in [api/types.ts:1574](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1574)*
 
 ___
 <a id="extension"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Extension**: *[NetworkCapabilitiesExtension](_api_types_.networkcapabilitiesextension.md)*
 
-*Defined in [api/types.ts:1575](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1575)*
+*Defined in [api/types.ts:1575](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1575)*
 
 ___
 <a id="ipfilter"></a>
@@ -46,7 +46,7 @@ ___
 
 **● IPFilter**: *`boolean`*
 
-*Defined in [api/types.ts:1571](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1571)*
+*Defined in [api/types.ts:1571](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1571)*
 
 ___
 <a id="ipversion6"></a>
@@ -55,7 +55,7 @@ ___
 
 **● IPVersion6**: *`boolean`*
 
-*Defined in [api/types.ts:1573](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1573)*
+*Defined in [api/types.ts:1573](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1573)*
 
 ___
 <a id="zeroconfiguration"></a>
@@ -64,7 +64,7 @@ ___
 
 **● ZeroConfiguration**: *`boolean`*
 
-*Defined in [api/types.ts:1572](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1572)*
+*Defined in [api/types.ts:1572](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1572)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkcapabilitiesextension.md
+++ b/docs/interfaces/_api_types_.networkcapabilitiesextension.md
@@ -23,7 +23,7 @@
 
 **● Dot11Configuration**: *`boolean`*
 
-*Defined in [api/types.ts:1582](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1582)*
+*Defined in [api/types.ts:1582](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1582)*
 
 ___
 <a id="extension"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Extension**: *[NetworkCapabilitiesExtension2](_api_types_.networkcapabilitiesextension2.md)*
 
-*Defined in [api/types.ts:1583](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1583)*
+*Defined in [api/types.ts:1583](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1583)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkgateway.md
+++ b/docs/interfaces/_api_types_.networkgateway.md
@@ -25,7 +25,7 @@ IPv4 address string.
 
 **● IPv4Address**: *[IPv4Address](_api_types_.networkgateway.md#ipv4address)*
 
-*Defined in [api/types.ts:1296](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1296)*
+*Defined in [api/types.ts:1296](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1296)*
 
 ___
 <a id="ipv6address"></a>
@@ -34,7 +34,7 @@ ___
 
 **● IPv6Address**: *[IPv6Address](_api_types_.networkgateway.md#ipv6address)*
 
-*Defined in [api/types.ts:1297](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1297)*
+*Defined in [api/types.ts:1297](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1297)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkhost.md
+++ b/docs/interfaces/_api_types_.networkhost.md
@@ -28,7 +28,7 @@ Network host type: IPv4, IPv6 or DNS.
 
 **● DNSname**: *[DNSName](../modules/_api_types_.md#dnsname)*
 
-*Defined in [api/types.ts:1153](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1153)*
+*Defined in [api/types.ts:1153](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1153)*
 
 ___
 <a id="extension"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Extension**: *[NetworkHostExtension](_api_types_.networkhostextension.md)*
 
-*Defined in [api/types.ts:1154](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1154)*
+*Defined in [api/types.ts:1154](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1154)*
 
 ___
 <a id="ipv4address"></a>
@@ -46,7 +46,7 @@ ___
 
 **● IPv4Address**: *[IPv4Address](_api_types_.networkhost.md#ipv4address)*
 
-*Defined in [api/types.ts:1151](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1151)*
+*Defined in [api/types.ts:1151](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1151)*
 
 ___
 <a id="ipv6address"></a>
@@ -55,7 +55,7 @@ ___
 
 **● IPv6Address**: *[IPv6Address](_api_types_.networkhost.md#ipv6address)*
 
-*Defined in [api/types.ts:1152](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1152)*
+*Defined in [api/types.ts:1152](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1152)*
 
 ___
 <a id="type"></a>
@@ -64,7 +64,7 @@ ___
 
 **● Type**: *[NetworkHostType](../enums/_api_types_.networkhosttype.md)*
 
-*Defined in [api/types.ts:1150](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1150)*
+*Defined in [api/types.ts:1150](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1150)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkinterface.md
+++ b/docs/interfaces/_api_types_.networkinterface.md
@@ -29,7 +29,7 @@ Indicates whether or not an interface is enabled.
 
 **● Enabled**: *`boolean`*
 
-*Defined in [api/types.ts:1028](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1028)*
+*Defined in [api/types.ts:1028](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1028)*
 
 ___
 <a id="extension"></a>
@@ -38,7 +38,7 @@ ___
 
 **● Extension**: *[NetworkInterfaceExtension](_api_types_.networkinterfaceextension.md)*
 
-*Defined in [api/types.ts:1033](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1033)*
+*Defined in [api/types.ts:1033](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1033)*
 
 ___
 <a id="ipv4"></a>
@@ -47,7 +47,7 @@ ___
 
 **● IPv4**: *[IPv4NetworkInterface](_api_types_.ipv4networkinterface.md)*
 
-*Defined in [api/types.ts:1031](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1031)*
+*Defined in [api/types.ts:1031](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1031)*
 
 ___
 <a id="ipv6"></a>
@@ -56,7 +56,7 @@ ___
 
 **● IPv6**: *[IPv6NetworkInterface](_api_types_.ipv6networkinterface.md)*
 
-*Defined in [api/types.ts:1032](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1032)*
+*Defined in [api/types.ts:1032](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1032)*
 
 ___
 <a id="info"></a>
@@ -65,7 +65,7 @@ ___
 
 **● Info**: *[NetworkInterfaceInfo](_api_types_.networkinterfaceinfo.md)*
 
-*Defined in [api/types.ts:1029](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1029)*
+*Defined in [api/types.ts:1029](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1029)*
 
 ___
 <a id="link"></a>
@@ -74,7 +74,7 @@ ___
 
 **● Link**: *[NetworkInterfaceLink](_api_types_.networkinterfacelink.md)*
 
-*Defined in [api/types.ts:1030](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1030)*
+*Defined in [api/types.ts:1030](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1030)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkinterfaceconnectionsetting.md
+++ b/docs/interfaces/_api_types_.networkinterfaceconnectionsetting.md
@@ -26,7 +26,7 @@ Auto negotiation on/off.
 
 **● AutoNegotiation**: *`boolean`*
 
-*Defined in [api/types.ts:1071](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1071)*
+*Defined in [api/types.ts:1071](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1071)*
 
 ___
 <a id="duplex"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Duplex**: *[Duplex](../enums/_api_types_.duplex.md)*
 
-*Defined in [api/types.ts:1073](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1073)*
+*Defined in [api/types.ts:1073](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1073)*
 
 ___
 <a id="speed"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Speed**: *`number`*
 
-*Defined in [api/types.ts:1072](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1072)*
+*Defined in [api/types.ts:1072](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1072)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkinterfaceextension.md
+++ b/docs/interfaces/_api_types_.networkinterfaceextension.md
@@ -27,7 +27,7 @@ Extension point prepared for future 802.3 configuration.
 
 **● Dot11**: *[Dot11Configuration](_api_types_.dot11configuration.md)*
 
-*Defined in [api/types.ts:1042](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1042)*
+*Defined in [api/types.ts:1042](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1042)*
 
 ___
 <a id="dot3"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Dot3**: *[Dot3Configuration](_api_types_.dot3configuration.md)*
 
-*Defined in [api/types.ts:1041](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1041)*
+*Defined in [api/types.ts:1041](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1041)*
 
 ___
 <a id="extension"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Extension**: *[NetworkInterfaceExtension2](_api_types_.networkinterfaceextension2.md)*
 
-*Defined in [api/types.ts:1043](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1043)*
+*Defined in [api/types.ts:1043](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1043)*
 
 ___
 <a id="interfacetype"></a>
@@ -54,7 +54,7 @@ ___
 
 **● InterfaceType**: *`any`*
 
-*Defined in [api/types.ts:1040](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1040)*
+*Defined in [api/types.ts:1040](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1040)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkinterfaceinfo.md
+++ b/docs/interfaces/_api_types_.networkinterfaceinfo.md
@@ -26,7 +26,7 @@ Network interface name, for example eth0.
 
 **● HwAddress**: *[HwAddress](_api_types_.networkinterfaceinfo.md#hwaddress)*
 
-*Defined in [api/types.ts:1081](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1081)*
+*Defined in [api/types.ts:1081](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1081)*
 
 ___
 <a id="mtu"></a>
@@ -35,7 +35,7 @@ ___
 
 **● MTU**: *`number`*
 
-*Defined in [api/types.ts:1082](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1082)*
+*Defined in [api/types.ts:1082](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1082)*
 
 ___
 <a id="name"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Name**: *`string`*
 
-*Defined in [api/types.ts:1080](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1080)*
+*Defined in [api/types.ts:1080](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1080)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkinterfacelink.md
+++ b/docs/interfaces/_api_types_.networkinterfacelink.md
@@ -26,7 +26,7 @@ Configured link settings.
 
 **● AdminSettings**: *[NetworkInterfaceConnectionSetting](_api_types_.networkinterfaceconnectionsetting.md)*
 
-*Defined in [api/types.ts:1062](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1062)*
+*Defined in [api/types.ts:1062](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1062)*
 
 ___
 <a id="interfacetype"></a>
@@ -35,7 +35,7 @@ ___
 
 **● InterfaceType**: *`any`*
 
-*Defined in [api/types.ts:1064](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1064)*
+*Defined in [api/types.ts:1064](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1064)*
 
 ___
 <a id="opersettings"></a>
@@ -44,7 +44,7 @@ ___
 
 **● OperSettings**: *[NetworkInterfaceConnectionSetting](_api_types_.networkinterfaceconnectionsetting.md)*
 
-*Defined in [api/types.ts:1063](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1063)*
+*Defined in [api/types.ts:1063](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1063)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkinterfacesetconfiguration.md
+++ b/docs/interfaces/_api_types_.networkinterfacesetconfiguration.md
@@ -29,7 +29,7 @@ Indicates whether or not an interface is enabled.
 
 **● Enabled**: *`boolean`*
 
-*Defined in [api/types.ts:1256](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1256)*
+*Defined in [api/types.ts:1256](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1256)*
 
 ___
 <a id="extension"></a>
@@ -38,7 +38,7 @@ ___
 
 **● Extension**: *[NetworkInterfaceSetConfigurationExtension](_api_types_.networkinterfacesetconfigurationextension.md)*
 
-*Defined in [api/types.ts:1261](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1261)*
+*Defined in [api/types.ts:1261](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1261)*
 
 ___
 <a id="ipv4"></a>
@@ -47,7 +47,7 @@ ___
 
 **● IPv4**: *[IPv4NetworkInterfaceSetConfiguration](_api_types_.ipv4networkinterfacesetconfiguration.md)*
 
-*Defined in [api/types.ts:1259](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1259)*
+*Defined in [api/types.ts:1259](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1259)*
 
 ___
 <a id="ipv6"></a>
@@ -56,7 +56,7 @@ ___
 
 **● IPv6**: *[IPv6NetworkInterfaceSetConfiguration](_api_types_.ipv6networkinterfacesetconfiguration.md)*
 
-*Defined in [api/types.ts:1260](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1260)*
+*Defined in [api/types.ts:1260](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1260)*
 
 ___
 <a id="link"></a>
@@ -65,7 +65,7 @@ ___
 
 **● Link**: *[NetworkInterfaceConnectionSetting](_api_types_.networkinterfaceconnectionsetting.md)*
 
-*Defined in [api/types.ts:1257](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1257)*
+*Defined in [api/types.ts:1257](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1257)*
 
 ___
 <a id="mtu"></a>
@@ -74,7 +74,7 @@ ___
 
 **● MTU**: *`number`*
 
-*Defined in [api/types.ts:1258](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1258)*
+*Defined in [api/types.ts:1258](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1258)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkinterfacesetconfigurationextension.md
+++ b/docs/interfaces/_api_types_.networkinterfacesetconfigurationextension.md
@@ -24,7 +24,7 @@
 
 **● Dot11**: *[Dot11Configuration](_api_types_.dot11configuration.md)*
 
-*Defined in [api/types.ts:1269](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1269)*
+*Defined in [api/types.ts:1269](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1269)*
 
 ___
 <a id="dot3"></a>
@@ -33,7 +33,7 @@ ___
 
 **● Dot3**: *[Dot3Configuration](_api_types_.dot3configuration.md)*
 
-*Defined in [api/types.ts:1268](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1268)*
+*Defined in [api/types.ts:1268](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1268)*
 
 ___
 <a id="extension"></a>
@@ -42,7 +42,7 @@ ___
 
 **● Extension**: *[NetworkInterfaceSetConfigurationExtension2](_api_types_.networkinterfacesetconfigurationextension2.md)*
 
-*Defined in [api/types.ts:1270](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1270)*
+*Defined in [api/types.ts:1270](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1270)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkprotocol.md
+++ b/docs/interfaces/_api_types_.networkprotocol.md
@@ -27,7 +27,7 @@ Network protocol type string.
 
 **● Enabled**: *`boolean`*
 
-*Defined in [api/types.ts:1135](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1135)*
+*Defined in [api/types.ts:1135](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1135)*
 
 ___
 <a id="extension"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Extension**: *[NetworkProtocolExtension](_api_types_.networkprotocolextension.md)*
 
-*Defined in [api/types.ts:1137](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1137)*
+*Defined in [api/types.ts:1137](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1137)*
 
 ___
 <a id="name"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Name**: *[NetworkProtocolType](../enums/_api_types_.networkprotocoltype.md)*
 
-*Defined in [api/types.ts:1134](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1134)*
+*Defined in [api/types.ts:1134](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1134)*
 
 ___
 <a id="port"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Port**: *`number`*
 
-*Defined in [api/types.ts:1136](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1136)*
+*Defined in [api/types.ts:1136](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1136)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkzeroconfiguration.md
+++ b/docs/interfaces/_api_types_.networkzeroconfiguration.md
@@ -27,7 +27,7 @@ Unique identifier of network interface.
 
 **● Addresses**: *[IPv4Address](../modules/_api_types_.md#ipv4address)*
 
-*Defined in [api/types.ts:1306](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1306)*
+*Defined in [api/types.ts:1306](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1306)*
 
 ___
 <a id="enabled"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Enabled**: *`boolean`*
 
-*Defined in [api/types.ts:1305](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1305)*
+*Defined in [api/types.ts:1305](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1305)*
 
 ___
 <a id="extension"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Extension**: *[NetworkZeroConfigurationExtension](_api_types_.networkzeroconfigurationextension.md)*
 
-*Defined in [api/types.ts:1307](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1307)*
+*Defined in [api/types.ts:1307](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1307)*
 
 ___
 <a id="interfacetoken"></a>
@@ -54,7 +54,7 @@ ___
 
 **● InterfaceToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:1304](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1304)*
+*Defined in [api/types.ts:1304](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1304)*
 
 ___
 

--- a/docs/interfaces/_api_types_.networkzeroconfigurationextension.md
+++ b/docs/interfaces/_api_types_.networkzeroconfigurationextension.md
@@ -25,7 +25,7 @@ Optional array holding the configuration for the second and possibly further int
 
 **● Additional**: *[NetworkZeroConfiguration](_api_types_.networkzeroconfiguration.md)*
 
-*Defined in [api/types.ts:1314](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1314)*
+*Defined in [api/types.ts:1314](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1314)*
 
 ___
 <a id="extension"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Extension**: *[NetworkZeroConfigurationExtension2](_api_types_.networkzeroconfigurationextension2.md)*
 
-*Defined in [api/types.ts:1315](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1315)*
+*Defined in [api/types.ts:1315](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1315)*
 
 ___
 

--- a/docs/interfaces/_api_types_.noisereduction.md
+++ b/docs/interfaces/_api_types_.noisereduction.md
@@ -24,7 +24,7 @@ Level parameter specified with unitless normalized value from 0.0 to +1.0. Level
 
 **● Level**: *`number`*
 
-*Defined in [api/types.ts:2851](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2851)*
+*Defined in [api/types.ts:2851](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2851)*
 
 ___
 

--- a/docs/interfaces/_api_types_.noisereductionoptions.md
+++ b/docs/interfaces/_api_types_.noisereductionoptions.md
@@ -24,7 +24,7 @@ Indicates whether or not support Level parameter for NoiseReduction.
 
 **● Level**: *`boolean`*
 
-*Defined in [api/types.ts:3105](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3105)*
+*Defined in [api/types.ts:3105](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3105)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ntpinformation.md
+++ b/docs/interfaces/_api_types_.ntpinformation.md
@@ -27,7 +27,7 @@ Indicates if NTP information is to be retrieved by using DHCP.
 
 **● Extension**: *[NTPInformationExtension](_api_types_.ntpinformationextension.md)*
 
-*Defined in [api/types.ts:1227](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1227)*
+*Defined in [api/types.ts:1227](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1227)*
 
 ___
 <a id="fromdhcp"></a>
@@ -36,7 +36,7 @@ ___
 
 **● FromDHCP**: *`boolean`*
 
-*Defined in [api/types.ts:1224](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1224)*
+*Defined in [api/types.ts:1224](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1224)*
 
 ___
 <a id="ntpfromdhcp"></a>
@@ -45,7 +45,7 @@ ___
 
 **● NTPFromDHCP**: *[NetworkHost](_api_types_.networkhost.md)*
 
-*Defined in [api/types.ts:1225](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1225)*
+*Defined in [api/types.ts:1225](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1225)*
 
 ___
 <a id="ntpmanual"></a>
@@ -54,7 +54,7 @@ ___
 
 **● NTPManual**: *[NetworkHost](_api_types_.networkhost.md)*
 
-*Defined in [api/types.ts:1226](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1226)*
+*Defined in [api/types.ts:1226](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1226)*
 
 ___
 

--- a/docs/interfaces/_api_types_.onvifversion.md
+++ b/docs/interfaces/_api_types_.onvifversion.md
@@ -25,7 +25,7 @@ Major version number.
 
 **● Major**: *`number`*
 
-*Defined in [api/types.ts:1659](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1659)*
+*Defined in [api/types.ts:1659](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1659)*
 
 ___
 <a id="minor"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Minor**: *`number`*
 
-*Defined in [api/types.ts:1660](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1660)*
+*Defined in [api/types.ts:1660](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1660)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdcolor.md
+++ b/docs/interfaces/_api_types_.osdcolor.md
@@ -24,7 +24,7 @@ The value range of "Transparent" could be defined by vendors only should follow 
 
 **● Color**: *[Color](_api_types_.color.md)*
 
-*Defined in [api/types.ts:3987](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3987)*
+*Defined in [api/types.ts:3987](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3987)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdcoloroptions.md
+++ b/docs/interfaces/_api_types_.osdcoloroptions.md
@@ -26,7 +26,7 @@ Describe the option of the color and its transparency.
 
 **● Color**: *[ColorOptions](_api_types_.coloroptions.md)*
 
-*Defined in [api/types.ts:4057](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4057)*
+*Defined in [api/types.ts:4057](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4057)*
 
 ___
 <a id="extension"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Extension**: *[OSDColorOptionsExtension](_api_types_.osdcoloroptionsextension.md)*
 
-*Defined in [api/types.ts:4059](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4059)*
+*Defined in [api/types.ts:4059](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4059)*
 
 ___
 <a id="transparent"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Transparent**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:4058](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4058)*
+*Defined in [api/types.ts:4058](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4058)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdconfiguration.md
+++ b/docs/interfaces/_api_types_.osdconfiguration.md
@@ -29,7 +29,7 @@ Reference to the video source configuration.
 
 **● Extension**: *[OSDConfigurationExtension](_api_types_.osdconfigurationextension.md)*
 
-*Defined in [api/types.ts:4110](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4110)*
+*Defined in [api/types.ts:4110](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4110)*
 
 ___
 <a id="image"></a>
@@ -38,7 +38,7 @@ ___
 
 **● Image**: *[OSDImgConfiguration](_api_types_.osdimgconfiguration.md)*
 
-*Defined in [api/types.ts:4109](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4109)*
+*Defined in [api/types.ts:4109](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4109)*
 
 ___
 <a id="position"></a>
@@ -47,7 +47,7 @@ ___
 
 **● Position**: *[OSDPosConfiguration](_api_types_.osdposconfiguration.md)*
 
-*Defined in [api/types.ts:4107](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4107)*
+*Defined in [api/types.ts:4107](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4107)*
 
 ___
 <a id="textstring"></a>
@@ -56,7 +56,7 @@ ___
 
 **● TextString**: *[OSDTextConfiguration](_api_types_.osdtextconfiguration.md)*
 
-*Defined in [api/types.ts:4108](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4108)*
+*Defined in [api/types.ts:4108](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4108)*
 
 ___
 <a id="type"></a>
@@ -65,7 +65,7 @@ ___
 
 **● Type**: *[OSDType](../enums/_api_types_.osdtype.md)*
 
-*Defined in [api/types.ts:4106](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4106)*
+*Defined in [api/types.ts:4106](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4106)*
 
 ___
 <a id="videosourceconfigurationtoken"></a>
@@ -74,7 +74,7 @@ ___
 
 **● VideoSourceConfigurationToken**: *[OSDReference](_api_types_.osdreference.md)*
 
-*Defined in [api/types.ts:4105](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4105)*
+*Defined in [api/types.ts:4105](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4105)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.osdconfigurationoptions.md
@@ -29,7 +29,7 @@ The maximum number of OSD configurations supported for the specified video sourc
 
 **● Extension**: *[OSDConfigurationOptionsExtension](_api_types_.osdconfigurationoptionsextension.md)*
 
-*Defined in [api/types.ts:4134](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4134)*
+*Defined in [api/types.ts:4134](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4134)*
 
 ___
 <a id="imageoption"></a>
@@ -38,7 +38,7 @@ ___
 
 **● ImageOption**: *[OSDImgOptions](_api_types_.osdimgoptions.md)*
 
-*Defined in [api/types.ts:4133](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4133)*
+*Defined in [api/types.ts:4133](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4133)*
 
 ___
 <a id="maximumnumberofosds"></a>
@@ -47,7 +47,7 @@ ___
 
 **● MaximumNumberOfOSDs**: *[MaximumNumberOfOSDs](_api_types_.maximumnumberofosds.md)*
 
-*Defined in [api/types.ts:4129](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4129)*
+*Defined in [api/types.ts:4129](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4129)*
 
 ___
 <a id="positionoption"></a>
@@ -56,7 +56,7 @@ ___
 
 **● PositionOption**: *`string`*
 
-*Defined in [api/types.ts:4131](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4131)*
+*Defined in [api/types.ts:4131](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4131)*
 
 ___
 <a id="textoption"></a>
@@ -65,7 +65,7 @@ ___
 
 **● TextOption**: *[OSDTextOptions](_api_types_.osdtextoptions.md)*
 
-*Defined in [api/types.ts:4132](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4132)*
+*Defined in [api/types.ts:4132](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4132)*
 
 ___
 <a id="type"></a>
@@ -74,7 +74,7 @@ ___
 
 **● Type**: *[OSDType](../enums/_api_types_.osdtype.md)*
 
-*Defined in [api/types.ts:4130](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4130)*
+*Defined in [api/types.ts:4130](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4130)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdimgconfiguration.md
+++ b/docs/interfaces/_api_types_.osdimgconfiguration.md
@@ -25,7 +25,7 @@ The URI of the image which to be displayed.
 
 **● Extension**: *[OSDImgConfigurationExtension](_api_types_.osdimgconfigurationextension.md)*
 
-*Defined in [api/types.ts:4022](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4022)*
+*Defined in [api/types.ts:4022](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4022)*
 
 ___
 <a id="imgpath"></a>
@@ -34,7 +34,7 @@ ___
 
 **● ImgPath**: *`string`*
 
-*Defined in [api/types.ts:4021](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4021)*
+*Defined in [api/types.ts:4021](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4021)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdimgoptions.md
+++ b/docs/interfaces/_api_types_.osdimgoptions.md
@@ -25,7 +25,7 @@ List of available image URIs.
 
 **● Extension**: *[OSDImgOptionsExtension](_api_types_.osdimgoptionsextension.md)*
 
-*Defined in [api/types.ts:4092](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4092)*
+*Defined in [api/types.ts:4092](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4092)*
 
 ___
 <a id="imagepath"></a>
@@ -34,7 +34,7 @@ ___
 
 **● ImagePath**: *`string`*
 
-*Defined in [api/types.ts:4091](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4091)*
+*Defined in [api/types.ts:4091](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4091)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdposconfiguration.md
+++ b/docs/interfaces/_api_types_.osdposconfiguration.md
@@ -26,7 +26,7 @@ For OSD position type, following are the pre-defined: UpperLeft UpperRight Lower
 
 **● Extension**: *[OSDPosConfigurationExtension](_api_types_.osdposconfigurationextension.md)*
 
-*Defined in [api/types.ts:3974](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3974)*
+*Defined in [api/types.ts:3974](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3974)*
 
 ___
 <a id="pos"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Pos**: *[Vector](_api_types_.vector.md)*
 
-*Defined in [api/types.ts:3973](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3973)*
+*Defined in [api/types.ts:3973](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3973)*
 
 ___
 <a id="type"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Type**: *`string`*
 
-*Defined in [api/types.ts:3972](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3972)*
+*Defined in [api/types.ts:3972](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3972)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdtextconfiguration.md
+++ b/docs/interfaces/_api_types_.osdtextconfiguration.md
@@ -37,7 +37,7 @@
 
 **● BackgroundColor**: *[OSDColor](_api_types_.osdcolor.md)*
 
-*Defined in [api/types.ts:4006](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4006)*
+*Defined in [api/types.ts:4006](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4006)*
 
 ___
 <a id="dateformat"></a>
@@ -46,7 +46,7 @@ ___
 
 **● DateFormat**: *`string`*
 
-*Defined in [api/types.ts:4002](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4002)*
+*Defined in [api/types.ts:4002](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4002)*
 
 ___
 <a id="extension"></a>
@@ -55,7 +55,7 @@ ___
 
 **● Extension**: *[OSDTextConfigurationExtension](_api_types_.osdtextconfigurationextension.md)*
 
-*Defined in [api/types.ts:4008](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4008)*
+*Defined in [api/types.ts:4008](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4008)*
 
 ___
 <a id="fontcolor"></a>
@@ -64,7 +64,7 @@ ___
 
 **● FontColor**: *[OSDColor](_api_types_.osdcolor.md)*
 
-*Defined in [api/types.ts:4005](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4005)*
+*Defined in [api/types.ts:4005](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4005)*
 
 ___
 <a id="fontsize"></a>
@@ -73,7 +73,7 @@ ___
 
 **● FontSize**: *`number`*
 
-*Defined in [api/types.ts:4004](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4004)*
+*Defined in [api/types.ts:4004](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4004)*
 
 ___
 <a id="plaintext"></a>
@@ -82,7 +82,7 @@ ___
 
 **● PlainText**: *`string`*
 
-*Defined in [api/types.ts:4007](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4007)*
+*Defined in [api/types.ts:4007](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4007)*
 
 ___
 <a id="timeformat"></a>
@@ -91,7 +91,7 @@ ___
 
 **● TimeFormat**: *`string`*
 
-*Defined in [api/types.ts:4003](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4003)*
+*Defined in [api/types.ts:4003](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4003)*
 
 ___
 <a id="type"></a>
@@ -100,7 +100,7 @@ ___
 
 **● Type**: *`string`*
 
-*Defined in [api/types.ts:4001](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4001)*
+*Defined in [api/types.ts:4001](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4001)*
 
 ___
 

--- a/docs/interfaces/_api_types_.osdtextoptions.md
+++ b/docs/interfaces/_api_types_.osdtextoptions.md
@@ -30,7 +30,7 @@ List of supported OSD text type. When a device indicates the supported number re
 
 **● BackgroundColor**: *[OSDColorOptions](_api_types_.osdcoloroptions.md)*
 
-*Defined in [api/types.ts:4077](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4077)*
+*Defined in [api/types.ts:4077](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4077)*
 
 ___
 <a id="dateformat"></a>
@@ -39,7 +39,7 @@ ___
 
 **● DateFormat**: *`string`*
 
-*Defined in [api/types.ts:4074](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4074)*
+*Defined in [api/types.ts:4074](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4074)*
 
 ___
 <a id="extension"></a>
@@ -48,7 +48,7 @@ ___
 
 **● Extension**: *[OSDTextOptionsExtension](_api_types_.osdtextoptionsextension.md)*
 
-*Defined in [api/types.ts:4078](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4078)*
+*Defined in [api/types.ts:4078](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4078)*
 
 ___
 <a id="fontcolor"></a>
@@ -57,7 +57,7 @@ ___
 
 **● FontColor**: *[OSDColorOptions](_api_types_.osdcoloroptions.md)*
 
-*Defined in [api/types.ts:4076](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4076)*
+*Defined in [api/types.ts:4076](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4076)*
 
 ___
 <a id="fontsizerange"></a>
@@ -66,7 +66,7 @@ ___
 
 **● FontSizeRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:4073](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4073)*
+*Defined in [api/types.ts:4073](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4073)*
 
 ___
 <a id="timeformat"></a>
@@ -75,7 +75,7 @@ ___
 
 **● TimeFormat**: *`string`*
 
-*Defined in [api/types.ts:4075](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4075)*
+*Defined in [api/types.ts:4075](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4075)*
 
 ___
 <a id="type"></a>
@@ -84,7 +84,7 @@ ___
 
 **● Type**: *`string`*
 
-*Defined in [api/types.ts:4072](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4072)*
+*Defined in [api/types.ts:4072](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4072)*
 
 ___
 

--- a/docs/interfaces/_api_types_.paneconfiguration.md
+++ b/docs/interfaces/_api_types_.paneconfiguration.md
@@ -29,7 +29,7 @@ Configuration of the streaming and coding settings of a Video window.
 
 **● AudioEncoderConfiguration**: *[AudioEncoderConfiguration](_api_types_.audioencoderconfiguration.md)*
 
-*Defined in [api/types.ts:3322](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3322)*
+*Defined in [api/types.ts:3322](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3322)*
 
 ___
 <a id="audiooutputtoken"></a>
@@ -38,7 +38,7 @@ ___
 
 **● AudioOutputToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3320](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3320)*
+*Defined in [api/types.ts:3320](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3320)*
 
 ___
 <a id="audiosourcetoken"></a>
@@ -47,7 +47,7 @@ ___
 
 **● AudioSourceToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3321](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3321)*
+*Defined in [api/types.ts:3321](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3321)*
 
 ___
 <a id="panename"></a>
@@ -56,7 +56,7 @@ ___
 
 **● PaneName**: *`string`*
 
-*Defined in [api/types.ts:3319](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3319)*
+*Defined in [api/types.ts:3319](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3319)*
 
 ___
 <a id="receivertoken"></a>
@@ -65,7 +65,7 @@ ___
 
 **● ReceiverToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3323](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3323)*
+*Defined in [api/types.ts:3323](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3323)*
 
 ___
 <a id="token"></a>
@@ -74,7 +74,7 @@ ___
 
 **● Token**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3324](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3324)*
+*Defined in [api/types.ts:3324](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3324)*
 
 ___
 

--- a/docs/interfaces/_api_types_.panelayout.md
+++ b/docs/interfaces/_api_types_.panelayout.md
@@ -25,7 +25,7 @@ A pane layout describes one Video window of a display. It links a pane configura
 
 **● Area**: *[Rectangle](_api_types_.rectangle.md)*
 
-*Defined in [api/types.ts:3332](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3332)*
+*Defined in [api/types.ts:3332](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3332)*
 
 ___
 <a id="pane"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Pane**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3331](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3331)*
+*Defined in [api/types.ts:3331](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3331)*
 
 ___
 

--- a/docs/interfaces/_api_types_.panelayoutoptions.md
+++ b/docs/interfaces/_api_types_.panelayoutoptions.md
@@ -25,7 +25,7 @@ Description of a pane layout describing a complete display layout.
 
 **● Area**: *[Rectangle](_api_types_.rectangle.md)*
 
-*Defined in [api/types.ts:3376](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3376)*
+*Defined in [api/types.ts:3376](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3376)*
 
 ___
 <a id="extension"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Extension**: *[PaneOptionExtension](_api_types_.paneoptionextension.md)*
 
-*Defined in [api/types.ts:3377](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3377)*
+*Defined in [api/types.ts:3377](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3377)*
 
 ___
 

--- a/docs/interfaces/_api_types_.pantiltlimits.md
+++ b/docs/interfaces/_api_types_.pantiltlimits.md
@@ -26,7 +26,7 @@
 
 **● Range**: *[Space2DDescription](_api_types_.space2ddescription.md)*
 
-*Defined in [api/types.ts:2215](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2215)*
+*Defined in [api/types.ts:2215](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2215)*
 
 ___
 

--- a/docs/interfaces/_api_types_.polygon.md
+++ b/docs/interfaces/_api_types_.polygon.md
@@ -22,7 +22,7 @@
 
 **● Point**: *[Vector](_api_types_.vector.md)*
 
-*Defined in [api/types.ts:192](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L192)*
+*Defined in [api/types.ts:192](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L192)*
 
 ___
 

--- a/docs/interfaces/_api_types_.polygonconfiguration.md
+++ b/docs/interfaces/_api_types_.polygonconfiguration.md
@@ -24,7 +24,7 @@ Contains Polygon configuration for rule parameters
 
 **● Polygon**: *[Polygon](_api_types_.polygon.md)*
 
-*Defined in [api/types.ts:3270](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3270)*
+*Defined in [api/types.ts:3270](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3270)*
 
 ___
 

--- a/docs/interfaces/_api_types_.polyline.md
+++ b/docs/interfaces/_api_types_.polyline.md
@@ -22,7 +22,7 @@
 
 **● Point**: *[Vector](_api_types_.vector.md)*
 
-*Defined in [api/types.ts:3175](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3175)*
+*Defined in [api/types.ts:3175](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3175)*
 
 ___
 

--- a/docs/interfaces/_api_types_.polylinearray.md
+++ b/docs/interfaces/_api_types_.polylinearray.md
@@ -25,7 +25,7 @@ Contains array of Polyline
 
 **● Extension**: *[PolylineArrayExtension](_api_types_.polylinearrayextension.md)*
 
-*Defined in [api/types.ts:3278](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3278)*
+*Defined in [api/types.ts:3278](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3278)*
 
 ___
 <a id="segment"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Segment**: *[Polyline](_api_types_.polyline.md)*
 
-*Defined in [api/types.ts:3277](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3277)*
+*Defined in [api/types.ts:3277](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3277)*
 
 ___
 

--- a/docs/interfaces/_api_types_.polylinearrayconfiguration.md
+++ b/docs/interfaces/_api_types_.polylinearrayconfiguration.md
@@ -24,7 +24,7 @@ Contains PolylineArray configuration data
 
 **● PolylineArray**: *[PolylineArray](_api_types_.polylinearray.md)*
 
-*Defined in [api/types.ts:3291](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3291)*
+*Defined in [api/types.ts:3291](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3291)*
 
 ___
 

--- a/docs/interfaces/_api_types_.prefixedipv4address.md
+++ b/docs/interfaces/_api_types_.prefixedipv4address.md
@@ -25,7 +25,7 @@ IPv4 address
 
 **● Address**: *[IPv4Address](../modules/_api_types_.md#ipv4address)*
 
-*Defined in [api/types.ts:1176](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1176)*
+*Defined in [api/types.ts:1176](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1176)*
 
 ___
 <a id="prefixlength"></a>
@@ -34,7 +34,7 @@ ___
 
 **● PrefixLength**: *`number`*
 
-*Defined in [api/types.ts:1177](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1177)*
+*Defined in [api/types.ts:1177](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1177)*
 
 ___
 

--- a/docs/interfaces/_api_types_.prefixedipv6address.md
+++ b/docs/interfaces/_api_types_.prefixedipv6address.md
@@ -25,7 +25,7 @@ IPv6 address
 
 **● Address**: *[IPv6Address](../modules/_api_types_.md#ipv6address)*
 
-*Defined in [api/types.ts:1184](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1184)*
+*Defined in [api/types.ts:1184](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1184)*
 
 ___
 <a id="prefixlength"></a>
@@ -34,7 +34,7 @@ ___
 
 **● PrefixLength**: *`number`*
 
-*Defined in [api/types.ts:1185](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1185)*
+*Defined in [api/types.ts:1185](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1185)*
 
 ___
 

--- a/docs/interfaces/_api_types_.presettour.md
+++ b/docs/interfaces/_api_types_.presettour.md
@@ -29,7 +29,7 @@ Readable name of the preset tour.
 
 **● AutoStart**: *`boolean`*
 
-*Defined in [api/types.ts:2296](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2296)*
+*Defined in [api/types.ts:2296](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2296)*
 
 ___
 <a id="extension"></a>
@@ -38,7 +38,7 @@ ___
 
 **● Extension**: *[PTZPresetTourExtension](_api_types_.ptzpresettourextension.md)*
 
-*Defined in [api/types.ts:2299](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2299)*
+*Defined in [api/types.ts:2299](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2299)*
 
 ___
 <a id="name"></a>
@@ -47,7 +47,7 @@ ___
 
 **● Name**: *[Name](_api_types_.presettour.md#name)*
 
-*Defined in [api/types.ts:2294](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2294)*
+*Defined in [api/types.ts:2294](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2294)*
 
 ___
 <a id="startingcondition"></a>
@@ -56,7 +56,7 @@ ___
 
 **● StartingCondition**: *[PTZPresetTourStartingCondition](_api_types_.ptzpresettourstartingcondition.md)*
 
-*Defined in [api/types.ts:2297](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2297)*
+*Defined in [api/types.ts:2297](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2297)*
 
 ___
 <a id="status"></a>
@@ -65,7 +65,7 @@ ___
 
 **● Status**: *[PTZPresetTourStatus](_api_types_.ptzpresettourstatus.md)*
 
-*Defined in [api/types.ts:2295](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2295)*
+*Defined in [api/types.ts:2295](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2295)*
 
 ___
 <a id="tourspot"></a>
@@ -74,7 +74,7 @@ ___
 
 **● TourSpot**: *[PTZPresetTourSpot](_api_types_.ptzpresettourspot.md)*
 
-*Defined in [api/types.ts:2298](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2298)*
+*Defined in [api/types.ts:2298](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2298)*
 
 ___
 

--- a/docs/interfaces/_api_types_.profile.md
+++ b/docs/interfaces/_api_types_.profile.md
@@ -41,7 +41,7 @@
 
 **● AudioEncoderConfiguration**: *[AudioEncoderConfiguration](_api_types_.audioencoderconfiguration.md)*
 
-*Defined in [api/types.ts:370](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L370)*
+*Defined in [api/types.ts:370](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L370)*
 
 ___
 <a id="audiosourceconfiguration"></a>
@@ -50,7 +50,7 @@ ___
 
 **● AudioSourceConfiguration**: *[AudioSourceConfiguration](_api_types_.audiosourceconfiguration.md)*
 
-*Defined in [api/types.ts:368](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L368)*
+*Defined in [api/types.ts:368](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L368)*
 
 ___
 <a id="extension"></a>
@@ -59,7 +59,7 @@ ___
 
 **● Extension**: *[ProfileExtension](_api_types_.profileextension.md)*
 
-*Defined in [api/types.ts:374](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L374)*
+*Defined in [api/types.ts:374](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L374)*
 
 ___
 <a id="metadataconfiguration"></a>
@@ -68,7 +68,7 @@ ___
 
 **● MetadataConfiguration**: *[MetadataConfiguration](_api_types_.metadataconfiguration.md)*
 
-*Defined in [api/types.ts:373](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L373)*
+*Defined in [api/types.ts:373](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L373)*
 
 ___
 <a id="name"></a>
@@ -77,7 +77,7 @@ ___
 
 **● Name**: *[Name](_api_types_.profile.md#name)*
 
-*Defined in [api/types.ts:366](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L366)*
+*Defined in [api/types.ts:366](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L366)*
 
 ___
 <a id="ptzconfiguration"></a>
@@ -86,7 +86,7 @@ ___
 
 **● PTZConfiguration**: *[PTZConfiguration](_api_types_.ptzconfiguration.md)*
 
-*Defined in [api/types.ts:372](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L372)*
+*Defined in [api/types.ts:372](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L372)*
 
 ___
 <a id="videoanalyticsconfiguration"></a>
@@ -95,7 +95,7 @@ ___
 
 **● VideoAnalyticsConfiguration**: *[VideoAnalyticsConfiguration](_api_types_.videoanalyticsconfiguration.md)*
 
-*Defined in [api/types.ts:371](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L371)*
+*Defined in [api/types.ts:371](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L371)*
 
 ___
 <a id="videoencoderconfiguration"></a>
@@ -104,7 +104,7 @@ ___
 
 **● VideoEncoderConfiguration**: *[VideoEncoderConfiguration](_api_types_.videoencoderconfiguration.md)*
 
-*Defined in [api/types.ts:369](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L369)*
+*Defined in [api/types.ts:369](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L369)*
 
 ___
 <a id="videosourceconfiguration"></a>
@@ -113,7 +113,7 @@ ___
 
 **● VideoSourceConfiguration**: *[VideoSourceConfiguration](_api_types_.videosourceconfiguration.md)*
 
-*Defined in [api/types.ts:367](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L367)*
+*Defined in [api/types.ts:367](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L367)*
 
 ___
 

--- a/docs/interfaces/_api_types_.profilecapabilities.md
+++ b/docs/interfaces/_api_types_.profilecapabilities.md
@@ -24,7 +24,7 @@ Maximum number of profiles.
 
 **● MaximumNumberOfProfiles**: *`number`*
 
-*Defined in [api/types.ts:1564](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1564)*
+*Defined in [api/types.ts:1564](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1564)*
 
 ___
 

--- a/docs/interfaces/_api_types_.profileextension.md
+++ b/docs/interfaces/_api_types_.profileextension.md
@@ -26,7 +26,7 @@ Optional configuration of the Audio output.
 
 **● AudioDecoderConfiguration**: *[AudioDecoderConfiguration](_api_types_.audiodecoderconfiguration.md)*
 
-*Defined in [api/types.ts:382](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L382)*
+*Defined in [api/types.ts:382](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L382)*
 
 ___
 <a id="audiooutputconfiguration"></a>
@@ -35,7 +35,7 @@ ___
 
 **● AudioOutputConfiguration**: *[AudioOutputConfiguration](_api_types_.audiooutputconfiguration.md)*
 
-*Defined in [api/types.ts:381](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L381)*
+*Defined in [api/types.ts:381](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L381)*
 
 ___
 <a id="extension"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Extension**: *[ProfileExtension2](_api_types_.profileextension2.md)*
 
-*Defined in [api/types.ts:383](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L383)*
+*Defined in [api/types.ts:383](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L383)*
 
 ___
 

--- a/docs/interfaces/_api_types_.profilestatus.md
+++ b/docs/interfaces/_api_types_.profilestatus.md
@@ -23,7 +23,7 @@
 
 **● ActiveConnections**: *[ActiveConnection](_api_types_.activeconnection.md)*
 
-*Defined in [api/types.ts:3947](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3947)*
+*Defined in [api/types.ts:3947](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3947)*
 
 ___
 <a id="extension"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Extension**: *[ProfileStatusExtension](_api_types_.profilestatusextension.md)*
 
-*Defined in [api/types.ts:3948](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3948)*
+*Defined in [api/types.ts:3948](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3948)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptcontroldirection.md
+++ b/docs/interfaces/_api_types_.ptcontroldirection.md
@@ -26,7 +26,7 @@ Optional element to configure related parameters for E-Flip.
 
 **● EFlip**: *[EFlip](_api_types_.eflip.md)*
 
-*Defined in [api/types.ts:2123](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2123)*
+*Defined in [api/types.ts:2123](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2123)*
 
 ___
 <a id="extension"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Extension**: *[PTControlDirectionExtension](_api_types_.ptcontroldirectionextension.md)*
 
-*Defined in [api/types.ts:2125](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2125)*
+*Defined in [api/types.ts:2125](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2125)*
 
 ___
 <a id="reverse"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Reverse**: *[Reverse](_api_types_.reverse.md)*
 
-*Defined in [api/types.ts:2124](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2124)*
+*Defined in [api/types.ts:2124](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2124)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptcontroldirectionoptions.md
+++ b/docs/interfaces/_api_types_.ptcontroldirectionoptions.md
@@ -26,7 +26,7 @@ Supported options for EFlip feature.
 
 **● EFlip**: *[EFlipOptions](_api_types_.eflipoptions.md)*
 
-*Defined in [api/types.ts:2170](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2170)*
+*Defined in [api/types.ts:2170](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2170)*
 
 ___
 <a id="extension"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Extension**: *[PTControlDirectionOptionsExtension](_api_types_.ptcontroldirectionoptionsextension.md)*
 
-*Defined in [api/types.ts:2172](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2172)*
+*Defined in [api/types.ts:2172](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2172)*
 
 ___
 <a id="reverse"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Reverse**: *[ReverseOptions](_api_types_.reverseoptions.md)*
 
-*Defined in [api/types.ts:2171](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2171)*
+*Defined in [api/types.ts:2171](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2171)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzcapabilities.md
+++ b/docs/interfaces/_api_types_.ptzcapabilities.md
@@ -24,7 +24,7 @@ PTZ service URI.
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1674](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1674)*
+*Defined in [api/types.ts:1674](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1674)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzconfiguration.md
+++ b/docs/interfaces/_api_types_.ptzconfiguration.md
@@ -37,7 +37,7 @@
 
 **● DefaultAbsolutePantTiltPositionSpace**: *`string`*
 
-*Defined in [api/types.ts:2092](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2092)*
+*Defined in [api/types.ts:2092](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2092)*
 
 ___
 <a id="defaultabsolutezoompositionspace"></a>
@@ -46,7 +46,7 @@ ___
 
 **● DefaultAbsoluteZoomPositionSpace**: *`string`*
 
-*Defined in [api/types.ts:2093](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2093)*
+*Defined in [api/types.ts:2093](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2093)*
 
 ___
 <a id="defaultcontinuouspantiltvelocityspace"></a>
@@ -55,7 +55,7 @@ ___
 
 **● DefaultContinuousPanTiltVelocitySpace**: *`string`*
 
-*Defined in [api/types.ts:2096](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2096)*
+*Defined in [api/types.ts:2096](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2096)*
 
 ___
 <a id="defaultcontinuouszoomvelocityspace"></a>
@@ -64,7 +64,7 @@ ___
 
 **● DefaultContinuousZoomVelocitySpace**: *`string`*
 
-*Defined in [api/types.ts:2097](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2097)*
+*Defined in [api/types.ts:2097](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2097)*
 
 ___
 <a id="defaultptzspeed"></a>
@@ -73,7 +73,7 @@ ___
 
 **● DefaultPTZSpeed**: *[PTZSpeed](_api_types_.ptzspeed.md)*
 
-*Defined in [api/types.ts:2098](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2098)*
+*Defined in [api/types.ts:2098](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2098)*
 
 ___
 <a id="defaultptztimeout"></a>
@@ -82,7 +82,7 @@ ___
 
 **● DefaultPTZTimeout**: *`string`*
 
-*Defined in [api/types.ts:2099](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2099)*
+*Defined in [api/types.ts:2099](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2099)*
 
 ___
 <a id="defaultrelativepantilttranslationspace"></a>
@@ -91,7 +91,7 @@ ___
 
 **● DefaultRelativePanTiltTranslationSpace**: *`string`*
 
-*Defined in [api/types.ts:2094](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2094)*
+*Defined in [api/types.ts:2094](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2094)*
 
 ___
 <a id="defaultrelativezoomtranslationspace"></a>
@@ -100,7 +100,7 @@ ___
 
 **● DefaultRelativeZoomTranslationSpace**: *`string`*
 
-*Defined in [api/types.ts:2095](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2095)*
+*Defined in [api/types.ts:2095](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2095)*
 
 ___
 <a id="extension"></a>
@@ -109,7 +109,7 @@ ___
 
 **● Extension**: *[PTZConfigurationExtension](_api_types_.ptzconfigurationextension.md)*
 
-*Defined in [api/types.ts:2102](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2102)*
+*Defined in [api/types.ts:2102](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2102)*
 
 ___
 <a id="nodetoken"></a>
@@ -118,7 +118,7 @@ ___
 
 **● NodeToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:2091](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2091)*
+*Defined in [api/types.ts:2091](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2091)*
 
 ___
 <a id="pantiltlimits"></a>
@@ -127,7 +127,7 @@ ___
 
 **● PanTiltLimits**: *[PanTiltLimits](_api_types_.pantiltlimits.md)*
 
-*Defined in [api/types.ts:2100](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2100)*
+*Defined in [api/types.ts:2100](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2100)*
 
 ___
 <a id="zoomlimits"></a>
@@ -136,7 +136,7 @@ ___
 
 **● ZoomLimits**: *[ZoomLimits](_api_types_.zoomlimits.md)*
 
-*Defined in [api/types.ts:2101](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2101)*
+*Defined in [api/types.ts:2101](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2101)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzconfigurationextension.md
+++ b/docs/interfaces/_api_types_.ptzconfigurationextension.md
@@ -25,7 +25,7 @@ Optional element to configure PT Control Direction related features.
 
 **● Extension**: *[PTZConfigurationExtension2](_api_types_.ptzconfigurationextension2.md)*
 
-*Defined in [api/types.ts:2110](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2110)*
+*Defined in [api/types.ts:2110](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2110)*
 
 ___
 <a id="ptcontroldirection"></a>
@@ -34,7 +34,7 @@ ___
 
 **● PTControlDirection**: *[PTControlDirection](_api_types_.ptcontroldirection.md)*
 
-*Defined in [api/types.ts:2109](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2109)*
+*Defined in [api/types.ts:2109](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2109)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.ptzconfigurationoptions.md
@@ -29,7 +29,7 @@
 
 **● Extension**: *[PTZConfigurationOptions2](_api_types_.ptzconfigurationoptions2.md)*
 
-*Defined in [api/types.ts:2157](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2157)*
+*Defined in [api/types.ts:2157](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2157)*
 
 ___
 <a id="ptcontroldirection"></a>
@@ -38,7 +38,7 @@ ___
 
 **● PTControlDirection**: *[PTControlDirectionOptions](_api_types_.ptcontroldirectionoptions.md)*
 
-*Defined in [api/types.ts:2156](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2156)*
+*Defined in [api/types.ts:2156](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2156)*
 
 ___
 <a id="ptztimeout"></a>
@@ -47,7 +47,7 @@ ___
 
 **● PTZTimeout**: *[DurationRange](_api_types_.durationrange.md)*
 
-*Defined in [api/types.ts:2155](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2155)*
+*Defined in [api/types.ts:2155](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2155)*
 
 ___
 <a id="spaces"></a>
@@ -56,7 +56,7 @@ ___
 
 **● Spaces**: *[PTZSpaces](_api_types_.ptzspaces.md)*
 
-*Defined in [api/types.ts:2154](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2154)*
+*Defined in [api/types.ts:2154](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2154)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzfilter.md
+++ b/docs/interfaces/_api_types_.ptzfilter.md
@@ -25,7 +25,7 @@ True if the metadata stream shall contain the PTZ status (IDLE, MOVING or UNKNOW
 
 **● Position**: *`boolean`*
 
-*Defined in [api/types.ts:784](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L784)*
+*Defined in [api/types.ts:784](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L784)*
 
 ___
 <a id="status"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Status**: *`boolean`*
 
-*Defined in [api/types.ts:783](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L783)*
+*Defined in [api/types.ts:783](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L783)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzmovestatus.md
+++ b/docs/interfaces/_api_types_.ptzmovestatus.md
@@ -23,7 +23,7 @@
 
 **● PanTilt**: *[MoveStatus](../enums/_api_types_.movestatus.md)*
 
-*Defined in [api/types.ts:172](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L172)*
+*Defined in [api/types.ts:172](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L172)*
 
 ___
 <a id="zoom"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Zoom**: *[MoveStatus](../enums/_api_types_.movestatus.md)*
 
-*Defined in [api/types.ts:173](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L173)*
+*Defined in [api/types.ts:173](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L173)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptznode.md
+++ b/docs/interfaces/_api_types_.ptznode.md
@@ -31,7 +31,7 @@
 
 **● AuxiliaryCommands**: *[AuxiliaryData](../modules/_api_types_.md#auxiliarydata)*
 
-*Defined in [api/types.ts:2050](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2050)*
+*Defined in [api/types.ts:2050](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2050)*
 
 ___
 <a id="extension"></a>
@@ -40,7 +40,7 @@ ___
 
 **● Extension**: *[PTZNodeExtension](_api_types_.ptznodeextension.md)*
 
-*Defined in [api/types.ts:2051](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2051)*
+*Defined in [api/types.ts:2051](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2051)*
 
 ___
 <a id="homesupported"></a>
@@ -49,7 +49,7 @@ ___
 
 **● HomeSupported**: *`boolean`*
 
-*Defined in [api/types.ts:2049](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2049)*
+*Defined in [api/types.ts:2049](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2049)*
 
 ___
 <a id="maximumnumberofpresets"></a>
@@ -58,7 +58,7 @@ ___
 
 **● MaximumNumberOfPresets**: *`number`*
 
-*Defined in [api/types.ts:2048](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2048)*
+*Defined in [api/types.ts:2048](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2048)*
 
 ___
 <a id="name"></a>
@@ -67,7 +67,7 @@ ___
 
 **● Name**: *[Name](_api_types_.ptznode.md#name)*
 
-*Defined in [api/types.ts:2046](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2046)*
+*Defined in [api/types.ts:2046](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2046)*
 
 ___
 <a id="supportedptzspaces"></a>
@@ -76,7 +76,7 @@ ___
 
 **● SupportedPTZSpaces**: *[PTZSpaces](_api_types_.ptzspaces.md)*
 
-*Defined in [api/types.ts:2047](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2047)*
+*Defined in [api/types.ts:2047](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2047)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptznodeextension.md
+++ b/docs/interfaces/_api_types_.ptznodeextension.md
@@ -27,7 +27,7 @@
 
 **● Extension**: *[PTZNodeExtension2](_api_types_.ptznodeextension2.md)*
 
-*Defined in [api/types.ts:2061](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2061)*
+*Defined in [api/types.ts:2061](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2061)*
 
 ___
 <a id="supportedpresettour"></a>
@@ -36,7 +36,7 @@ ___
 
 **● SupportedPresetTour**: *[PTZPresetTourSupported](_api_types_.ptzpresettoursupported.md)*
 
-*Defined in [api/types.ts:2060](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2060)*
+*Defined in [api/types.ts:2060](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2060)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpositionfilter.md
+++ b/docs/interfaces/_api_types_.ptzpositionfilter.md
@@ -26,7 +26,7 @@ The lower boundary of the PTZ volume to look for.
 
 **● EnterOrExit**: *`boolean`*
 
-*Defined in [api/types.ts:3469](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3469)*
+*Defined in [api/types.ts:3469](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3469)*
 
 ___
 <a id="maxposition"></a>
@@ -35,7 +35,7 @@ ___
 
 **● MaxPosition**: *[PTZVector](_api_types_.ptzvector.md)*
 
-*Defined in [api/types.ts:3468](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3468)*
+*Defined in [api/types.ts:3468](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3468)*
 
 ___
 <a id="minposition"></a>
@@ -44,7 +44,7 @@ ___
 
 **● MinPosition**: *[PTZVector](_api_types_.ptzvector.md)*
 
-*Defined in [api/types.ts:3467](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3467)*
+*Defined in [api/types.ts:3467](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3467)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpreset.md
+++ b/docs/interfaces/_api_types_.ptzpreset.md
@@ -27,7 +27,7 @@
 
 **● Name**: *[Name](_api_types_.ptzpreset.md#name)*
 
-*Defined in [api/types.ts:2286](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2286)*
+*Defined in [api/types.ts:2286](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2286)*
 
 ___
 <a id="ptzposition"></a>
@@ -36,7 +36,7 @@ ___
 
 **● PTZPosition**: *[PTZVector](_api_types_.ptzvector.md)*
 
-*Defined in [api/types.ts:2287](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2287)*
+*Defined in [api/types.ts:2287](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2287)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettouroptions.md
+++ b/docs/interfaces/_api_types_.ptzpresettouroptions.md
@@ -26,7 +26,7 @@ Indicates whether or not the AutoStart is supported.
 
 **● AutoStart**: *`boolean`*
 
-*Defined in [api/types.ts:2375](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2375)*
+*Defined in [api/types.ts:2375](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2375)*
 
 ___
 <a id="startingcondition"></a>
@@ -35,7 +35,7 @@ ___
 
 **● StartingCondition**: *[PTZPresetTourStartingConditionOptions](_api_types_.ptzpresettourstartingconditionoptions.md)*
 
-*Defined in [api/types.ts:2376](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2376)*
+*Defined in [api/types.ts:2376](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2376)*
 
 ___
 <a id="tourspot"></a>
@@ -44,7 +44,7 @@ ___
 
 **● TourSpot**: *[PTZPresetTourSpotOptions](_api_types_.ptzpresettourspotoptions.md)*
 
-*Defined in [api/types.ts:2377](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2377)*
+*Defined in [api/types.ts:2377](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2377)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettourpresetdetail.md
+++ b/docs/interfaces/_api_types_.ptzpresettourpresetdetail.md
@@ -27,7 +27,7 @@ Option to specify the preset position with Preset Token defined in advance.
 
 **● Home**: *`boolean`*
 
-*Defined in [api/types.ts:2329](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2329)*
+*Defined in [api/types.ts:2329](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2329)*
 
 ___
 <a id="ptzposition"></a>
@@ -36,7 +36,7 @@ ___
 
 **● PTZPosition**: *[PTZVector](_api_types_.ptzvector.md)*
 
-*Defined in [api/types.ts:2330](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2330)*
+*Defined in [api/types.ts:2330](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2330)*
 
 ___
 <a id="presettoken"></a>
@@ -45,7 +45,7 @@ ___
 
 **● PresetToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:2328](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2328)*
+*Defined in [api/types.ts:2328](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2328)*
 
 ___
 <a id="typeextension"></a>
@@ -54,7 +54,7 @@ ___
 
 **● TypeExtension**: *[PTZPresetTourTypeExtension](_api_types_.ptzpresettourtypeextension.md)*
 
-*Defined in [api/types.ts:2331](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2331)*
+*Defined in [api/types.ts:2331](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2331)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettourpresetdetailoptions.md
+++ b/docs/interfaces/_api_types_.ptzpresettourpresetdetailoptions.md
@@ -28,7 +28,7 @@ A list of available Preset Tokens for tour spots.
 
 **● Extension**: *[PTZPresetTourPresetDetailOptionsExtension](_api_types_.ptzpresettourpresetdetailoptionsextension.md)*
 
-*Defined in [api/types.ts:2396](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2396)*
+*Defined in [api/types.ts:2396](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2396)*
 
 ___
 <a id="home"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Home**: *`boolean`*
 
-*Defined in [api/types.ts:2393](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2393)*
+*Defined in [api/types.ts:2393](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2393)*
 
 ___
 <a id="pantiltpositionspace"></a>
@@ -46,7 +46,7 @@ ___
 
 **● PanTiltPositionSpace**: *[Space2DDescription](_api_types_.space2ddescription.md)*
 
-*Defined in [api/types.ts:2394](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2394)*
+*Defined in [api/types.ts:2394](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2394)*
 
 ___
 <a id="presettoken"></a>
@@ -55,7 +55,7 @@ ___
 
 **● PresetToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:2392](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2392)*
+*Defined in [api/types.ts:2392](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2392)*
 
 ___
 <a id="zoompositionspace"></a>
@@ -64,7 +64,7 @@ ___
 
 **● ZoomPositionSpace**: *[Space1DDescription](_api_types_.space1ddescription.md)*
 
-*Defined in [api/types.ts:2395](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2395)*
+*Defined in [api/types.ts:2395](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2395)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettourspot.md
+++ b/docs/interfaces/_api_types_.ptzpresettourspot.md
@@ -27,7 +27,7 @@ Detail definition of preset position of the tour spot.
 
 **● Extension**: *[PTZPresetTourSpotExtension](_api_types_.ptzpresettourspotextension.md)*
 
-*Defined in [api/types.ts:2315](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2315)*
+*Defined in [api/types.ts:2315](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2315)*
 
 ___
 <a id="presetdetail"></a>
@@ -36,7 +36,7 @@ ___
 
 **● PresetDetail**: *[PTZPresetTourPresetDetail](_api_types_.ptzpresettourpresetdetail.md)*
 
-*Defined in [api/types.ts:2312](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2312)*
+*Defined in [api/types.ts:2312](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2312)*
 
 ___
 <a id="speed"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Speed**: *[PTZSpeed](_api_types_.ptzspeed.md)*
 
-*Defined in [api/types.ts:2313](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2313)*
+*Defined in [api/types.ts:2313](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2313)*
 
 ___
 <a id="staytime"></a>
@@ -54,7 +54,7 @@ ___
 
 **● StayTime**: *`string`*
 
-*Defined in [api/types.ts:2314](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2314)*
+*Defined in [api/types.ts:2314](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2314)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettourspotoptions.md
+++ b/docs/interfaces/_api_types_.ptzpresettourspotoptions.md
@@ -25,7 +25,7 @@ Supported options for detail definition of preset position of the tour spot.
 
 **● PresetDetail**: *[PTZPresetTourPresetDetailOptions](_api_types_.ptzpresettourpresetdetailoptions.md)*
 
-*Defined in [api/types.ts:2384](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2384)*
+*Defined in [api/types.ts:2384](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2384)*
 
 ___
 <a id="staytime"></a>
@@ -34,7 +34,7 @@ ___
 
 **● StayTime**: *[DurationRange](_api_types_.durationrange.md)*
 
-*Defined in [api/types.ts:2385](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2385)*
+*Defined in [api/types.ts:2385](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2385)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettourstartingcondition.md
+++ b/docs/interfaces/_api_types_.ptzpresettourstartingcondition.md
@@ -27,7 +27,7 @@ Optional parameter to specify how many times the preset tour is recurred.
 
 **● Direction**: *[PTZPresetTourDirection](../enums/_api_types_.ptzpresettourdirection.md)*
 
-*Defined in [api/types.ts:2361](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2361)*
+*Defined in [api/types.ts:2361](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2361)*
 
 ___
 <a id="extension"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Extension**: *[PTZPresetTourStartingConditionExtension](_api_types_.ptzpresettourstartingconditionextension.md)*
 
-*Defined in [api/types.ts:2362](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2362)*
+*Defined in [api/types.ts:2362](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2362)*
 
 ___
 <a id="recurringduration"></a>
@@ -45,7 +45,7 @@ ___
 
 **● RecurringDuration**: *`string`*
 
-*Defined in [api/types.ts:2360](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2360)*
+*Defined in [api/types.ts:2360](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2360)*
 
 ___
 <a id="recurringtime"></a>
@@ -54,7 +54,7 @@ ___
 
 **● RecurringTime**: *`number`*
 
-*Defined in [api/types.ts:2359](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2359)*
+*Defined in [api/types.ts:2359](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2359)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettourstartingconditionoptions.md
+++ b/docs/interfaces/_api_types_.ptzpresettourstartingconditionoptions.md
@@ -27,7 +27,7 @@ Supported range of Recurring Time.
 
 **● Direction**: *[PTZPresetTourDirection](../enums/_api_types_.ptzpresettourdirection.md)*
 
-*Defined in [api/types.ts:2411](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2411)*
+*Defined in [api/types.ts:2411](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2411)*
 
 ___
 <a id="extension"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Extension**: *[PTZPresetTourStartingConditionOptionsExtension](_api_types_.ptzpresettourstartingconditionoptionsextension.md)*
 
-*Defined in [api/types.ts:2412](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2412)*
+*Defined in [api/types.ts:2412](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2412)*
 
 ___
 <a id="recurringduration"></a>
@@ -45,7 +45,7 @@ ___
 
 **● RecurringDuration**: *[DurationRange](_api_types_.durationrange.md)*
 
-*Defined in [api/types.ts:2410](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2410)*
+*Defined in [api/types.ts:2410](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2410)*
 
 ___
 <a id="recurringtime"></a>
@@ -54,7 +54,7 @@ ___
 
 **● RecurringTime**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:2409](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2409)*
+*Defined in [api/types.ts:2409](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2409)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettourstatus.md
+++ b/docs/interfaces/_api_types_.ptzpresettourstatus.md
@@ -26,7 +26,7 @@ Indicates state of this preset tour by Idle/Touring/Paused.
 
 **● CurrentTourSpot**: *[PTZPresetTourSpot](_api_types_.ptzpresettourspot.md)*
 
-*Defined in [api/types.ts:2345](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2345)*
+*Defined in [api/types.ts:2345](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2345)*
 
 ___
 <a id="extension"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Extension**: *[PTZPresetTourStatusExtension](_api_types_.ptzpresettourstatusextension.md)*
 
-*Defined in [api/types.ts:2346](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2346)*
+*Defined in [api/types.ts:2346](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2346)*
 
 ___
 <a id="state"></a>
@@ -44,7 +44,7 @@ ___
 
 **● State**: *[PTZPresetTourState](../enums/_api_types_.ptzpresettourstate.md)*
 
-*Defined in [api/types.ts:2344](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2344)*
+*Defined in [api/types.ts:2344](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2344)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzpresettoursupported.md
+++ b/docs/interfaces/_api_types_.ptzpresettoursupported.md
@@ -26,7 +26,7 @@ Indicates number of preset tours that can be created. Required preset tour opera
 
 **● Extension**: *[PTZPresetTourSupportedExtension](_api_types_.ptzpresettoursupportedextension.md)*
 
-*Defined in [api/types.ts:2076](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2076)*
+*Defined in [api/types.ts:2076](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2076)*
 
 ___
 <a id="maximumnumberofpresettours"></a>
@@ -35,7 +35,7 @@ ___
 
 **● MaximumNumberOfPresetTours**: *`number`*
 
-*Defined in [api/types.ts:2074](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2074)*
+*Defined in [api/types.ts:2074](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2074)*
 
 ___
 <a id="ptzpresettouroperation"></a>
@@ -44,7 +44,7 @@ ___
 
 **● PTZPresetTourOperation**: *[PTZPresetTourOperation](../enums/_api_types_.ptzpresettouroperation.md)*
 
-*Defined in [api/types.ts:2075](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2075)*
+*Defined in [api/types.ts:2075](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2075)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzspaces.md
+++ b/docs/interfaces/_api_types_.ptzspaces.md
@@ -35,7 +35,7 @@
 
 **● AbsolutePanTiltPositionSpace**: *[Space2DDescription](_api_types_.space2ddescription.md)*
 
-*Defined in [api/types.ts:2234](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2234)*
+*Defined in [api/types.ts:2234](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2234)*
 
 ___
 <a id="absolutezoompositionspace"></a>
@@ -44,7 +44,7 @@ ___
 
 **● AbsoluteZoomPositionSpace**: *[Space1DDescription](_api_types_.space1ddescription.md)*
 
-*Defined in [api/types.ts:2235](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2235)*
+*Defined in [api/types.ts:2235](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2235)*
 
 ___
 <a id="continuouspantiltvelocityspace"></a>
@@ -53,7 +53,7 @@ ___
 
 **● ContinuousPanTiltVelocitySpace**: *[Space2DDescription](_api_types_.space2ddescription.md)*
 
-*Defined in [api/types.ts:2238](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2238)*
+*Defined in [api/types.ts:2238](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2238)*
 
 ___
 <a id="continuouszoomvelocityspace"></a>
@@ -62,7 +62,7 @@ ___
 
 **● ContinuousZoomVelocitySpace**: *[Space1DDescription](_api_types_.space1ddescription.md)*
 
-*Defined in [api/types.ts:2239](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2239)*
+*Defined in [api/types.ts:2239](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2239)*
 
 ___
 <a id="extension"></a>
@@ -71,7 +71,7 @@ ___
 
 **● Extension**: *[PTZSpacesExtension](_api_types_.ptzspacesextension.md)*
 
-*Defined in [api/types.ts:2242](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2242)*
+*Defined in [api/types.ts:2242](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2242)*
 
 ___
 <a id="pantiltspeedspace"></a>
@@ -80,7 +80,7 @@ ___
 
 **● PanTiltSpeedSpace**: *[Space1DDescription](_api_types_.space1ddescription.md)*
 
-*Defined in [api/types.ts:2240](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2240)*
+*Defined in [api/types.ts:2240](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2240)*
 
 ___
 <a id="relativepantilttranslationspace"></a>
@@ -89,7 +89,7 @@ ___
 
 **● RelativePanTiltTranslationSpace**: *[Space2DDescription](_api_types_.space2ddescription.md)*
 
-*Defined in [api/types.ts:2236](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2236)*
+*Defined in [api/types.ts:2236](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2236)*
 
 ___
 <a id="relativezoomtranslationspace"></a>
@@ -98,7 +98,7 @@ ___
 
 **● RelativeZoomTranslationSpace**: *[Space1DDescription](_api_types_.space1ddescription.md)*
 
-*Defined in [api/types.ts:2237](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2237)*
+*Defined in [api/types.ts:2237](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2237)*
 
 ___
 <a id="zoomspeedspace"></a>
@@ -107,7 +107,7 @@ ___
 
 **● ZoomSpeedSpace**: *[Space1DDescription](_api_types_.space1ddescription.md)*
 
-*Defined in [api/types.ts:2241](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2241)*
+*Defined in [api/types.ts:2241](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2241)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzspeed.md
+++ b/docs/interfaces/_api_types_.ptzspeed.md
@@ -25,7 +25,7 @@ Pan and tilt speed. The x component corresponds to pan and the y component to ti
 
 **● PanTilt**: *[Vector2D](_api_types_.vector2d.md)*
 
-*Defined in [api/types.ts:2276](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2276)*
+*Defined in [api/types.ts:2276](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2276)*
 
 ___
 <a id="zoom"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Zoom**: *[Vector1D](_api_types_.vector1d.md)*
 
-*Defined in [api/types.ts:2277](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2277)*
+*Defined in [api/types.ts:2277](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2277)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzstatus.md
+++ b/docs/interfaces/_api_types_.ptzstatus.md
@@ -29,7 +29,7 @@
 
 **● Error**: *`string`*
 
-*Defined in [api/types.ts:163](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L163)*
+*Defined in [api/types.ts:163](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L163)*
 
 ___
 <a id="movestatus"></a>
@@ -38,7 +38,7 @@ ___
 
 **● MoveStatus**: *[PTZMoveStatus](_api_types_.ptzmovestatus.md)*
 
-*Defined in [api/types.ts:162](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L162)*
+*Defined in [api/types.ts:162](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L162)*
 
 ___
 <a id="position"></a>
@@ -47,7 +47,7 @@ ___
 
 **● Position**: *[PTZVector](_api_types_.ptzvector.md)*
 
-*Defined in [api/types.ts:161](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L161)*
+*Defined in [api/types.ts:161](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L161)*
 
 ___
 <a id="utctime"></a>
@@ -56,7 +56,7 @@ ___
 
 **● UtcTime**: *`string`*
 
-*Defined in [api/types.ts:164](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L164)*
+*Defined in [api/types.ts:164](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L164)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzstatusfilteroptions.md
+++ b/docs/interfaces/_api_types_.ptzstatusfilteroptions.md
@@ -28,7 +28,7 @@ True if the device is able to stream pan or tilt status information.
 
 **● Extension**: *[PTZStatusFilterOptionsExtension](_api_types_.ptzstatusfilteroptionsextension.md)*
 
-*Defined in [api/types.ts:825](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L825)*
+*Defined in [api/types.ts:825](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L825)*
 
 ___
 <a id="pantiltpositionsupported"></a>
@@ -37,7 +37,7 @@ ___
 
 **● PanTiltPositionSupported**: *`boolean`*
 
-*Defined in [api/types.ts:823](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L823)*
+*Defined in [api/types.ts:823](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L823)*
 
 ___
 <a id="pantiltstatussupported"></a>
@@ -46,7 +46,7 @@ ___
 
 **● PanTiltStatusSupported**: *`boolean`*
 
-*Defined in [api/types.ts:821](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L821)*
+*Defined in [api/types.ts:821](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L821)*
 
 ___
 <a id="zoompositionsupported"></a>
@@ -55,7 +55,7 @@ ___
 
 **● ZoomPositionSupported**: *`boolean`*
 
-*Defined in [api/types.ts:824](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L824)*
+*Defined in [api/types.ts:824](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L824)*
 
 ___
 <a id="zoomstatussupported"></a>
@@ -64,7 +64,7 @@ ___
 
 **● ZoomStatusSupported**: *`boolean`*
 
-*Defined in [api/types.ts:822](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L822)*
+*Defined in [api/types.ts:822](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L822)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ptzvector.md
+++ b/docs/interfaces/_api_types_.ptzvector.md
@@ -25,7 +25,7 @@ Pan and tilt position. The x component corresponds to pan and the y component to
 
 **● PanTilt**: *[Vector2D](_api_types_.vector2d.md)*
 
-*Defined in [api/types.ts:151](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L151)*
+*Defined in [api/types.ts:151](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L151)*
 
 ___
 <a id="zoom"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Zoom**: *[Vector1D](_api_types_.vector1d.md)*
 
-*Defined in [api/types.ts:152](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L152)*
+*Defined in [api/types.ts:152](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L152)*
 
 ___
 

--- a/docs/interfaces/_api_types_.realtimestreamingcapabilities.md
+++ b/docs/interfaces/_api_types_.realtimestreamingcapabilities.md
@@ -27,7 +27,7 @@ Indicates whether or not RTP multicast is supported.
 
 **● Extension**: *[RealTimeStreamingCapabilitiesExtension](_api_types_.realtimestreamingcapabilitiesextension.md)*
 
-*Defined in [api/types.ts:1551](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1551)*
+*Defined in [api/types.ts:1551](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1551)*
 
 ___
 <a id="rtpmulticast"></a>
@@ -36,7 +36,7 @@ ___
 
 **● RTPMulticast**: *`boolean`*
 
-*Defined in [api/types.ts:1548](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1548)*
+*Defined in [api/types.ts:1548](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1548)*
 
 ___
 <a id="rtp_rtsp_tcp"></a>
@@ -45,7 +45,7 @@ ___
 
 **● RTP_RTSP_TCP**: *`boolean`*
 
-*Defined in [api/types.ts:1550](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1550)*
+*Defined in [api/types.ts:1550](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1550)*
 
 ___
 <a id="rtp_tcp"></a>
@@ -54,7 +54,7 @@ ___
 
 **● RTP_TCP**: *`boolean`*
 
-*Defined in [api/types.ts:1549](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1549)*
+*Defined in [api/types.ts:1549](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1549)*
 
 ___
 

--- a/docs/interfaces/_api_types_.receiver.md
+++ b/docs/interfaces/_api_types_.receiver.md
@@ -27,7 +27,7 @@
 
 **● Configuration**: *[ReceiverConfiguration](_api_types_.receiverconfiguration.md)*
 
-*Defined in [api/types.ts:3393](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3393)*
+*Defined in [api/types.ts:3393](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3393)*
 
 ___
 <a id="token"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Token**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3392](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3392)*
+*Defined in [api/types.ts:3392](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3392)*
 
 ___
 

--- a/docs/interfaces/_api_types_.receivercapabilities.md
+++ b/docs/interfaces/_api_types_.receivercapabilities.md
@@ -29,7 +29,7 @@ The address of the receiver service.
 
 **● MaximumRTSPURILength**: *`number`*
 
-*Defined in [api/types.ts:1733](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1733)*
+*Defined in [api/types.ts:1733](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1733)*
 
 ___
 <a id="rtp_multicast"></a>
@@ -38,7 +38,7 @@ ___
 
 **● RTP_Multicast**: *`boolean`*
 
-*Defined in [api/types.ts:1729](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1729)*
+*Defined in [api/types.ts:1729](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1729)*
 
 ___
 <a id="rtp_rtsp_tcp"></a>
@@ -47,7 +47,7 @@ ___
 
 **● RTP_RTSP_TCP**: *`boolean`*
 
-*Defined in [api/types.ts:1731](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1731)*
+*Defined in [api/types.ts:1731](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1731)*
 
 ___
 <a id="rtp_tcp"></a>
@@ -56,7 +56,7 @@ ___
 
 **● RTP_TCP**: *`boolean`*
 
-*Defined in [api/types.ts:1730](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1730)*
+*Defined in [api/types.ts:1730](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1730)*
 
 ___
 <a id="supportedreceivers"></a>
@@ -65,7 +65,7 @@ ___
 
 **● SupportedReceivers**: *`number`*
 
-*Defined in [api/types.ts:1732](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1732)*
+*Defined in [api/types.ts:1732](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1732)*
 
 ___
 <a id="xaddr"></a>
@@ -74,7 +74,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1728](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1728)*
+*Defined in [api/types.ts:1728](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1728)*
 
 ___
 

--- a/docs/interfaces/_api_types_.receiverconfiguration.md
+++ b/docs/interfaces/_api_types_.receiverconfiguration.md
@@ -28,7 +28,7 @@
 
 **● MediaUri**: *`string`*
 
-*Defined in [api/types.ts:3403](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3403)*
+*Defined in [api/types.ts:3403](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3403)*
 
 ___
 <a id="mode"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Mode**: *[ReceiverMode](../enums/_api_types_.receivermode.md)*
 
-*Defined in [api/types.ts:3402](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3402)*
+*Defined in [api/types.ts:3402](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3402)*
 
 ___
 <a id="streamsetup"></a>
@@ -46,7 +46,7 @@ ___
 
 **● StreamSetup**: *[StreamSetup](_api_types_.streamsetup.md)*
 
-*Defined in [api/types.ts:3404](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3404)*
+*Defined in [api/types.ts:3404](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3404)*
 
 ___
 

--- a/docs/interfaces/_api_types_.receiverstateinformation.md
+++ b/docs/interfaces/_api_types_.receiverstateinformation.md
@@ -27,7 +27,7 @@
 
 **● AutoCreated**: *`boolean`*
 
-*Defined in [api/types.ts:3414](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3414)*
+*Defined in [api/types.ts:3414](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3414)*
 
 ___
 <a id="state"></a>
@@ -36,7 +36,7 @@ ___
 
 **● State**: *[ReceiverState](../enums/_api_types_.receiverstate.md)*
 
-*Defined in [api/types.ts:3413](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3413)*
+*Defined in [api/types.ts:3413](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3413)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingcapabilities.md
+++ b/docs/interfaces/_api_types_.recordingcapabilities.md
@@ -27,7 +27,7 @@
 
 **● DynamicRecordings**: *`boolean`*
 
-*Defined in [api/types.ts:1704](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1704)*
+*Defined in [api/types.ts:1704](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1704)*
 
 ___
 <a id="dynamictracks"></a>
@@ -36,7 +36,7 @@ ___
 
 **● DynamicTracks**: *`boolean`*
 
-*Defined in [api/types.ts:1705](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1705)*
+*Defined in [api/types.ts:1705](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1705)*
 
 ___
 <a id="maxstringlength"></a>
@@ -45,7 +45,7 @@ ___
 
 **● MaxStringLength**: *`number`*
 
-*Defined in [api/types.ts:1706](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1706)*
+*Defined in [api/types.ts:1706](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1706)*
 
 ___
 <a id="mediaprofilesource"></a>
@@ -54,7 +54,7 @@ ___
 
 **● MediaProfileSource**: *`boolean`*
 
-*Defined in [api/types.ts:1703](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1703)*
+*Defined in [api/types.ts:1703](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1703)*
 
 ___
 <a id="receiversource"></a>
@@ -63,7 +63,7 @@ ___
 
 **● ReceiverSource**: *`boolean`*
 
-*Defined in [api/types.ts:1702](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1702)*
+*Defined in [api/types.ts:1702](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1702)*
 
 ___
 <a id="xaddr"></a>
@@ -72,7 +72,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1701](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1701)*
+*Defined in [api/types.ts:1701](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1701)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingconfiguration.md
+++ b/docs/interfaces/_api_types_.recordingconfiguration.md
@@ -26,7 +26,7 @@ Information about the source of the recording.
 
 **● Content**: *[Description](../modules/_api_types_.md#description)*
 
-*Defined in [api/types.ts:3644](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3644)*
+*Defined in [api/types.ts:3644](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3644)*
 
 ___
 <a id="maximumretentiontime"></a>
@@ -35,7 +35,7 @@ ___
 
 **● MaximumRetentionTime**: *`string`*
 
-*Defined in [api/types.ts:3645](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3645)*
+*Defined in [api/types.ts:3645](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3645)*
 
 ___
 <a id="source"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Source**: *[RecordingSourceInformation](_api_types_.recordingsourceinformation.md)*
 
-*Defined in [api/types.ts:3643](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3643)*
+*Defined in [api/types.ts:3643](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3643)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordinginformation.md
+++ b/docs/interfaces/_api_types_.recordinginformation.md
@@ -34,7 +34,7 @@
 
 **● Content**: *[Description](../modules/_api_types_.md#description)*
 
-*Defined in [api/types.ts:3553](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3553)*
+*Defined in [api/types.ts:3553](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3553)*
 
 ___
 <a id="earliestrecording"></a>
@@ -43,7 +43,7 @@ ___
 
 **● EarliestRecording**: *`string`*
 
-*Defined in [api/types.ts:3551](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3551)*
+*Defined in [api/types.ts:3551](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3551)*
 
 ___
 <a id="latestrecording"></a>
@@ -52,7 +52,7 @@ ___
 
 **● LatestRecording**: *`string`*
 
-*Defined in [api/types.ts:3552](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3552)*
+*Defined in [api/types.ts:3552](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3552)*
 
 ___
 <a id="recordingstatus"></a>
@@ -61,7 +61,7 @@ ___
 
 **● RecordingStatus**: *[RecordingStatus](../enums/_api_types_.recordingstatus.md)*
 
-*Defined in [api/types.ts:3555](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3555)*
+*Defined in [api/types.ts:3555](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3555)*
 
 ___
 <a id="recordingtoken"></a>
@@ -70,7 +70,7 @@ ___
 
 **● RecordingToken**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3549](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3549)*
+*Defined in [api/types.ts:3549](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3549)*
 
 ___
 <a id="source"></a>
@@ -79,7 +79,7 @@ ___
 
 **● Source**: *[RecordingSourceInformation](_api_types_.recordingsourceinformation.md)*
 
-*Defined in [api/types.ts:3550](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3550)*
+*Defined in [api/types.ts:3550](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3550)*
 
 ___
 <a id="track"></a>
@@ -88,7 +88,7 @@ ___
 
 **● Track**: *[TrackInformation](_api_types_.trackinformation.md)*
 
-*Defined in [api/types.ts:3554](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3554)*
+*Defined in [api/types.ts:3554](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3554)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingjobconfiguration.md
+++ b/docs/interfaces/_api_types_.recordingjobconfiguration.md
@@ -28,7 +28,7 @@ Identifies the recording to which this job shall store the received data.
 
 **● Extension**: *[RecordingJobConfigurationExtension](_api_types_.recordingjobconfigurationextension.md)*
 
-*Defined in [api/types.ts:3689](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3689)*
+*Defined in [api/types.ts:3689](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3689)*
 
 ___
 <a id="mode"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Mode**: *[RecordingJobMode](../modules/_api_types_.md#recordingjobmode)*
 
-*Defined in [api/types.ts:3686](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3686)*
+*Defined in [api/types.ts:3686](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3686)*
 
 ___
 <a id="priority"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Priority**: *`number`*
 
-*Defined in [api/types.ts:3687](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3687)*
+*Defined in [api/types.ts:3687](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3687)*
 
 ___
 <a id="recordingtoken"></a>
@@ -55,7 +55,7 @@ ___
 
 **● RecordingToken**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3685](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3685)*
+*Defined in [api/types.ts:3685](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3685)*
 
 ___
 <a id="source"></a>
@@ -64,7 +64,7 @@ ___
 
 **● Source**: *[RecordingJobSource](_api_types_.recordingjobsource.md)*
 
-*Defined in [api/types.ts:3688](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3688)*
+*Defined in [api/types.ts:3688](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3688)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingjobsource.md
+++ b/docs/interfaces/_api_types_.recordingjobsource.md
@@ -27,7 +27,7 @@ This field shall be a reference to the source of the data. The type of the sourc
 
 **● AutoCreateReceiver**: *`boolean`*
 
-*Defined in [api/types.ts:3708](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3708)*
+*Defined in [api/types.ts:3708](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3708)*
 
 ___
 <a id="extension"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Extension**: *[RecordingJobSourceExtension](_api_types_.recordingjobsourceextension.md)*
 
-*Defined in [api/types.ts:3710](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3710)*
+*Defined in [api/types.ts:3710](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3710)*
 
 ___
 <a id="sourcetoken"></a>
@@ -45,7 +45,7 @@ ___
 
 **● SourceToken**: *[SourceReference](_api_types_.sourcereference.md)*
 
-*Defined in [api/types.ts:3707](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3707)*
+*Defined in [api/types.ts:3707](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3707)*
 
 ___
 <a id="tracks"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Tracks**: *[RecordingJobTrack](_api_types_.recordingjobtrack.md)*
 
-*Defined in [api/types.ts:3709](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3709)*
+*Defined in [api/types.ts:3709](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3709)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingjobstateinformation.md
+++ b/docs/interfaces/_api_types_.recordingjobstateinformation.md
@@ -27,7 +27,7 @@ Identification of the recording that the recording job records to.
 
 **● Extension**: *[RecordingJobStateInformationExtension](_api_types_.recordingjobstateinformationextension.md)*
 
-*Defined in [api/types.ts:3735](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3735)*
+*Defined in [api/types.ts:3735](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3735)*
 
 ___
 <a id="recordingtoken"></a>
@@ -36,7 +36,7 @@ ___
 
 **● RecordingToken**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3732](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3732)*
+*Defined in [api/types.ts:3732](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3732)*
 
 ___
 <a id="sources"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Sources**: *[RecordingJobStateSource](_api_types_.recordingjobstatesource.md)*
 
-*Defined in [api/types.ts:3734](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3734)*
+*Defined in [api/types.ts:3734](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3734)*
 
 ___
 <a id="state"></a>
@@ -54,7 +54,7 @@ ___
 
 **● State**: *[RecordingJobState](../modules/_api_types_.md#recordingjobstate)*
 
-*Defined in [api/types.ts:3733](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3733)*
+*Defined in [api/types.ts:3733](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3733)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingjobstatesource.md
+++ b/docs/interfaces/_api_types_.recordingjobstatesource.md
@@ -26,7 +26,7 @@ Identifies the data source of the recording job.
 
 **● SourceToken**: *[SourceReference](_api_types_.sourcereference.md)*
 
-*Defined in [api/types.ts:3748](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3748)*
+*Defined in [api/types.ts:3748](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3748)*
 
 ___
 <a id="state"></a>
@@ -35,7 +35,7 @@ ___
 
 **● State**: *[RecordingJobState](../modules/_api_types_.md#recordingjobstate)*
 
-*Defined in [api/types.ts:3749](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3749)*
+*Defined in [api/types.ts:3749](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3749)*
 
 ___
 <a id="tracks"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Tracks**: *[RecordingJobStateTracks](_api_types_.recordingjobstatetracks.md)*
 
-*Defined in [api/types.ts:3750](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3750)*
+*Defined in [api/types.ts:3750](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3750)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingjobstatetrack.md
+++ b/docs/interfaces/_api_types_.recordingjobstatetrack.md
@@ -27,7 +27,7 @@ Identifies the track of the data source that provides the data.
 
 **● Destination**: *[TrackReference](../modules/_api_types_.md#trackreference)*
 
-*Defined in [api/types.ts:3765](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3765)*
+*Defined in [api/types.ts:3765](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3765)*
 
 ___
 <a id="error"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Error**: *`string`*
 
-*Defined in [api/types.ts:3766](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3766)*
+*Defined in [api/types.ts:3766](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3766)*
 
 ___
 <a id="sourcetag"></a>
@@ -45,7 +45,7 @@ ___
 
 **● SourceTag**: *`string`*
 
-*Defined in [api/types.ts:3764](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3764)*
+*Defined in [api/types.ts:3764](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3764)*
 
 ___
 <a id="state"></a>
@@ -54,7 +54,7 @@ ___
 
 **● State**: *[RecordingJobState](../modules/_api_types_.md#recordingjobstate)*
 
-*Defined in [api/types.ts:3767](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3767)*
+*Defined in [api/types.ts:3767](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3767)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingjobstatetracks.md
+++ b/docs/interfaces/_api_types_.recordingjobstatetracks.md
@@ -22,7 +22,7 @@
 
 **● Track**: *[RecordingJobStateTrack](_api_types_.recordingjobstatetrack.md)*
 
-*Defined in [api/types.ts:3757](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3757)*
+*Defined in [api/types.ts:3757](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3757)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingjobtrack.md
+++ b/docs/interfaces/_api_types_.recordingjobtrack.md
@@ -25,7 +25,7 @@ If the received RTSP stream contains multiple tracks of the same type, the Sourc
 
 **● Destination**: *[TrackReference](../modules/_api_types_.md#trackreference)*
 
-*Defined in [api/types.ts:3725](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3725)*
+*Defined in [api/types.ts:3725](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3725)*
 
 ___
 <a id="sourcetag"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SourceTag**: *`string`*
 
-*Defined in [api/types.ts:3724](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3724)*
+*Defined in [api/types.ts:3724](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3724)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingsourceinformation.md
+++ b/docs/interfaces/_api_types_.recordingsourceinformation.md
@@ -30,7 +30,7 @@
 
 **● Address**: *`string`*
 
-*Defined in [api/types.ts:3568](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3568)*
+*Defined in [api/types.ts:3568](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3568)*
 
 ___
 <a id="description"></a>
@@ -39,7 +39,7 @@ ___
 
 **● Description**: *[Description](_api_types_.recordingsourceinformation.md#description)*
 
-*Defined in [api/types.ts:3567](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3567)*
+*Defined in [api/types.ts:3567](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3567)*
 
 ___
 <a id="location"></a>
@@ -48,7 +48,7 @@ ___
 
 **● Location**: *[Description](_api_types_.recordingsourceinformation.md#description)*
 
-*Defined in [api/types.ts:3566](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3566)*
+*Defined in [api/types.ts:3566](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3566)*
 
 ___
 <a id="name"></a>
@@ -57,7 +57,7 @@ ___
 
 **● Name**: *[Name](_api_types_.recordingsourceinformation.md#name)*
 
-*Defined in [api/types.ts:3565](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3565)*
+*Defined in [api/types.ts:3565](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3565)*
 
 ___
 <a id="sourceid"></a>
@@ -66,7 +66,7 @@ ___
 
 **● SourceId**: *`string`*
 
-*Defined in [api/types.ts:3564](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3564)*
+*Defined in [api/types.ts:3564](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3564)*
 
 ___
 

--- a/docs/interfaces/_api_types_.recordingsummary.md
+++ b/docs/interfaces/_api_types_.recordingsummary.md
@@ -26,7 +26,7 @@ The earliest point in time where there is recorded data on the device.
 
 **● DataFrom**: *`string`*
 
-*Defined in [api/types.ts:3436](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3436)*
+*Defined in [api/types.ts:3436](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3436)*
 
 ___
 <a id="datauntil"></a>
@@ -35,7 +35,7 @@ ___
 
 **● DataUntil**: *`string`*
 
-*Defined in [api/types.ts:3437](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3437)*
+*Defined in [api/types.ts:3437](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3437)*
 
 ___
 <a id="numberrecordings"></a>
@@ -44,7 +44,7 @@ ___
 
 **● NumberRecordings**: *`number`*
 
-*Defined in [api/types.ts:3438](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3438)*
+*Defined in [api/types.ts:3438](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3438)*
 
 ___
 

--- a/docs/interfaces/_api_types_.relativefocus.md
+++ b/docs/interfaces/_api_types_.relativefocus.md
@@ -27,7 +27,7 @@
 
 **● Distance**: *`number`*
 
-*Defined in [api/types.ts:2609](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2609)*
+*Defined in [api/types.ts:2609](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2609)*
 
 ___
 <a id="speed"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Speed**: *`number`*
 
-*Defined in [api/types.ts:2610](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2610)*
+*Defined in [api/types.ts:2610](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2610)*
 
 ___
 

--- a/docs/interfaces/_api_types_.relativefocusoptions.md
+++ b/docs/interfaces/_api_types_.relativefocusoptions.md
@@ -27,7 +27,7 @@
 
 **● Distance**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2647](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2647)*
+*Defined in [api/types.ts:2647](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2647)*
 
 ___
 <a id="speed"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Speed**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2648](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2648)*
+*Defined in [api/types.ts:2648](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2648)*
 
 ___
 

--- a/docs/interfaces/_api_types_.relativefocusoptions20.md
+++ b/docs/interfaces/_api_types_.relativefocusoptions20.md
@@ -27,7 +27,7 @@
 
 **● Distance**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2994](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2994)*
+*Defined in [api/types.ts:2994](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2994)*
 
 ___
 <a id="speed"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Speed**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2995](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2995)*
+*Defined in [api/types.ts:2995](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2995)*
 
 ___
 

--- a/docs/interfaces/_api_types_.relayoutput.md
+++ b/docs/interfaces/_api_types_.relayoutput.md
@@ -22,7 +22,7 @@
 
 **● Properties**: *[RelayOutputSettings](_api_types_.relayoutputsettings.md)*
 
-*Defined in [api/types.ts:2029](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2029)*
+*Defined in [api/types.ts:2029](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2029)*
 
 ___
 

--- a/docs/interfaces/_api_types_.relayoutputsettings.md
+++ b/docs/interfaces/_api_types_.relayoutputsettings.md
@@ -33,7 +33,7 @@
 
 **● DelayTime**: *`string`*
 
-*Defined in [api/types.ts:2021](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2021)*
+*Defined in [api/types.ts:2021](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2021)*
 
 ___
 <a id="idlestate"></a>
@@ -42,7 +42,7 @@ ___
 
 **● IdleState**: *[RelayIdleState](../enums/_api_types_.relayidlestate.md)*
 
-*Defined in [api/types.ts:2022](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2022)*
+*Defined in [api/types.ts:2022](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2022)*
 
 ___
 <a id="mode"></a>
@@ -51,7 +51,7 @@ ___
 
 **● Mode**: *[RelayMode](../enums/_api_types_.relaymode.md)*
 
-*Defined in [api/types.ts:2020](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2020)*
+*Defined in [api/types.ts:2020](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2020)*
 
 ___
 

--- a/docs/interfaces/_api_types_.remoteuser.md
+++ b/docs/interfaces/_api_types_.remoteuser.md
@@ -24,7 +24,7 @@
 
 **● Password**: *`string`*
 
-*Defined in [api/types.ts:1870](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1870)*
+*Defined in [api/types.ts:1870](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1870)*
 
 ___
 <a id="usederivedpassword"></a>
@@ -33,7 +33,7 @@ ___
 
 **● UseDerivedPassword**: *`boolean`*
 
-*Defined in [api/types.ts:1871](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1871)*
+*Defined in [api/types.ts:1871](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1871)*
 
 ___
 <a id="username"></a>
@@ -42,7 +42,7 @@ ___
 
 **● Username**: *`string`*
 
-*Defined in [api/types.ts:1869](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1869)*
+*Defined in [api/types.ts:1869](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1869)*
 
 ___
 

--- a/docs/interfaces/_api_types_.replaycapabilities.md
+++ b/docs/interfaces/_api_types_.replaycapabilities.md
@@ -24,7 +24,7 @@ The address of the replay service.
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1721](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1721)*
+*Defined in [api/types.ts:1721](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1721)*
 
 ___
 

--- a/docs/interfaces/_api_types_.replayconfiguration.md
+++ b/docs/interfaces/_api_types_.replayconfiguration.md
@@ -26,7 +26,7 @@
 
 **● SessionTimeout**: *`string`*
 
-*Defined in [api/types.ts:3784](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3784)*
+*Defined in [api/types.ts:3784](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3784)*
 
 ___
 

--- a/docs/interfaces/_api_types_.reverse.md
+++ b/docs/interfaces/_api_types_.reverse.md
@@ -24,7 +24,7 @@ Parameter to enable/disable Reverse feature.
 
 **● Mode**: *[ReverseMode](../enums/_api_types_.reversemode.md)*
 
-*Defined in [api/types.ts:2145](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2145)*
+*Defined in [api/types.ts:2145](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2145)*
 
 ___
 

--- a/docs/interfaces/_api_types_.reverseoptions.md
+++ b/docs/interfaces/_api_types_.reverseoptions.md
@@ -25,7 +25,7 @@ Options of Reverse mode parameter.
 
 **● Extension**: *[ReverseOptionsExtension](_api_types_.reverseoptionsextension.md)*
 
-*Defined in [api/types.ts:2200](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2200)*
+*Defined in [api/types.ts:2200](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2200)*
 
 ___
 <a id="mode"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Mode**: *[ReverseMode](../enums/_api_types_.reversemode.md)*
 
-*Defined in [api/types.ts:2199](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2199)*
+*Defined in [api/types.ts:2199](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2199)*
 
 ___
 

--- a/docs/interfaces/_api_types_.rotate.md
+++ b/docs/interfaces/_api_types_.rotate.md
@@ -26,7 +26,7 @@ Parameter to enable/disable Rotation feature.
 
 **● Degree**: *`number`*
 
-*Defined in [api/types.ts:435](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L435)*
+*Defined in [api/types.ts:435](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L435)*
 
 ___
 <a id="extension"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Extension**: *[RotateExtension](_api_types_.rotateextension.md)*
 
-*Defined in [api/types.ts:436](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L436)*
+*Defined in [api/types.ts:436](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L436)*
 
 ___
 <a id="mode"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Mode**: *[RotateMode](../enums/_api_types_.rotatemode.md)*
 
-*Defined in [api/types.ts:434](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L434)*
+*Defined in [api/types.ts:434](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L434)*
 
 ___
 

--- a/docs/interfaces/_api_types_.rotateoptions.md
+++ b/docs/interfaces/_api_types_.rotateoptions.md
@@ -26,7 +26,7 @@ Supported options of Rotate mode parameter.
 
 **● DegreeList**: *[IntList](_api_types_.intlist.md)*
 
-*Defined in [api/types.ts:502](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L502)*
+*Defined in [api/types.ts:502](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L502)*
 
 ___
 <a id="extension"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Extension**: *[RotateOptionsExtension](_api_types_.rotateoptionsextension.md)*
 
-*Defined in [api/types.ts:503](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L503)*
+*Defined in [api/types.ts:503](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L503)*
 
 ___
 <a id="mode"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Mode**: *[RotateMode](../enums/_api_types_.rotatemode.md)*
 
-*Defined in [api/types.ts:501](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L501)*
+*Defined in [api/types.ts:501](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L501)*
 
 ___
 

--- a/docs/interfaces/_api_types_.ruleengineconfiguration.md
+++ b/docs/interfaces/_api_types_.ruleengineconfiguration.md
@@ -23,7 +23,7 @@
 
 **● Extension**: *[RuleEngineConfigurationExtension](_api_types_.ruleengineconfigurationextension.md)*
 
-*Defined in [api/types.ts:3197](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3197)*
+*Defined in [api/types.ts:3197](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3197)*
 
 ___
 <a id="rule"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Rule**: *[Config](_api_types_.config.md)*
 
-*Defined in [api/types.ts:3196](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3196)*
+*Defined in [api/types.ts:3196](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3196)*
 
 ___
 

--- a/docs/interfaces/_api_types_.sceneorientation.md
+++ b/docs/interfaces/_api_types_.sceneorientation.md
@@ -27,7 +27,7 @@
 
 **● Mode**: *[SceneOrientationMode](../enums/_api_types_.sceneorientationmode.md)*
 
-*Defined in [api/types.ts:518](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L518)*
+*Defined in [api/types.ts:518](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L518)*
 
 ___
 <a id="orientation"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Orientation**: *`string`*
 
-*Defined in [api/types.ts:519](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L519)*
+*Defined in [api/types.ts:519](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L519)*
 
 ___
 

--- a/docs/interfaces/_api_types_.scope.md
+++ b/docs/interfaces/_api_types_.scope.md
@@ -25,7 +25,7 @@ Indicates if the scope is fixed or configurable.
 
 **● ScopeDef**: *[ScopeDefinition](../enums/_api_types_.scopedefinition.md)*
 
-*Defined in [api/types.ts:1020](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1020)*
+*Defined in [api/types.ts:1020](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1020)*
 
 ___
 <a id="scopeitem"></a>
@@ -34,7 +34,7 @@ ___
 
 **● ScopeItem**: *`string`*
 
-*Defined in [api/types.ts:1021](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1021)*
+*Defined in [api/types.ts:1021](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1021)*
 
 ___
 

--- a/docs/interfaces/_api_types_.searchcapabilities.md
+++ b/docs/interfaces/_api_types_.searchcapabilities.md
@@ -23,7 +23,7 @@
 
 **● MetadataSearch**: *`boolean`*
 
-*Defined in [api/types.ts:1714](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1714)*
+*Defined in [api/types.ts:1714](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1714)*
 
 ___
 <a id="xaddr"></a>
@@ -32,7 +32,7 @@ ___
 
 **● XAddr**: *`string`*
 
-*Defined in [api/types.ts:1713](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1713)*
+*Defined in [api/types.ts:1713](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1713)*
 
 ___
 

--- a/docs/interfaces/_api_types_.searchscope.md
+++ b/docs/interfaces/_api_types_.searchscope.md
@@ -27,7 +27,7 @@ A structure for defining a limited scope when searching in recorded data.
 
 **● Extension**: *[SearchScopeExtension](_api_types_.searchscopeextension.md)*
 
-*Defined in [api/types.ts:3448](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3448)*
+*Defined in [api/types.ts:3448](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3448)*
 
 ___
 <a id="includedrecordings"></a>
@@ -36,7 +36,7 @@ ___
 
 **● IncludedRecordings**: *[RecordingReference](../modules/_api_types_.md#recordingreference)*
 
-*Defined in [api/types.ts:3446](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3446)*
+*Defined in [api/types.ts:3446](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3446)*
 
 ___
 <a id="includedsources"></a>
@@ -45,7 +45,7 @@ ___
 
 **● IncludedSources**: *[SourceReference](_api_types_.sourcereference.md)*
 
-*Defined in [api/types.ts:3445](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3445)*
+*Defined in [api/types.ts:3445](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3445)*
 
 ___
 <a id="recordinginformationfilter"></a>
@@ -54,7 +54,7 @@ ___
 
 **● RecordingInformationFilter**: *[XPathExpression](../modules/_api_types_.md#xpathexpression)*
 
-*Defined in [api/types.ts:3447](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3447)*
+*Defined in [api/types.ts:3447](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3447)*
 
 ___
 

--- a/docs/interfaces/_api_types_.securitycapabilities.md
+++ b/docs/interfaces/_api_types_.securitycapabilities.md
@@ -32,7 +32,7 @@ Indicates whether or not TLS 1.1 is supported.
 
 **● AccessPolicyConfig**: *`boolean`*
 
-*Defined in [api/types.ts:1599](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1599)*
+*Defined in [api/types.ts:1599](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1599)*
 
 ___
 <a id="extension"></a>
@@ -41,7 +41,7 @@ ___
 
 **● Extension**: *[SecurityCapabilitiesExtension](_api_types_.securitycapabilitiesextension.md)*
 
-*Defined in [api/types.ts:1604](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1604)*
+*Defined in [api/types.ts:1604](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1604)*
 
 ___
 <a id="kerberostoken"></a>
@@ -50,7 +50,7 @@ ___
 
 **● KerberosToken**: *`boolean`*
 
-*Defined in [api/types.ts:1602](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1602)*
+*Defined in [api/types.ts:1602](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1602)*
 
 ___
 <a id="onboardkeygeneration"></a>
@@ -59,7 +59,7 @@ ___
 
 **● OnboardKeyGeneration**: *`boolean`*
 
-*Defined in [api/types.ts:1598](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1598)*
+*Defined in [api/types.ts:1598](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1598)*
 
 ___
 <a id="reltoken"></a>
@@ -68,7 +68,7 @@ ___
 
 **● RELToken**: *`boolean`*
 
-*Defined in [api/types.ts:1603](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1603)*
+*Defined in [api/types.ts:1603](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1603)*
 
 ___
 <a id="samltoken"></a>
@@ -77,7 +77,7 @@ ___
 
 **● SAMLToken**: *`boolean`*
 
-*Defined in [api/types.ts:1601](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1601)*
+*Defined in [api/types.ts:1601](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1601)*
 
 ___
 <a id="tls1_1"></a>
@@ -86,7 +86,7 @@ ___
 
 **● TLS1.1**: *`boolean`*
 
-*Defined in [api/types.ts:1596](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1596)*
+*Defined in [api/types.ts:1596](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1596)*
 
 ___
 <a id="tls1_2"></a>
@@ -95,7 +95,7 @@ ___
 
 **● TLS1.2**: *`boolean`*
 
-*Defined in [api/types.ts:1597](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1597)*
+*Defined in [api/types.ts:1597](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1597)*
 
 ___
 <a id="x_509token"></a>
@@ -104,7 +104,7 @@ ___
 
 **● X.509Token**: *`boolean`*
 
-*Defined in [api/types.ts:1600](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1600)*
+*Defined in [api/types.ts:1600](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1600)*
 
 ___
 

--- a/docs/interfaces/_api_types_.securitycapabilitiesextension.md
+++ b/docs/interfaces/_api_types_.securitycapabilitiesextension.md
@@ -23,7 +23,7 @@
 
 **● Extension**: *[SecurityCapabilitiesExtension2](_api_types_.securitycapabilitiesextension2.md)*
 
-*Defined in [api/types.ts:1612](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1612)*
+*Defined in [api/types.ts:1612](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1612)*
 
 ___
 <a id="tls1_0"></a>
@@ -32,7 +32,7 @@ ___
 
 **● TLS1.0**: *`boolean`*
 
-*Defined in [api/types.ts:1611](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1611)*
+*Defined in [api/types.ts:1611](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1611)*
 
 ___
 

--- a/docs/interfaces/_api_types_.securitycapabilitiesextension2.md
+++ b/docs/interfaces/_api_types_.securitycapabilitiesextension2.md
@@ -26,7 +26,7 @@ EAP Methods supported by the device. The int values refer to the IANA EAP Regist
 
 **● Dot1X**: *`boolean`*
 
-*Defined in [api/types.ts:1619](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1619)*
+*Defined in [api/types.ts:1619](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1619)*
 
 ___
 <a id="remoteuserhandling"></a>
@@ -35,7 +35,7 @@ ___
 
 **● RemoteUserHandling**: *`boolean`*
 
-*Defined in [api/types.ts:1621](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1621)*
+*Defined in [api/types.ts:1621](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1621)*
 
 ___
 <a id="supportedeapmethod"></a>
@@ -44,7 +44,7 @@ ___
 
 **● SupportedEAPMethod**: *`number`*
 
-*Defined in [api/types.ts:1620](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1620)*
+*Defined in [api/types.ts:1620](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1620)*
 
 ___
 

--- a/docs/interfaces/_api_types_.sourceidentification.md
+++ b/docs/interfaces/_api_types_.sourceidentification.md
@@ -24,7 +24,7 @@
 
 **● Extension**: *[SourceIdentificationExtension](_api_types_.sourceidentificationextension.md)*
 
-*Defined in [api/types.ts:3845](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3845)*
+*Defined in [api/types.ts:3845](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3845)*
 
 ___
 <a id="name"></a>
@@ -33,7 +33,7 @@ ___
 
 **● Name**: *`string`*
 
-*Defined in [api/types.ts:3843](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3843)*
+*Defined in [api/types.ts:3843](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3843)*
 
 ___
 <a id="token"></a>
@@ -42,7 +42,7 @@ ___
 
 **● Token**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3844](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3844)*
+*Defined in [api/types.ts:3844](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3844)*
 
 ___
 

--- a/docs/interfaces/_api_types_.sourcereference.md
+++ b/docs/interfaces/_api_types_.sourcereference.md
@@ -22,7 +22,7 @@
 
 **● Token**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:3421](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3421)*
+*Defined in [api/types.ts:3421](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3421)*
 
 ___
 

--- a/docs/interfaces/_api_types_.space1ddescription.md
+++ b/docs/interfaces/_api_types_.space1ddescription.md
@@ -27,7 +27,7 @@
 
 **● URI**: *`string`*
 
-*Defined in [api/types.ts:2268](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2268)*
+*Defined in [api/types.ts:2268](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2268)*
 
 ___
 <a id="xrange"></a>
@@ -36,7 +36,7 @@ ___
 
 **● XRange**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2269](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2269)*
+*Defined in [api/types.ts:2269](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2269)*
 
 ___
 

--- a/docs/interfaces/_api_types_.space2ddescription.md
+++ b/docs/interfaces/_api_types_.space2ddescription.md
@@ -28,7 +28,7 @@
 
 **● URI**: *`string`*
 
-*Defined in [api/types.ts:2257](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2257)*
+*Defined in [api/types.ts:2257](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2257)*
 
 ___
 <a id="xrange"></a>
@@ -37,7 +37,7 @@ ___
 
 **● XRange**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2258](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2258)*
+*Defined in [api/types.ts:2258](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2258)*
 
 ___
 <a id="yrange"></a>
@@ -46,7 +46,7 @@ ___
 
 **● YRange**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2259](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2259)*
+*Defined in [api/types.ts:2259](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2259)*
 
 ___
 

--- a/docs/interfaces/_api_types_.storagereferencepath.md
+++ b/docs/interfaces/_api_types_.storagereferencepath.md
@@ -26,7 +26,7 @@ identifier of an existing Storage Configuration.
 
 **● Extension**: *[StorageReferencePathExtension](_api_types_.storagereferencepathextension.md)*
 
-*Defined in [api/types.ts:4171](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4171)*
+*Defined in [api/types.ts:4171](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4171)*
 
 ___
 <a id="relativepath"></a>
@@ -35,7 +35,7 @@ ___
 
 **● RelativePath**: *`string`*
 
-*Defined in [api/types.ts:4170](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4170)*
+*Defined in [api/types.ts:4170](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4170)*
 
 ___
 <a id="storagetoken"></a>
@@ -44,7 +44,7 @@ ___
 
 **● StorageToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:4169](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L4169)*
+*Defined in [api/types.ts:4169](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L4169)*
 
 ___
 

--- a/docs/interfaces/_api_types_.streamsetup.md
+++ b/docs/interfaces/_api_types_.streamsetup.md
@@ -25,7 +25,7 @@ Defines if a multicast or unicast stream is requested
 
 **● Stream**: *[StreamType](../enums/_api_types_.streamtype.md)*
 
-*Defined in [api/types.ts:994](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L994)*
+*Defined in [api/types.ts:994](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L994)*
 
 ___
 <a id="transport"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Transport**: *[Transport](_api_types_.transport.md)*
 
-*Defined in [api/types.ts:995](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L995)*
+*Defined in [api/types.ts:995](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L995)*
 
 ___
 

--- a/docs/interfaces/_api_types_.supportedanalyticsmodules.md
+++ b/docs/interfaces/_api_types_.supportedanalyticsmodules.md
@@ -26,7 +26,7 @@ It optionally contains a list of URLs that provide the location of schema files.
 
 **● AnalyticsModuleContentSchemaLocation**: *`string`*
 
-*Defined in [api/types.ts:3255](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3255)*
+*Defined in [api/types.ts:3255](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3255)*
 
 ___
 <a id="analyticsmoduledescription"></a>
@@ -35,7 +35,7 @@ ___
 
 **● AnalyticsModuleDescription**: *[ConfigDescription](_api_types_.configdescription.md)*
 
-*Defined in [api/types.ts:3256](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3256)*
+*Defined in [api/types.ts:3256](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3256)*
 
 ___
 <a id="extension"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Extension**: *[SupportedAnalyticsModulesExtension](_api_types_.supportedanalyticsmodulesextension.md)*
 
-*Defined in [api/types.ts:3257](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3257)*
+*Defined in [api/types.ts:3257](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3257)*
 
 ___
 

--- a/docs/interfaces/_api_types_.supportedrules.md
+++ b/docs/interfaces/_api_types_.supportedrules.md
@@ -26,7 +26,7 @@ Lists the location of all schemas that are referenced in the rules.
 
 **● Extension**: *[SupportedRulesExtension](_api_types_.supportedrulesextension.md)*
 
-*Defined in [api/types.ts:3239](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3239)*
+*Defined in [api/types.ts:3239](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3239)*
 
 ___
 <a id="rulecontentschemalocation"></a>
@@ -35,7 +35,7 @@ ___
 
 **● RuleContentSchemaLocation**: *`string`*
 
-*Defined in [api/types.ts:3237](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3237)*
+*Defined in [api/types.ts:3237](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3237)*
 
 ___
 <a id="ruledescription"></a>
@@ -44,7 +44,7 @@ ___
 
 **● RuleDescription**: *[ConfigDescription](_api_types_.configdescription.md)*
 
-*Defined in [api/types.ts:3238](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3238)*
+*Defined in [api/types.ts:3238](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3238)*
 
 ___
 

--- a/docs/interfaces/_api_types_.supportinformation.md
+++ b/docs/interfaces/_api_types_.supportinformation.md
@@ -25,7 +25,7 @@ The support information as attachment data.
 
 **● Binary**: *[AttachmentData](_api_types_.attachmentdata.md)*
 
-*Defined in [api/types.ts:1763](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1763)*
+*Defined in [api/types.ts:1763](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1763)*
 
 ___
 <a id="string"></a>
@@ -34,7 +34,7 @@ ___
 
 **● String**: *`string`*
 
-*Defined in [api/types.ts:1764](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1764)*
+*Defined in [api/types.ts:1764](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1764)*
 
 ___
 

--- a/docs/interfaces/_api_types_.systemcapabilities.md
+++ b/docs/interfaces/_api_types_.systemcapabilities.md
@@ -31,7 +31,7 @@ Indicates whether or not WS Discovery resolve requests are supported.
 
 **● DiscoveryBye**: *`boolean`*
 
-*Defined in [api/types.ts:1629](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1629)*
+*Defined in [api/types.ts:1629](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1629)*
 
 ___
 <a id="discoveryresolve"></a>
@@ -40,7 +40,7 @@ ___
 
 **● DiscoveryResolve**: *`boolean`*
 
-*Defined in [api/types.ts:1628](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1628)*
+*Defined in [api/types.ts:1628](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1628)*
 
 ___
 <a id="extension"></a>
@@ -49,7 +49,7 @@ ___
 
 **● Extension**: *[SystemCapabilitiesExtension](_api_types_.systemcapabilitiesextension.md)*
 
-*Defined in [api/types.ts:1635](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1635)*
+*Defined in [api/types.ts:1635](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1635)*
 
 ___
 <a id="firmwareupgrade"></a>
@@ -58,7 +58,7 @@ ___
 
 **● FirmwareUpgrade**: *`boolean`*
 
-*Defined in [api/types.ts:1633](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1633)*
+*Defined in [api/types.ts:1633](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1633)*
 
 ___
 <a id="remotediscovery"></a>
@@ -67,7 +67,7 @@ ___
 
 **● RemoteDiscovery**: *`boolean`*
 
-*Defined in [api/types.ts:1630](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1630)*
+*Defined in [api/types.ts:1630](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1630)*
 
 ___
 <a id="supportedversions"></a>
@@ -76,7 +76,7 @@ ___
 
 **● SupportedVersions**: *[OnvifVersion](_api_types_.onvifversion.md)*
 
-*Defined in [api/types.ts:1634](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1634)*
+*Defined in [api/types.ts:1634](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1634)*
 
 ___
 <a id="systembackup"></a>
@@ -85,7 +85,7 @@ ___
 
 **● SystemBackup**: *`boolean`*
 
-*Defined in [api/types.ts:1631](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1631)*
+*Defined in [api/types.ts:1631](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1631)*
 
 ___
 <a id="systemlogging"></a>
@@ -94,7 +94,7 @@ ___
 
 **● SystemLogging**: *`boolean`*
 
-*Defined in [api/types.ts:1632](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1632)*
+*Defined in [api/types.ts:1632](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1632)*
 
 ___
 

--- a/docs/interfaces/_api_types_.systemcapabilitiesextension.md
+++ b/docs/interfaces/_api_types_.systemcapabilitiesextension.md
@@ -26,7 +26,7 @@
 
 **● Extension**: *[SystemCapabilitiesExtension2](_api_types_.systemcapabilitiesextension2.md)*
 
-*Defined in [api/types.ts:1646](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1646)*
+*Defined in [api/types.ts:1646](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1646)*
 
 ___
 <a id="httpfirmwareupgrade"></a>
@@ -35,7 +35,7 @@ ___
 
 **● HttpFirmwareUpgrade**: *`boolean`*
 
-*Defined in [api/types.ts:1642](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1642)*
+*Defined in [api/types.ts:1642](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1642)*
 
 ___
 <a id="httpsupportinformation"></a>
@@ -44,7 +44,7 @@ ___
 
 **● HttpSupportInformation**: *`boolean`*
 
-*Defined in [api/types.ts:1645](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1645)*
+*Defined in [api/types.ts:1645](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1645)*
 
 ___
 <a id="httpsystembackup"></a>
@@ -53,7 +53,7 @@ ___
 
 **● HttpSystemBackup**: *`boolean`*
 
-*Defined in [api/types.ts:1643](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1643)*
+*Defined in [api/types.ts:1643](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1643)*
 
 ___
 <a id="httpsystemlogging"></a>
@@ -62,7 +62,7 @@ ___
 
 **● HttpSystemLogging**: *`boolean`*
 
-*Defined in [api/types.ts:1644](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1644)*
+*Defined in [api/types.ts:1644](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1644)*
 
 ___
 

--- a/docs/interfaces/_api_types_.systemdatetime.md
+++ b/docs/interfaces/_api_types_.systemdatetime.md
@@ -29,7 +29,7 @@ General date time inforamtion returned by the GetSystemDateTime method.
 
 **● DateTimeType**: *[SetDateTimeType](../enums/_api_types_.setdatetimetype.md)*
 
-*Defined in [api/types.ts:1807](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1807)*
+*Defined in [api/types.ts:1807](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1807)*
 
 ___
 <a id="daylightsavings"></a>
@@ -38,7 +38,7 @@ ___
 
 **● DaylightSavings**: *`boolean`*
 
-*Defined in [api/types.ts:1808](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1808)*
+*Defined in [api/types.ts:1808](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1808)*
 
 ___
 <a id="extension"></a>
@@ -47,7 +47,7 @@ ___
 
 **● Extension**: *[SystemDateTimeExtension](_api_types_.systemdatetimeextension.md)*
 
-*Defined in [api/types.ts:1812](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1812)*
+*Defined in [api/types.ts:1812](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1812)*
 
 ___
 <a id="localdatetime"></a>
@@ -56,7 +56,7 @@ ___
 
 **● LocalDateTime**: *[DateTime](_api_types_.datetime.md)*
 
-*Defined in [api/types.ts:1811](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1811)*
+*Defined in [api/types.ts:1811](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1811)*
 
 ___
 <a id="timezone"></a>
@@ -65,7 +65,7 @@ ___
 
 **● TimeZone**: *[TimeZone](_api_types_.timezone.md)*
 
-*Defined in [api/types.ts:1809](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1809)*
+*Defined in [api/types.ts:1809](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1809)*
 
 ___
 <a id="utcdatetime"></a>
@@ -74,7 +74,7 @@ ___
 
 **● UTCDateTime**: *[DateTime](_api_types_.datetime.md)*
 
-*Defined in [api/types.ts:1810](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1810)*
+*Defined in [api/types.ts:1810](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1810)*
 
 ___
 

--- a/docs/interfaces/_api_types_.systemlog.md
+++ b/docs/interfaces/_api_types_.systemlog.md
@@ -25,7 +25,7 @@ The log information as attachment data.
 
 **● Binary**: *[AttachmentData](_api_types_.attachmentdata.md)*
 
-*Defined in [api/types.ts:1755](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1755)*
+*Defined in [api/types.ts:1755](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1755)*
 
 ___
 <a id="string"></a>
@@ -34,7 +34,7 @@ ___
 
 **● String**: *`string`*
 
-*Defined in [api/types.ts:1756](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1756)*
+*Defined in [api/types.ts:1756](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1756)*
 
 ___
 

--- a/docs/interfaces/_api_types_.systemloguri.md
+++ b/docs/interfaces/_api_types_.systemloguri.md
@@ -23,7 +23,7 @@
 
 **● Type**: *[SystemLogType](../enums/_api_types_.systemlogtype.md)*
 
-*Defined in [api/types.ts:1799](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1799)*
+*Defined in [api/types.ts:1799](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1799)*
 
 ___
 <a id="uri"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Uri**: *`string`*
 
-*Defined in [api/types.ts:1800](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1800)*
+*Defined in [api/types.ts:1800](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1800)*
 
 ___
 

--- a/docs/interfaces/_api_types_.systemlogurilist.md
+++ b/docs/interfaces/_api_types_.systemlogurilist.md
@@ -22,7 +22,7 @@
 
 **● SystemLog**: *[SystemLogUri](_api_types_.systemloguri.md)*
 
-*Defined in [api/types.ts:1792](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1792)*
+*Defined in [api/types.ts:1792](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1792)*
 
 ___
 

--- a/docs/interfaces/_api_types_.time.md
+++ b/docs/interfaces/_api_types_.time.md
@@ -26,7 +26,7 @@ Range is 0 to 23.
 
 **● Hour**: *`number`*
 
-*Defined in [api/types.ts:1842](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1842)*
+*Defined in [api/types.ts:1842](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1842)*
 
 ___
 <a id="minute"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Minute**: *`number`*
 
-*Defined in [api/types.ts:1843](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1843)*
+*Defined in [api/types.ts:1843](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1843)*
 
 ___
 <a id="second"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Second**: *`number`*
 
-*Defined in [api/types.ts:1844](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1844)*
+*Defined in [api/types.ts:1844](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1844)*
 
 ___
 

--- a/docs/interfaces/_api_types_.timezone.md
+++ b/docs/interfaces/_api_types_.timezone.md
@@ -35,7 +35,7 @@
 
 **● TZ**: *`string`*
 
-*Defined in [api/types.ts:1862](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1862)*
+*Defined in [api/types.ts:1862](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1862)*
 
 ___
 

--- a/docs/interfaces/_api_types_.tlsconfiguration.md
+++ b/docs/interfaces/_api_types_.tlsconfiguration.md
@@ -22,7 +22,7 @@
 
 **● CertificateID**: *`string`*
 
-*Defined in [api/types.ts:2001](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2001)*
+*Defined in [api/types.ts:2001](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2001)*
 
 ___
 

--- a/docs/interfaces/_api_types_.tonecompensation.md
+++ b/docs/interfaces/_api_types_.tonecompensation.md
@@ -26,7 +26,7 @@ Parameter to enable/disable or automatic ToneCompensation feature. Its options s
 
 **● Extension**: *[ToneCompensationExtension](_api_types_.tonecompensationextension.md)*
 
-*Defined in [api/types.ts:2823](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2823)*
+*Defined in [api/types.ts:2823](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2823)*
 
 ___
 <a id="level"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Level**: *`number`*
 
-*Defined in [api/types.ts:2822](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2822)*
+*Defined in [api/types.ts:2822](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2822)*
 
 ___
 <a id="mode"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Mode**: *`string`*
 
-*Defined in [api/types.ts:2821](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2821)*
+*Defined in [api/types.ts:2821](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2821)*
 
 ___
 

--- a/docs/interfaces/_api_types_.tonecompensationoptions.md
+++ b/docs/interfaces/_api_types_.tonecompensationoptions.md
@@ -25,7 +25,7 @@ Supported options for Tone Compensation mode. Its options shall be chosen from t
 
 **● Level**: *`boolean`*
 
-*Defined in [api/types.ts:3090](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3090)*
+*Defined in [api/types.ts:3090](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3090)*
 
 ___
 <a id="mode"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Mode**: *`string`*
 
-*Defined in [api/types.ts:3089](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3089)*
+*Defined in [api/types.ts:3089](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3089)*
 
 ___
 

--- a/docs/interfaces/_api_types_.trackattributes.md
+++ b/docs/interfaces/_api_types_.trackattributes.md
@@ -28,7 +28,7 @@ The basic information about the track. Note that a track may represent a single 
 
 **● AudioAttributes**: *[AudioAttributes](_api_types_.audioattributes.md)*
 
-*Defined in [api/types.ts:3599](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3599)*
+*Defined in [api/types.ts:3599](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3599)*
 
 ___
 <a id="extension"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Extension**: *[TrackAttributesExtension](_api_types_.trackattributesextension.md)*
 
-*Defined in [api/types.ts:3601](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3601)*
+*Defined in [api/types.ts:3601](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3601)*
 
 ___
 <a id="metadataattributes"></a>
@@ -46,7 +46,7 @@ ___
 
 **● MetadataAttributes**: *[MetadataAttributes](_api_types_.metadataattributes.md)*
 
-*Defined in [api/types.ts:3600](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3600)*
+*Defined in [api/types.ts:3600](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3600)*
 
 ___
 <a id="trackinformation"></a>
@@ -55,7 +55,7 @@ ___
 
 **● TrackInformation**: *[TrackInformation](_api_types_.trackinformation.md)*
 
-*Defined in [api/types.ts:3597](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3597)*
+*Defined in [api/types.ts:3597](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3597)*
 
 ___
 <a id="videoattributes"></a>
@@ -64,7 +64,7 @@ ___
 
 **● VideoAttributes**: *[VideoAttributes](_api_types_.videoattributes.md)*
 
-*Defined in [api/types.ts:3598](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3598)*
+*Defined in [api/types.ts:3598](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3598)*
 
 ___
 

--- a/docs/interfaces/_api_types_.trackconfiguration.md
+++ b/docs/interfaces/_api_types_.trackconfiguration.md
@@ -25,7 +25,7 @@ Type of the track. It shall be equal to the strings “Video”, “Audio” or 
 
 **● Description**: *[Description](_api_types_.trackconfiguration.md#description)*
 
-*Defined in [api/types.ts:3654](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3654)*
+*Defined in [api/types.ts:3654](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3654)*
 
 ___
 <a id="tracktype"></a>
@@ -34,7 +34,7 @@ ___
 
 **● TrackType**: *[TrackType](../enums/_api_types_.tracktype.md)*
 
-*Defined in [api/types.ts:3653](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3653)*
+*Defined in [api/types.ts:3653](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3653)*
 
 ___
 

--- a/docs/interfaces/_api_types_.trackinformation.md
+++ b/docs/interfaces/_api_types_.trackinformation.md
@@ -28,7 +28,7 @@ Type of the track: "Video", "Audio" or "Metadata". The track shall only be able 
 
 **● DataFrom**: *`string`*
 
-*Defined in [api/types.ts:3579](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3579)*
+*Defined in [api/types.ts:3579](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3579)*
 
 ___
 <a id="datato"></a>
@@ -37,7 +37,7 @@ ___
 
 **● DataTo**: *`string`*
 
-*Defined in [api/types.ts:3580](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3580)*
+*Defined in [api/types.ts:3580](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3580)*
 
 ___
 <a id="description"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Description**: *[Description](_api_types_.trackinformation.md#description)*
 
-*Defined in [api/types.ts:3578](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3578)*
+*Defined in [api/types.ts:3578](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3578)*
 
 ___
 <a id="tracktoken"></a>
@@ -55,7 +55,7 @@ ___
 
 **● TrackToken**: *[TrackReference](../modules/_api_types_.md#trackreference)*
 
-*Defined in [api/types.ts:3576](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3576)*
+*Defined in [api/types.ts:3576](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3576)*
 
 ___
 <a id="tracktype"></a>
@@ -64,7 +64,7 @@ ___
 
 **● TrackType**: *[TrackType](../enums/_api_types_.tracktype.md)*
 
-*Defined in [api/types.ts:3577](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3577)*
+*Defined in [api/types.ts:3577](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3577)*
 
 ___
 

--- a/docs/interfaces/_api_types_.transformation.md
+++ b/docs/interfaces/_api_types_.transformation.md
@@ -24,7 +24,7 @@
 
 **● Extension**: *[TransformationExtension](_api_types_.transformationextension.md)*
 
-*Defined in [api/types.ts:213](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L213)*
+*Defined in [api/types.ts:213](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L213)*
 
 ___
 <a id="scale"></a>
@@ -33,7 +33,7 @@ ___
 
 **● Scale**: *[Vector](_api_types_.vector.md)*
 
-*Defined in [api/types.ts:212](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L212)*
+*Defined in [api/types.ts:212](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L212)*
 
 ___
 <a id="translate"></a>
@@ -42,7 +42,7 @@ ___
 
 **● Translate**: *[Vector](_api_types_.vector.md)*
 
-*Defined in [api/types.ts:211](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L211)*
+*Defined in [api/types.ts:211](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L211)*
 
 ___
 

--- a/docs/interfaces/_api_types_.transport.md
+++ b/docs/interfaces/_api_types_.transport.md
@@ -25,7 +25,7 @@ Defines the network protocol for streaming, either UDP=RTP/UDP, RTSP=RTP/RTSP/TC
 
 **● Protocol**: *[TransportProtocol](../enums/_api_types_.transportprotocol.md)*
 
-*Defined in [api/types.ts:1002](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1002)*
+*Defined in [api/types.ts:1002](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1002)*
 
 ___
 <a id="tunnel"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Tunnel**: *[Transport](_api_types_.transport.md)*
 
-*Defined in [api/types.ts:1003](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1003)*
+*Defined in [api/types.ts:1003](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1003)*
 
 ___
 

--- a/docs/interfaces/_api_types_.user.md
+++ b/docs/interfaces/_api_types_.user.md
@@ -27,7 +27,7 @@ Username string.
 
 **● Extension**: *[UserExtension](_api_types_.userextension.md)*
 
-*Defined in [api/types.ts:1881](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1881)*
+*Defined in [api/types.ts:1881](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1881)*
 
 ___
 <a id="password"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Password**: *`string`*
 
-*Defined in [api/types.ts:1879](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1879)*
+*Defined in [api/types.ts:1879](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1879)*
 
 ___
 <a id="userlevel"></a>
@@ -45,7 +45,7 @@ ___
 
 **● UserLevel**: *[UserLevel](../enums/_api_types_.userlevel.md)*
 
-*Defined in [api/types.ts:1880](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1880)*
+*Defined in [api/types.ts:1880](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1880)*
 
 ___
 <a id="username"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Username**: *`string`*
 
-*Defined in [api/types.ts:1878](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L1878)*
+*Defined in [api/types.ts:1878](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L1878)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoanalyticsconfiguration.md
+++ b/docs/interfaces/_api_types_.videoanalyticsconfiguration.md
@@ -23,7 +23,7 @@
 
 **● AnalyticsEngineConfiguration**: *[AnalyticsEngineConfiguration](_api_types_.analyticsengineconfiguration.md)*
 
-*Defined in [api/types.ts:756](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L756)*
+*Defined in [api/types.ts:756](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L756)*
 
 ___
 <a id="ruleengineconfiguration"></a>
@@ -32,7 +32,7 @@ ___
 
 **● RuleEngineConfiguration**: *[RuleEngineConfiguration](_api_types_.ruleengineconfiguration.md)*
 
-*Defined in [api/types.ts:757](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L757)*
+*Defined in [api/types.ts:757](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L757)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoattributes.md
+++ b/docs/interfaces/_api_types_.videoattributes.md
@@ -28,7 +28,7 @@ Average bitrate in kbps.
 
 **● Bitrate**: *`number`*
 
-*Defined in [api/types.ts:3614](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3614)*
+*Defined in [api/types.ts:3614](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3614)*
 
 ___
 <a id="encoding"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Encoding**: *`string`*
 
-*Defined in [api/types.ts:3617](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3617)*
+*Defined in [api/types.ts:3617](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3617)*
 
 ___
 <a id="framerate"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Framerate**: *`number`*
 
-*Defined in [api/types.ts:3618](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3618)*
+*Defined in [api/types.ts:3618](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3618)*
 
 ___
 <a id="height"></a>
@@ -55,7 +55,7 @@ ___
 
 **● Height**: *`number`*
 
-*Defined in [api/types.ts:3616](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3616)*
+*Defined in [api/types.ts:3616](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3616)*
 
 ___
 <a id="width"></a>
@@ -64,7 +64,7 @@ ___
 
 **● Width**: *`number`*
 
-*Defined in [api/types.ts:3615](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3615)*
+*Defined in [api/types.ts:3615](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3615)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videodecoderconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.videodecoderconfigurationoptions.md
@@ -27,7 +27,7 @@ If the device is able to decode Jpeg streams this element describes the supporte
 
 **● Extension**: *[VideoDecoderConfigurationOptionsExtension](_api_types_.videodecoderconfigurationoptionsextension.md)*
 
-*Defined in [api/types.ts:871](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L871)*
+*Defined in [api/types.ts:871](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L871)*
 
 ___
 <a id="h264decoptions"></a>
@@ -36,7 +36,7 @@ ___
 
 **● H264DecOptions**: *[H264DecOptions](_api_types_.h264decoptions.md)*
 
-*Defined in [api/types.ts:869](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L869)*
+*Defined in [api/types.ts:869](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L869)*
 
 ___
 <a id="jpegdecoptions"></a>
@@ -45,7 +45,7 @@ ___
 
 **● JpegDecOptions**: *[JpegDecOptions](_api_types_.jpegdecoptions.md)*
 
-*Defined in [api/types.ts:868](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L868)*
+*Defined in [api/types.ts:868](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L868)*
 
 ___
 <a id="mpeg4decoptions"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Mpeg4DecOptions**: *[Mpeg4DecOptions](_api_types_.mpeg4decoptions.md)*
 
-*Defined in [api/types.ts:870](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L870)*
+*Defined in [api/types.ts:870](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L870)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoencoder2configuration.md
+++ b/docs/interfaces/_api_types_.videoencoder2configuration.md
@@ -28,7 +28,7 @@ Video Media Subtype for the video format. For definitions see tt:VideoEncodingMi
 
 **● Encoding**: *`string`*
 
-*Defined in [api/types.ts:652](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L652)*
+*Defined in [api/types.ts:652](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L652)*
 
 ___
 <a id="multicast"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Multicast**: *[MulticastConfiguration](_api_types_.multicastconfiguration.md)*
 
-*Defined in [api/types.ts:655](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L655)*
+*Defined in [api/types.ts:655](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L655)*
 
 ___
 <a id="quality"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Quality**: *`number`*
 
-*Defined in [api/types.ts:656](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L656)*
+*Defined in [api/types.ts:656](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L656)*
 
 ___
 <a id="ratecontrol"></a>
@@ -55,7 +55,7 @@ ___
 
 **● RateControl**: *[VideoRateControl2](_api_types_.videoratecontrol2.md)*
 
-*Defined in [api/types.ts:654](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L654)*
+*Defined in [api/types.ts:654](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L654)*
 
 ___
 <a id="resolution"></a>
@@ -64,7 +64,7 @@ ___
 
 **● Resolution**: *[VideoResolution2](_api_types_.videoresolution2.md)*
 
-*Defined in [api/types.ts:653](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L653)*
+*Defined in [api/types.ts:653](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L653)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoencoder2configurationoptions.md
+++ b/docs/interfaces/_api_types_.videoencoder2configurationoptions.md
@@ -27,7 +27,7 @@ Video Media Subtype for the video format. For definitions see tt:VideoEncodingMi
 
 **● BitrateRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:682](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L682)*
+*Defined in [api/types.ts:682](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L682)*
 
 ___
 <a id="encoding"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Encoding**: *`string`*
 
-*Defined in [api/types.ts:679](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L679)*
+*Defined in [api/types.ts:679](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L679)*
 
 ___
 <a id="qualityrange"></a>
@@ -45,7 +45,7 @@ ___
 
 **● QualityRange**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:680](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L680)*
+*Defined in [api/types.ts:680](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L680)*
 
 ___
 <a id="resolutionsavailable"></a>
@@ -54,7 +54,7 @@ ___
 
 **● ResolutionsAvailable**: *[VideoResolution2](_api_types_.videoresolution2.md)*
 
-*Defined in [api/types.ts:681](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L681)*
+*Defined in [api/types.ts:681](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L681)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoencoderconfiguration.md
+++ b/docs/interfaces/_api_types_.videoencoderconfiguration.md
@@ -31,7 +31,7 @@ Used video codec, either Jpeg, H.264 or Mpeg4
 
 **● Encoding**: *[VideoEncoding](../enums/_api_types_.videoencoding.md)*
 
-*Defined in [api/types.ts:526](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L526)*
+*Defined in [api/types.ts:526](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L526)*
 
 ___
 <a id="h264"></a>
@@ -40,7 +40,7 @@ ___
 
 **● H264**: *[H264Configuration](_api_types_.h264configuration.md)*
 
-*Defined in [api/types.ts:531](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L531)*
+*Defined in [api/types.ts:531](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L531)*
 
 ___
 <a id="mpeg4"></a>
@@ -49,7 +49,7 @@ ___
 
 **● MPEG4**: *[Mpeg4Configuration](_api_types_.mpeg4configuration.md)*
 
-*Defined in [api/types.ts:530](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L530)*
+*Defined in [api/types.ts:530](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L530)*
 
 ___
 <a id="multicast"></a>
@@ -58,7 +58,7 @@ ___
 
 **● Multicast**: *[MulticastConfiguration](_api_types_.multicastconfiguration.md)*
 
-*Defined in [api/types.ts:532](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L532)*
+*Defined in [api/types.ts:532](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L532)*
 
 ___
 <a id="quality"></a>
@@ -67,7 +67,7 @@ ___
 
 **● Quality**: *`number`*
 
-*Defined in [api/types.ts:528](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L528)*
+*Defined in [api/types.ts:528](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L528)*
 
 ___
 <a id="ratecontrol"></a>
@@ -76,7 +76,7 @@ ___
 
 **● RateControl**: *[VideoRateControl](_api_types_.videoratecontrol.md)*
 
-*Defined in [api/types.ts:529](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L529)*
+*Defined in [api/types.ts:529](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L529)*
 
 ___
 <a id="resolution"></a>
@@ -85,7 +85,7 @@ ___
 
 **● Resolution**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:527](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L527)*
+*Defined in [api/types.ts:527](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L527)*
 
 ___
 <a id="sessiontimeout"></a>
@@ -94,7 +94,7 @@ ___
 
 **● SessionTimeout**: *`string`*
 
-*Defined in [api/types.ts:533](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L533)*
+*Defined in [api/types.ts:533](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L533)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoencoderconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.videoencoderconfigurationoptions.md
@@ -28,7 +28,7 @@ Range of the quality values. A high value means higher quality.
 
 **● Extension**: *[VideoEncoderOptionsExtension](_api_types_.videoencoderoptionsextension.md)*
 
-*Defined in [api/types.ts:577](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L577)*
+*Defined in [api/types.ts:577](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L577)*
 
 ___
 <a id="h264"></a>
@@ -37,7 +37,7 @@ ___
 
 **● H264**: *[H264Options](_api_types_.h264options.md)*
 
-*Defined in [api/types.ts:576](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L576)*
+*Defined in [api/types.ts:576](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L576)*
 
 ___
 <a id="jpeg"></a>
@@ -46,7 +46,7 @@ ___
 
 **● JPEG**: *[JpegOptions](_api_types_.jpegoptions.md)*
 
-*Defined in [api/types.ts:574](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L574)*
+*Defined in [api/types.ts:574](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L574)*
 
 ___
 <a id="mpeg4"></a>
@@ -55,7 +55,7 @@ ___
 
 **● MPEG4**: *[Mpeg4Options](_api_types_.mpeg4options.md)*
 
-*Defined in [api/types.ts:575](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L575)*
+*Defined in [api/types.ts:575](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L575)*
 
 ___
 <a id="qualityrange"></a>
@@ -64,7 +64,7 @@ ___
 
 **● QualityRange**: *[IntRange](_api_types_.intrange.md)*
 
-*Defined in [api/types.ts:573](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L573)*
+*Defined in [api/types.ts:573](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L573)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoencoderoptionsextension.md
+++ b/docs/interfaces/_api_types_.videoencoderoptionsextension.md
@@ -27,7 +27,7 @@ Optional JPEG encoder settings ranges.
 
 **● Extension**: *[VideoEncoderOptionsExtension2](_api_types_.videoencoderoptionsextension2.md)*
 
-*Defined in [api/types.ts:587](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L587)*
+*Defined in [api/types.ts:587](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L587)*
 
 ___
 <a id="h264"></a>
@@ -36,7 +36,7 @@ ___
 
 **● H264**: *[H264Options2](_api_types_.h264options2.md)*
 
-*Defined in [api/types.ts:586](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L586)*
+*Defined in [api/types.ts:586](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L586)*
 
 ___
 <a id="jpeg"></a>
@@ -45,7 +45,7 @@ ___
 
 **● JPEG**: *[JpegOptions2](_api_types_.jpegoptions2.md)*
 
-*Defined in [api/types.ts:584](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L584)*
+*Defined in [api/types.ts:584](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L584)*
 
 ___
 <a id="mpeg4"></a>
@@ -54,7 +54,7 @@ ___
 
 **● MPEG4**: *[Mpeg4Options2](_api_types_.mpeg4options2.md)*
 
-*Defined in [api/types.ts:585](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L585)*
+*Defined in [api/types.ts:585](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L585)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videooutput.md
+++ b/docs/interfaces/_api_types_.videooutput.md
@@ -28,7 +28,7 @@ Representation of a physical video outputs.
 
 **● AspectRatio**: *`number`*
 
-*Defined in [api/types.ts:841](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L841)*
+*Defined in [api/types.ts:841](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L841)*
 
 ___
 <a id="extension"></a>
@@ -37,7 +37,7 @@ ___
 
 **● Extension**: *[VideoOutputExtension](_api_types_.videooutputextension.md)*
 
-*Defined in [api/types.ts:842](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L842)*
+*Defined in [api/types.ts:842](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L842)*
 
 ___
 <a id="layout"></a>
@@ -46,7 +46,7 @@ ___
 
 **● Layout**: *[Layout](_api_types_.layout.md)*
 
-*Defined in [api/types.ts:838](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L838)*
+*Defined in [api/types.ts:838](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L838)*
 
 ___
 <a id="refreshrate"></a>
@@ -55,7 +55,7 @@ ___
 
 **● RefreshRate**: *`number`*
 
-*Defined in [api/types.ts:840](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L840)*
+*Defined in [api/types.ts:840](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L840)*
 
 ___
 <a id="resolution"></a>
@@ -64,7 +64,7 @@ ___
 
 **● Resolution**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:839](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L839)*
+*Defined in [api/types.ts:839](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L839)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videooutputconfiguration.md
+++ b/docs/interfaces/_api_types_.videooutputconfiguration.md
@@ -24,7 +24,7 @@ Token of the Video Output the configuration applies to
 
 **● OutputToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:855](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L855)*
+*Defined in [api/types.ts:855](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L855)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoratecontrol.md
+++ b/docs/interfaces/_api_types_.videoratecontrol.md
@@ -26,7 +26,7 @@ Maximum output framerate in fps. If an EncodingInterval is provided the resultin
 
 **● BitrateLimit**: *`number`*
 
-*Defined in [api/types.ts:550](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L550)*
+*Defined in [api/types.ts:550](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L550)*
 
 ___
 <a id="encodinginterval"></a>
@@ -35,7 +35,7 @@ ___
 
 **● EncodingInterval**: *`number`*
 
-*Defined in [api/types.ts:549](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L549)*
+*Defined in [api/types.ts:549](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L549)*
 
 ___
 <a id="frameratelimit"></a>
@@ -44,7 +44,7 @@ ___
 
 **● FrameRateLimit**: *`number`*
 
-*Defined in [api/types.ts:548](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L548)*
+*Defined in [api/types.ts:548](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L548)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoratecontrol2.md
+++ b/docs/interfaces/_api_types_.videoratecontrol2.md
@@ -25,7 +25,7 @@ Desired frame rate in fps. The actual rate may be lower due to e.g. performance 
 
 **● BitrateLimit**: *`number`*
 
-*Defined in [api/types.ts:672](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L672)*
+*Defined in [api/types.ts:672](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L672)*
 
 ___
 <a id="frameratelimit"></a>
@@ -34,7 +34,7 @@ ___
 
 **● FrameRateLimit**: *`number`*
 
-*Defined in [api/types.ts:671](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L671)*
+*Defined in [api/types.ts:671](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L671)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoresolution.md
+++ b/docs/interfaces/_api_types_.videoresolution.md
@@ -25,7 +25,7 @@ Number of the columns of the Video image.
 
 **● Height**: *`number`*
 
-*Defined in [api/types.ts:541](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L541)*
+*Defined in [api/types.ts:541](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L541)*
 
 ___
 <a id="width"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Width**: *`number`*
 
-*Defined in [api/types.ts:540](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L540)*
+*Defined in [api/types.ts:540](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L540)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videoresolution2.md
+++ b/docs/interfaces/_api_types_.videoresolution2.md
@@ -25,7 +25,7 @@ Number of the columns of the Video image.
 
 **● Height**: *`number`*
 
-*Defined in [api/types.ts:664](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L664)*
+*Defined in [api/types.ts:664](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L664)*
 
 ___
 <a id="width"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Width**: *`number`*
 
-*Defined in [api/types.ts:663](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L663)*
+*Defined in [api/types.ts:663](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L663)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videosource.md
+++ b/docs/interfaces/_api_types_.videosource.md
@@ -27,7 +27,7 @@ Representation of a physical video input.
 
 **● Extension**: *[VideoSourceExtension](_api_types_.videosourceextension.md)*
 
-*Defined in [api/types.ts:329](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L329)*
+*Defined in [api/types.ts:329](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L329)*
 
 ___
 <a id="framerate"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Framerate**: *`number`*
 
-*Defined in [api/types.ts:326](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L326)*
+*Defined in [api/types.ts:326](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L326)*
 
 ___
 <a id="imaging"></a>
@@ -45,7 +45,7 @@ ___
 
 **● Imaging**: *[ImagingSettings](_api_types_.imagingsettings.md)*
 
-*Defined in [api/types.ts:328](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L328)*
+*Defined in [api/types.ts:328](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L328)*
 
 ___
 <a id="resolution"></a>
@@ -54,7 +54,7 @@ ___
 
 **● Resolution**: *[VideoResolution](_api_types_.videoresolution.md)*
 
-*Defined in [api/types.ts:327](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L327)*
+*Defined in [api/types.ts:327](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L327)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videosourceconfiguration.md
+++ b/docs/interfaces/_api_types_.videosourceconfiguration.md
@@ -26,7 +26,7 @@ Reference to the physical input.
 
 **● Bounds**: *[IntRectangle](_api_types_.intrectangle.md)*
 
-*Defined in [api/types.ts:405](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L405)*
+*Defined in [api/types.ts:405](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L405)*
 
 ___
 <a id="extension"></a>
@@ -35,7 +35,7 @@ ___
 
 **● Extension**: *[VideoSourceConfigurationExtension](_api_types_.videosourceconfigurationextension.md)*
 
-*Defined in [api/types.ts:406](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L406)*
+*Defined in [api/types.ts:406](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L406)*
 
 ___
 <a id="sourcetoken"></a>
@@ -44,7 +44,7 @@ ___
 
 **● SourceToken**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:404](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L404)*
+*Defined in [api/types.ts:404](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L404)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videosourceconfigurationextension.md
+++ b/docs/interfaces/_api_types_.videosourceconfigurationextension.md
@@ -25,7 +25,7 @@ Optional element to configure rotation of captured image. What resolutions a dev
 
 **● Extension**: *[VideoSourceConfigurationExtension2](_api_types_.videosourceconfigurationextension2.md)*
 
-*Defined in [api/types.ts:419](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L419)*
+*Defined in [api/types.ts:419](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L419)*
 
 ___
 <a id="rotate"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Rotate**: *[Rotate](_api_types_.rotate.md)*
 
-*Defined in [api/types.ts:418](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L418)*
+*Defined in [api/types.ts:418](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L418)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videosourceconfigurationextension2.md
+++ b/docs/interfaces/_api_types_.videosourceconfigurationextension2.md
@@ -25,7 +25,7 @@ Optional element describing the geometric lens distortion. Multiple instances fo
 
 **● LensDescription**: *[LensDescription](_api_types_.lensdescription.md)*
 
-*Defined in [api/types.ts:426](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L426)*
+*Defined in [api/types.ts:426](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L426)*
 
 ___
 <a id="sceneorientation"></a>
@@ -34,7 +34,7 @@ ___
 
 **● SceneOrientation**: *[SceneOrientation](_api_types_.sceneorientation.md)*
 
-*Defined in [api/types.ts:427](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L427)*
+*Defined in [api/types.ts:427](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L427)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videosourceconfigurationoptions.md
+++ b/docs/interfaces/_api_types_.videosourceconfigurationoptions.md
@@ -30,7 +30,7 @@
 
 **● BoundsRange**: *[IntRectangleRange](_api_types_.intrectanglerange.md)*
 
-*Defined in [api/types.ts:477](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L477)*
+*Defined in [api/types.ts:477](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L477)*
 
 ___
 <a id="extension"></a>
@@ -39,7 +39,7 @@ ___
 
 **● Extension**: *[VideoSourceConfigurationOptionsExtension](_api_types_.videosourceconfigurationoptionsextension.md)*
 
-*Defined in [api/types.ts:479](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L479)*
+*Defined in [api/types.ts:479](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L479)*
 
 ___
 <a id="videosourcetokensavailable"></a>
@@ -48,7 +48,7 @@ ___
 
 **● VideoSourceTokensAvailable**: *[ReferenceToken](../modules/_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:478](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L478)*
+*Defined in [api/types.ts:478](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L478)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videosourceconfigurationoptionsextension.md
+++ b/docs/interfaces/_api_types_.videosourceconfigurationoptionsextension.md
@@ -25,7 +25,7 @@ Options of parameters for Rotation feature.
 
 **● Extension**: *[VideoSourceConfigurationOptionsExtension2](_api_types_.videosourceconfigurationoptionsextension2.md)*
 
-*Defined in [api/types.ts:487](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L487)*
+*Defined in [api/types.ts:487](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L487)*
 
 ___
 <a id="rotate"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Rotate**: *[RotateOptions](_api_types_.rotateoptions.md)*
 
-*Defined in [api/types.ts:486](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L486)*
+*Defined in [api/types.ts:486](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L486)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videosourceconfigurationoptionsextension2.md
+++ b/docs/interfaces/_api_types_.videosourceconfigurationoptionsextension2.md
@@ -24,7 +24,7 @@ Scene orientation modes supported by the device for this configuration.
 
 **● SceneOrientationMode**: *[SceneOrientationMode](../enums/_api_types_.sceneorientationmode.md)*
 
-*Defined in [api/types.ts:494](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L494)*
+*Defined in [api/types.ts:494](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L494)*
 
 ___
 

--- a/docs/interfaces/_api_types_.videosourceextension.md
+++ b/docs/interfaces/_api_types_.videosourceextension.md
@@ -25,7 +25,7 @@ Optional configuration of the image sensor. To be used if imaging service 2.00 i
 
 **● Extension**: *[VideoSourceExtension2](_api_types_.videosourceextension2.md)*
 
-*Defined in [api/types.ts:337](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L337)*
+*Defined in [api/types.ts:337](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L337)*
 
 ___
 <a id="imaging"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Imaging**: *[ImagingSettings20](_api_types_.imagingsettings20.md)*
 
-*Defined in [api/types.ts:336](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L336)*
+*Defined in [api/types.ts:336](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L336)*
 
 ___
 

--- a/docs/interfaces/_api_types_.whitebalance.md
+++ b/docs/interfaces/_api_types_.whitebalance.md
@@ -26,7 +26,7 @@ Auto whitebalancing mode (auto/manual).
 
 **● CbGain**: *`number`*
 
-*Defined in [api/types.ts:2666](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2666)*
+*Defined in [api/types.ts:2666](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2666)*
 
 ___
 <a id="crgain"></a>
@@ -35,7 +35,7 @@ ___
 
 **● CrGain**: *`number`*
 
-*Defined in [api/types.ts:2665](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2665)*
+*Defined in [api/types.ts:2665](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2665)*
 
 ___
 <a id="mode"></a>
@@ -44,7 +44,7 @@ ___
 
 **● Mode**: *[WhiteBalanceMode](../enums/_api_types_.whitebalancemode.md)*
 
-*Defined in [api/types.ts:2664](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2664)*
+*Defined in [api/types.ts:2664](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2664)*
 
 ___
 

--- a/docs/interfaces/_api_types_.whitebalance20.md
+++ b/docs/interfaces/_api_types_.whitebalance20.md
@@ -29,7 +29,7 @@
 
 **● CbGain**: *`number`*
 
-*Defined in [api/types.ts:3006](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3006)*
+*Defined in [api/types.ts:3006](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3006)*
 
 ___
 <a id="crgain"></a>
@@ -38,7 +38,7 @@ ___
 
 **● CrGain**: *`number`*
 
-*Defined in [api/types.ts:3005](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3005)*
+*Defined in [api/types.ts:3005](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3005)*
 
 ___
 <a id="extension"></a>
@@ -47,7 +47,7 @@ ___
 
 **● Extension**: *[WhiteBalance20Extension](_api_types_.whitebalance20extension.md)*
 
-*Defined in [api/types.ts:3007](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3007)*
+*Defined in [api/types.ts:3007](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3007)*
 
 ___
 <a id="mode"></a>
@@ -56,7 +56,7 @@ ___
 
 **● Mode**: *[WhiteBalanceMode](../enums/_api_types_.whitebalancemode.md)*
 
-*Defined in [api/types.ts:3004](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3004)*
+*Defined in [api/types.ts:3004](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3004)*
 
 ___
 

--- a/docs/interfaces/_api_types_.whitebalanceoptions.md
+++ b/docs/interfaces/_api_types_.whitebalanceoptions.md
@@ -24,7 +24,7 @@
 
 **● Mode**: *[WhiteBalanceMode](../enums/_api_types_.whitebalancemode.md)*
 
-*Defined in [api/types.ts:2577](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2577)*
+*Defined in [api/types.ts:2577](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2577)*
 
 ___
 <a id="ybgain"></a>
@@ -33,7 +33,7 @@ ___
 
 **● YbGain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2579](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2579)*
+*Defined in [api/types.ts:2579](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2579)*
 
 ___
 <a id="yrgain"></a>
@@ -42,7 +42,7 @@ ___
 
 **● YrGain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2578](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2578)*
+*Defined in [api/types.ts:2578](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2578)*
 
 ___
 

--- a/docs/interfaces/_api_types_.whitebalanceoptions20.md
+++ b/docs/interfaces/_api_types_.whitebalanceoptions20.md
@@ -34,7 +34,7 @@
 
 **● Extension**: *[WhiteBalanceOptions20Extension](_api_types_.whitebalanceoptions20extension.md)*
 
-*Defined in [api/types.ts:3053](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3053)*
+*Defined in [api/types.ts:3053](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3053)*
 
 ___
 <a id="mode"></a>
@@ -43,7 +43,7 @@ ___
 
 **● Mode**: *[WhiteBalanceMode](../enums/_api_types_.whitebalancemode.md)*
 
-*Defined in [api/types.ts:3050](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3050)*
+*Defined in [api/types.ts:3050](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3050)*
 
 ___
 <a id="ybgain"></a>
@@ -52,7 +52,7 @@ ___
 
 **● YbGain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:3052](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3052)*
+*Defined in [api/types.ts:3052](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3052)*
 
 ___
 <a id="yrgain"></a>
@@ -61,7 +61,7 @@ ___
 
 **● YrGain**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:3051](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L3051)*
+*Defined in [api/types.ts:3051](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L3051)*
 
 ___
 

--- a/docs/interfaces/_api_types_.widedynamicrange.md
+++ b/docs/interfaces/_api_types_.widedynamicrange.md
@@ -27,7 +27,7 @@
 
 **● Level**: *`number`*
 
-*Defined in [api/types.ts:2503](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2503)*
+*Defined in [api/types.ts:2503](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2503)*
 
 ___
 <a id="mode"></a>
@@ -36,7 +36,7 @@ ___
 
 **● Mode**: *[WideDynamicMode](../enums/_api_types_.widedynamicmode.md)*
 
-*Defined in [api/types.ts:2502](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2502)*
+*Defined in [api/types.ts:2502](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2502)*
 
 ___
 

--- a/docs/interfaces/_api_types_.widedynamicrange20.md
+++ b/docs/interfaces/_api_types_.widedynamicrange20.md
@@ -25,7 +25,7 @@ Type describing whether WDR mode is enabled or disabled (on/off).
 
 **● Level**: *`number`*
 
-*Defined in [api/types.ts:2788](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2788)*
+*Defined in [api/types.ts:2788](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2788)*
 
 ___
 <a id="mode"></a>
@@ -34,7 +34,7 @@ ___
 
 **● Mode**: *[WideDynamicMode](../enums/_api_types_.widedynamicmode.md)*
 
-*Defined in [api/types.ts:2787](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2787)*
+*Defined in [api/types.ts:2787](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2787)*
 
 ___
 

--- a/docs/interfaces/_api_types_.widedynamicrangeoptions.md
+++ b/docs/interfaces/_api_types_.widedynamicrangeoptions.md
@@ -23,7 +23,7 @@
 
 **● Level**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2535](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2535)*
+*Defined in [api/types.ts:2535](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2535)*
 
 ___
 <a id="mode"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Mode**: *[WideDynamicMode](../enums/_api_types_.widedynamicmode.md)*
 
-*Defined in [api/types.ts:2534](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2534)*
+*Defined in [api/types.ts:2534](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2534)*
 
 ___
 

--- a/docs/interfaces/_api_types_.widedynamicrangeoptions20.md
+++ b/docs/interfaces/_api_types_.widedynamicrangeoptions20.md
@@ -23,7 +23,7 @@
 
 **● Level**: *[FloatRange](_api_types_.floatrange.md)*
 
-*Defined in [api/types.ts:2941](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2941)*
+*Defined in [api/types.ts:2941](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2941)*
 
 ___
 <a id="mode"></a>
@@ -32,7 +32,7 @@ ___
 
 **● Mode**: *[WideDynamicMode](../enums/_api_types_.widedynamicmode.md)*
 
-*Defined in [api/types.ts:2940](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2940)*
+*Defined in [api/types.ts:2940](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2940)*
 
 ___
 

--- a/docs/interfaces/_api_types_.zoomlimits.md
+++ b/docs/interfaces/_api_types_.zoomlimits.md
@@ -26,7 +26,7 @@
 
 **● Range**: *[Space1DDescription](_api_types_.space1ddescription.md)*
 
-*Defined in [api/types.ts:2224](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L2224)*
+*Defined in [api/types.ts:2224](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L2224)*
 
 ___
 

--- a/docs/interfaces/_config_interfaces_.ideviceconfig.md
+++ b/docs/interfaces/_config_interfaces_.ideviceconfig.md
@@ -24,7 +24,7 @@
 
 **● deviceUrl**: *`string`*
 
-*Defined in [config/interfaces.ts:25](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L25)*
+*Defined in [config/interfaces.ts:25](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L25)*
 
 ___
 <a id="system"></a>
@@ -33,7 +33,7 @@ ___
 
 **● system**: *[ISystemConfig](_config_interfaces_.isystemconfig.md)*
 
-*Defined in [config/interfaces.ts:24](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L24)*
+*Defined in [config/interfaces.ts:24](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L24)*
 
 ___
 <a id="user"></a>
@@ -42,7 +42,7 @@ ___
 
 **● user**: *`IMaybe`<[IUserCredentials](_config_interfaces_.iusercredentials.md)>*
 
-*Defined in [config/interfaces.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L26)*
+*Defined in [config/interfaces.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L26)*
 
 ___
 

--- a/docs/interfaces/_config_interfaces_.isystemconfig.md
+++ b/docs/interfaces/_config_interfaces_.isystemconfig.md
@@ -26,7 +26,7 @@
 
 **● buffer**: *`any`*
 
-*Defined in [config/interfaces.ts:19](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L19)*
+*Defined in [config/interfaces.ts:19](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L19)*
 
 ___
 <a id="digestsha1"></a>
@@ -35,7 +35,7 @@ ___
 
 **● digestSha1**: *[ISha1Digest](../modules/_config_interfaces_.md#isha1digest)*
 
-*Defined in [config/interfaces.ts:20](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L20)*
+*Defined in [config/interfaces.ts:20](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L20)*
 
 ___
 <a id="nonce"></a>
@@ -44,7 +44,7 @@ ___
 
 **● nonce**: *[INonce](../modules/_config_interfaces_.md#inonce)*
 
-*Defined in [config/interfaces.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L18)*
+*Defined in [config/interfaces.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L18)*
 
 ___
 <a id="parser"></a>
@@ -53,7 +53,7 @@ ___
 
 **● parser**: *`DOMParser`*
 
-*Defined in [config/interfaces.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L16)*
+*Defined in [config/interfaces.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L16)*
 
 ___
 <a id="transport"></a>
@@ -62,7 +62,7 @@ ___
 
 **● transport**: *[ITransport](../modules/_config_interfaces_.md#itransport)*
 
-*Defined in [config/interfaces.ts:17](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L17)*
+*Defined in [config/interfaces.ts:17](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L17)*
 
 ___
 

--- a/docs/interfaces/_config_interfaces_.itransportpayoad.md
+++ b/docs/interfaces/_config_interfaces_.itransportpayoad.md
@@ -24,7 +24,7 @@
 
 **● body**: *`string`*
 
-*Defined in [config/interfaces.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L5)*
+*Defined in [config/interfaces.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L5)*
 
 ___
 <a id="status"></a>
@@ -33,7 +33,7 @@ ___
 
 **● status**: *`number`*
 
-*Defined in [config/interfaces.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L7)*
+*Defined in [config/interfaces.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L7)*
 
 ___
 <a id="statusmessage"></a>
@@ -42,7 +42,7 @@ ___
 
 **● statusMessage**: *`string`*
 
-*Defined in [config/interfaces.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L6)*
+*Defined in [config/interfaces.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L6)*
 
 ___
 

--- a/docs/interfaces/_config_interfaces_.iusercredentials.md
+++ b/docs/interfaces/_config_interfaces_.iusercredentials.md
@@ -23,7 +23,7 @@
 
 **● password**: *`string`*
 
-*Defined in [config/interfaces.ts:31](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L31)*
+*Defined in [config/interfaces.ts:31](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L31)*
 
 ___
 <a id="username"></a>
@@ -32,7 +32,7 @@ ___
 
 **● username**: *`string`*
 
-*Defined in [config/interfaces.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L30)*
+*Defined in [config/interfaces.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L30)*
 
 ___
 

--- a/docs/interfaces/_manage_device_.ideviceinitconfig.md
+++ b/docs/interfaces/_manage_device_.ideviceinitconfig.md
@@ -24,7 +24,7 @@
 
 **● deviceUrl**: *`string`*
 
-*Defined in [manage/device.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/manage/device.ts#L13)*
+*Defined in [manage/device.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/manage/device.ts#L13)*
 
 ___
 <a id="password"></a>
@@ -33,7 +33,7 @@ ___
 
 **● password**: *`undefined` \| `string`*
 
-*Defined in [manage/device.ts:15](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/manage/device.ts#L15)*
+*Defined in [manage/device.ts:15](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/manage/device.ts#L15)*
 
 ___
 <a id="username"></a>
@@ -42,7 +42,7 @@ ___
 
 **● username**: *`undefined` \| `string`*
 
-*Defined in [manage/device.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/manage/device.ts#L14)*
+*Defined in [manage/device.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/manage/device.ts#L14)*
 
 ___
 

--- a/docs/interfaces/_manage_device_.imanageddevice.md
+++ b/docs/interfaces/_manage_device_.imanageddevice.md
@@ -22,7 +22,7 @@
 
 **● api**: *[ManagedONVIFApi](../classes/_api_index_.managedonvifapi.md)*
 
-*Defined in [manage/device.ts:9](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/manage/device.ts#L9)*
+*Defined in [manage/device.ts:9](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/manage/device.ts#L9)*
 
 ONVIF standard API
 

--- a/docs/interfaces/_soap_auth_.idigestbag.md
+++ b/docs/interfaces/_soap_auth_.idigestbag.md
@@ -25,7 +25,7 @@
 
 **● dateIsoString**: *`string`*
 
-*Defined in [soap/auth.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L5)*
+*Defined in [soap/auth.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L5)*
 
 ___
 <a id="digest64"></a>
@@ -34,7 +34,7 @@ ___
 
 **● digest64**: *`string`*
 
-*Defined in [soap/auth.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L7)*
+*Defined in [soap/auth.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L7)*
 
 ___
 <a id="noncebase64"></a>
@@ -43,7 +43,7 @@ ___
 
 **● nonceBase64**: *`string`*
 
-*Defined in [soap/auth.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L6)*
+*Defined in [soap/auth.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L6)*
 
 ___
 <a id="username"></a>
@@ -52,7 +52,7 @@ ___
 
 **● username**: *`string`*
 
-*Defined in [soap/auth.ts:8](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L8)*
+*Defined in [soap/auth.ts:8](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L8)*
 
 ___
 

--- a/docs/interfaces/_soap_auth_.iusercredentials.md
+++ b/docs/interfaces/_soap_auth_.iusercredentials.md
@@ -23,7 +23,7 @@
 
 **● password**: *`string`*
 
-*Defined in [soap/auth.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L13)*
+*Defined in [soap/auth.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L13)*
 
 ___
 <a id="username"></a>
@@ -32,7 +32,7 @@ ___
 
 **● username**: *`string`*
 
-*Defined in [soap/auth.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L12)*
+*Defined in [soap/auth.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L12)*
 
 ___
 

--- a/docs/interfaces/_soap_request_.itransportpayloadxml.md
+++ b/docs/interfaces/_soap_request_.itransportpayloadxml.md
@@ -24,7 +24,7 @@
 
 **● body**: *`Document`*
 
-*Defined in [soap/request.ts:45](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L45)*
+*Defined in [soap/request.ts:45](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L45)*
 
 ___
 <a id="status"></a>
@@ -33,7 +33,7 @@ ___
 
 **● status**: *`number`*
 
-*Defined in [soap/request.ts:47](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L47)*
+*Defined in [soap/request.ts:47](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L47)*
 
 ___
 <a id="statusmessage"></a>
@@ -42,7 +42,7 @@ ___
 
 **● statusMessage**: *`string`*
 
-*Defined in [soap/request.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L46)*
+*Defined in [soap/request.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L46)*
 
 ___
 

--- a/docs/modules/_api_advancedsecurity_.md
+++ b/docs/modules/_api_advancedsecurity_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [AdvancedSecurity](../classes/_api_advancedsecurity_.advancedsecurity.md)
+* [ONVIFAdvancedSecurity](../classes/_api_advancedsecurity_.onvifadvancedsecurity.md)
 
 ---
 

--- a/docs/modules/_api_analytics_.md
+++ b/docs/modules/_api_analytics_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Analytics](../classes/_api_analytics_.analytics.md)
+* [ONVIFAnalytics](../classes/_api_analytics_.onvifanalytics.md)
 
 ---
 

--- a/docs/modules/_api_device_.md
+++ b/docs/modules/_api_device_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Device](../classes/_api_device_.device.md)
+* [ONVIFDevice](../classes/_api_device_.onvifdevice.md)
 
 ---
 

--- a/docs/modules/_api_display_.md
+++ b/docs/modules/_api_display_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Display](../classes/_api_display_.display.md)
+* [ONVIFDisplay](../classes/_api_display_.onvifdisplay.md)
 
 ---
 

--- a/docs/modules/_api_imaging_.md
+++ b/docs/modules/_api_imaging_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Imaging](../classes/_api_imaging_.imaging.md)
+* [ONVIFImaging](../classes/_api_imaging_.onvifimaging.md)
 
 ---
 

--- a/docs/modules/_api_media_.md
+++ b/docs/modules/_api_media_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Media](../classes/_api_media_.media.md)
+* [ONVIFMedia](../classes/_api_media_.onvifmedia.md)
 
 ---
 

--- a/docs/modules/_api_provisioning_.md
+++ b/docs/modules/_api_provisioning_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Provisioning](../classes/_api_provisioning_.provisioning.md)
+* [ONVIFProvisioning](../classes/_api_provisioning_.onvifprovisioning.md)
 
 ---
 

--- a/docs/modules/_api_ptz_.md
+++ b/docs/modules/_api_ptz_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [PTZ](../classes/_api_ptz_.ptz.md)
+* [ONVIFPTZ](../classes/_api_ptz_.onvifptz.md)
 
 ---
 

--- a/docs/modules/_api_receiver_.md
+++ b/docs/modules/_api_receiver_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Receiver](../classes/_api_receiver_.receiver.md)
+* [ONVIFReceiver](../classes/_api_receiver_.onvifreceiver.md)
 
 ---
 

--- a/docs/modules/_api_recording_.md
+++ b/docs/modules/_api_recording_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Recording](../classes/_api_recording_.recording.md)
+* [ONVIFRecording](../classes/_api_recording_.onvifrecording.md)
 
 ---
 

--- a/docs/modules/_api_replay_.md
+++ b/docs/modules/_api_replay_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Replay](../classes/_api_replay_.replay.md)
+* [ONVIFReplay](../classes/_api_replay_.onvifreplay.md)
 
 ---
 

--- a/docs/modules/_api_search_.md
+++ b/docs/modules/_api_search_.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-* [Search](../classes/_api_search_.search.md)
+* [ONVIFSearch](../classes/_api_search_.onvifsearch.md)
 
 ---
 

--- a/docs/modules/_api_types_.md
+++ b/docs/modules/_api_types_.md
@@ -583,7 +583,7 @@
 
 **Ƭ AudioClassType**: *`string`*
 
-*Defined in [api/types.ts:113](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L113)*
+*Defined in [api/types.ts:113](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L113)*
 
 ```
       AudioClassType acceptable values are;
@@ -597,7 +597,7 @@ ___
 
 **Ƭ AuxiliaryData**: *`string`*
 
-*Defined in [api/types.ts:66](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L66)*
+*Defined in [api/types.ts:66](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L66)*
 
 ___
 <a id="dnsname"></a>
@@ -606,7 +606,7 @@ ___
 
 **Ƭ DNSName**: *`string`*
 
-*Defined in [api/types.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L46)*
+*Defined in [api/types.ts:46](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L46)*
 
 ___
 <a id="description"></a>
@@ -615,7 +615,7 @@ ___
 
 **Ƭ Description**: *`string`*
 
-*Defined in [api/types.ts:86](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L86)*
+*Defined in [api/types.ts:86](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L86)*
 
 ___
 <a id="domain"></a>
@@ -624,7 +624,7 @@ ___
 
 **Ƭ Domain**: *`string`*
 
-*Defined in [api/types.ts:50](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L50)*
+*Defined in [api/types.ts:50](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L50)*
 
 ___
 <a id="dot11psk"></a>
@@ -633,7 +633,7 @@ ___
 
 **Ƭ Dot11PSK**: *`string`*
 
-*Defined in [api/types.ts:58](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L58)*
+*Defined in [api/types.ts:58](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L58)*
 
 ___
 <a id="dot11pskpassphrase"></a>
@@ -642,7 +642,7 @@ ___
 
 **Ƭ Dot11PSKPassphrase**: *`string`*
 
-*Defined in [api/types.ts:62](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L62)*
+*Defined in [api/types.ts:62](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L62)*
 
 ___
 <a id="dot11ssidtype"></a>
@@ -651,7 +651,7 @@ ___
 
 **Ƭ Dot11SSIDType**: *`string`*
 
-*Defined in [api/types.ts:54](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L54)*
+*Defined in [api/types.ts:54](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L54)*
 
 ___
 <a id="floatattrlist"></a>
@@ -660,7 +660,7 @@ ___
 
 **Ƭ FloatAttrList**: *`ReadonlyArray`<`number`>*
 
-*Defined in [api/types.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L18)*
+*Defined in [api/types.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L18)*
 
 ___
 <a id="hwaddress"></a>
@@ -669,7 +669,7 @@ ___
 
 **Ƭ HwAddress**: *`string`*
 
-*Defined in [api/types.ts:42](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L42)*
+*Defined in [api/types.ts:42](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L42)*
 
 ___
 <a id="ipv4address"></a>
@@ -678,7 +678,7 @@ ___
 
 **Ƭ IPv4Address**: *`string`*
 
-*Defined in [api/types.ts:34](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L34)*
+*Defined in [api/types.ts:34](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L34)*
 
 ___
 <a id="ipv6address"></a>
@@ -687,7 +687,7 @@ ___
 
 **Ƭ IPv6Address**: *`string`*
 
-*Defined in [api/types.ts:38](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L38)*
+*Defined in [api/types.ts:38](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L38)*
 
 ___
 <a id="intattrlist"></a>
@@ -696,7 +696,7 @@ ___
 
 **Ƭ IntAttrList**: *`ReadonlyArray`<`number`>*
 
-*Defined in [api/types.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L14)*
+*Defined in [api/types.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L14)*
 
 ___
 <a id="jobtoken"></a>
@@ -705,7 +705,7 @@ ___
 
 **Ƭ JobToken**: *[ReferenceToken](_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:94](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L94)*
+*Defined in [api/types.ts:94](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L94)*
 
 ___
 <a id="name"></a>
@@ -714,7 +714,7 @@ ___
 
 **Ƭ Name**: *`string`*
 
-*Defined in [api/types.ts:10](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L10)*
+*Defined in [api/types.ts:10](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L10)*
 
 User readable name. Length up to 64 characters.
 
@@ -725,7 +725,7 @@ ___
 
 **Ƭ NetworkInterfaceConfigPriority**: *`number`*
 
-*Defined in [api/types.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L30)*
+*Defined in [api/types.ts:30](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L30)*
 
 ___
 <a id="receiverreference"></a>
@@ -734,7 +734,7 @@ ___
 
 **Ƭ ReceiverReference**: *[ReferenceToken](_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:74](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L74)*
+*Defined in [api/types.ts:74](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L74)*
 
 ___
 <a id="recordingjobmode"></a>
@@ -743,7 +743,7 @@ ___
 
 **Ƭ RecordingJobMode**: *`string`*
 
-*Defined in [api/types.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L102)*
+*Defined in [api/types.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L102)*
 
 ___
 <a id="recordingjobreference"></a>
@@ -752,7 +752,7 @@ ___
 
 **Ƭ RecordingJobReference**: *[ReferenceToken](_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:98](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L98)*
+*Defined in [api/types.ts:98](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L98)*
 
 ___
 <a id="recordingjobstate"></a>
@@ -761,7 +761,7 @@ ___
 
 **Ƭ RecordingJobState**: *`string`*
 
-*Defined in [api/types.ts:106](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L106)*
+*Defined in [api/types.ts:106](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L106)*
 
 ___
 <a id="recordingreference"></a>
@@ -770,7 +770,7 @@ ___
 
 **Ƭ RecordingReference**: *[ReferenceToken](_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:78](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L78)*
+*Defined in [api/types.ts:78](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L78)*
 
 ___
 <a id="referencetoken"></a>
@@ -779,7 +779,7 @@ ___
 
 **Ƭ ReferenceToken**: *`string`*
 
-*Defined in [api/types.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L6)*
+*Defined in [api/types.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L6)*
 
 Unique identifier for a physical or logical resource. Tokens should be assigned such that they are unique within a device. Tokens must be at least unique within its class. Length up to 64 characters.
 
@@ -790,7 +790,7 @@ ___
 
 **Ƭ ReferenceTokenList**: *`ReadonlyArray`<[ReferenceToken](_api_types_.md#referencetoken)>*
 
-*Defined in [api/types.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L26)*
+*Defined in [api/types.ts:26](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L26)*
 
 ___
 <a id="stringattrlist"></a>
@@ -799,7 +799,7 @@ ___
 
 **Ƭ StringAttrList**: *`ReadonlyArray`<`string`>*
 
-*Defined in [api/types.ts:22](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L22)*
+*Defined in [api/types.ts:22](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L22)*
 
 ___
 <a id="topicnamespacelocation"></a>
@@ -808,7 +808,7 @@ ___
 
 **Ƭ TopicNamespaceLocation**: *`string`*
 
-*Defined in [api/types.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L70)*
+*Defined in [api/types.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L70)*
 
 ___
 <a id="trackreference"></a>
@@ -817,7 +817,7 @@ ___
 
 **Ƭ TrackReference**: *[ReferenceToken](_api_types_.md#referencetoken)*
 
-*Defined in [api/types.ts:82](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L82)*
+*Defined in [api/types.ts:82](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L82)*
 
 ___
 <a id="xpathexpression"></a>
@@ -826,7 +826,7 @@ ___
 
 **Ƭ XPathExpression**: *`string`*
 
-*Defined in [api/types.ts:90](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L90)*
+*Defined in [api/types.ts:90](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L90)*
 
 ___
 <a id="encodingstyle"></a>
@@ -835,7 +835,7 @@ ___
 
 **Ƭ encodingStyle**: *`ReadonlyArray`<`string`>*
 
-*Defined in [api/types.ts:119](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/api/types.ts#L119)*
+*Defined in [api/types.ts:119](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/api/types.ts#L119)*
 
 ```
     'encodingStyle' indicates any canonicalization conventions followed in the contents of the containing element.  For example, the value 'http://schemas.xmlsoap.org/soap/encoding/' indicates the pattern described in SOAP specification

--- a/docs/modules/_browser_.md
+++ b/docs/modules/_browser_.md
@@ -18,7 +18,7 @@
 
 ▸ **createManagedDeviceInBrowser**(config: *[IDeviceInitConfig](../interfaces/_manage_device_.ideviceinitconfig.md)*): [IManagedDevice](../interfaces/_manage_device_.imanageddevice.md)
 
-*Defined in [browser.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/browser.ts#L7)*
+*Defined in [browser.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/browser.ts#L7)*
 
 **Parameters:**
 

--- a/docs/modules/_config_browser_.md
+++ b/docs/modules/_config_browser_.md
@@ -22,7 +22,7 @@
 
 ▸ **transport**(body: *`string`*): `(Anonymous function)`
 
-*Defined in [config/browser.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/browser.ts#L5)*
+*Defined in [config/browser.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/browser.ts#L5)*
 
 **Parameters:**
 
@@ -42,7 +42,7 @@ ___
 
 **DEFAULT_BROWSER_ENV**: *`object`*
 
-*Defined in [config/browser.ts:10](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/browser.ts#L10)*
+*Defined in [config/browser.ts:10](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/browser.ts#L10)*
 
 <a id="default_browser_env.buffer"></a>
 
@@ -50,7 +50,7 @@ ___
 
 **● buffer**: *`object`* =  Buffer
 
-*Defined in [config/browser.ts:15](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/browser.ts#L15)*
+*Defined in [config/browser.ts:15](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/browser.ts#L15)*
 
 #### Type declaration
 
@@ -371,7 +371,7 @@ ___
 
 **● digestSha1**: *`function`*
 
-*Defined in [config/browser.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/browser.ts#L13)*
+*Defined in [config/browser.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/browser.ts#L13)*
 
 #### Type declaration
 ▸(str: *`string`*): `string`
@@ -391,7 +391,7 @@ ___
 
 **● nonce**: *`function`*
 
-*Defined in [config/browser.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/browser.ts#L12)*
+*Defined in [config/browser.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/browser.ts#L12)*
 
 #### Type declaration
 ▸(size?: *`undefined` \| `number`*): `string`
@@ -411,7 +411,7 @@ ___
 
 **● parser**: *`DOMParser`* =  typeof DOMParser !== 'undefined' ? new DOMParser() : {} as DOMParser
 
-*Defined in [config/browser.ts:11](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/browser.ts#L11)*
+*Defined in [config/browser.ts:11](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/browser.ts#L11)*
 
 ___
 <a id="default_browser_env.transport-1"></a>
@@ -420,7 +420,7 @@ ___
 
 **● transport**: *[transport]()*
 
-*Defined in [config/browser.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/browser.ts#L14)*
+*Defined in [config/browser.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/browser.ts#L14)*
 
 ___
 

--- a/docs/modules/_config_interfaces_.md
+++ b/docs/modules/_config_interfaces_.md
@@ -28,7 +28,7 @@
 
 **Ƭ IEncodeBase64**: *`function`*
 
-*Defined in [config/interfaces.ts:11](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L11)*
+*Defined in [config/interfaces.ts:11](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L11)*
 
 #### Type declaration
 ▸(str: *`string`*): `string`
@@ -48,7 +48,7 @@ ___
 
 **Ƭ INonce**: *`function`*
 
-*Defined in [config/interfaces.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L13)*
+*Defined in [config/interfaces.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L13)*
 
 #### Type declaration
 ▸(size?: *`undefined` \| `number`*): `string`
@@ -68,7 +68,7 @@ ___
 
 **Ƭ ISha1Digest**: *`function`*
 
-*Defined in [config/interfaces.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L12)*
+*Defined in [config/interfaces.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L12)*
 
 #### Type declaration
 ▸(str: *`string`*): `string`
@@ -88,7 +88,7 @@ ___
 
 **Ƭ ITransport**: *`function`*
 
-*Defined in [config/interfaces.ts:9](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/interfaces.ts#L9)*
+*Defined in [config/interfaces.ts:9](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/interfaces.ts#L9)*
 
 #### Type declaration
 ▸(body: *`string`*): `function`

--- a/docs/modules/_config_node_.md
+++ b/docs/modules/_config_node_.md
@@ -26,7 +26,7 @@
 
 **● parser**: *`DOMParser`* =  new DOMParser()
 
-*Defined in [config/node.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/node.ts#L6)*
+*Defined in [config/node.ts:6](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/node.ts#L6)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 ▸ **transport**(body: *`string`*): `(Anonymous function)`
 
-*Defined in [config/node.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/node.ts#L7)*
+*Defined in [config/node.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/node.ts#L7)*
 
 **Parameters:**
 
@@ -58,7 +58,7 @@ ___
 
 **DEFAULT_NODE_ENV**: *`object`*
 
-*Defined in [config/node.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/node.ts#L12)*
+*Defined in [config/node.ts:12](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/node.ts#L12)*
 
 <a id="default_node_env.buffer"></a>
 
@@ -66,7 +66,7 @@ ___
 
 **● buffer**: *`object`* =  Buffer
 
-*Defined in [config/node.ts:17](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/node.ts#L17)*
+*Defined in [config/node.ts:17](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/node.ts#L17)*
 
 #### Type declaration
 
@@ -387,7 +387,7 @@ ___
 
 **● digestSha1**: *`function`*
 
-*Defined in [config/node.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/node.ts#L16)*
+*Defined in [config/node.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/node.ts#L16)*
 
 #### Type declaration
 ▸(str: *`string`*): `string`
@@ -407,7 +407,7 @@ ___
 
 **● nonce**: *`function`*
 
-*Defined in [config/node.ts:15](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/node.ts#L15)*
+*Defined in [config/node.ts:15](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/node.ts#L15)*
 
 #### Type declaration
 ▸(size?: *`undefined` \| `number`*): `string`
@@ -427,7 +427,7 @@ ___
 
 **● parser**: *`DOMParser`*
 
-*Defined in [config/node.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/node.ts#L13)*
+*Defined in [config/node.ts:13](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/node.ts#L13)*
 
 ___
 <a id="default_node_env.transport-1"></a>
@@ -436,7 +436,7 @@ ___
 
 **● transport**: *[transport]()*
 
-*Defined in [config/node.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/node.ts#L14)*
+*Defined in [config/node.ts:14](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/node.ts#L14)*
 
 ___
 

--- a/docs/modules/_config_universal_.md
+++ b/docs/modules/_config_universal_.md
@@ -28,7 +28,7 @@
 
 **● digestSha1**: *[ISha1Digest](_config_interfaces_.md#isha1digest)* =  require('js-sha1').digest
 
-*Defined in [config/universal.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/universal.ts#L5)*
+*Defined in [config/universal.ts:5](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/universal.ts#L5)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 ▸ **FETCH_CONFIG**(body: *`string`*): `object`
 
-*Defined in [config/universal.ts:8](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/universal.ts#L8)*
+*Defined in [config/universal.ts:8](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/universal.ts#L8)*
 
 **Parameters:**
 
@@ -57,7 +57,7 @@ ___
 
 ▸ **nonce**(size?: *`undefined` \| `number`*): `string`
 
-*Defined in [config/universal.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/universal.ts#L21)*
+*Defined in [config/universal.ts:21](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/universal.ts#L21)*
 
 **Parameters:**
 
@@ -74,7 +74,7 @@ ___
 
 ▸ **sharedFetchWrapper**(fetchResponse: *`Promise`<`any`>*): `Observable`<[ITransportPayoad](../interfaces/_config_interfaces_.itransportpayoad.md)>
 
-*Defined in [config/universal.ts:10](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/universal.ts#L10)*
+*Defined in [config/universal.ts:10](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/universal.ts#L10)*
 
 **Parameters:**
 
@@ -94,7 +94,7 @@ ___
 
 **REQUEST_HEADERS**: *`object`*
 
-*Defined in [config/universal.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/universal.ts#L7)*
+*Defined in [config/universal.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/universal.ts#L7)*
 
 <a id="request_headers.content_type"></a>
 
@@ -102,7 +102,7 @@ ___
 
 **● Content-Type**: *`string`* = "application/soap+xml; charset=utf-8;"
 
-*Defined in [config/universal.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/config/universal.ts#L7)*
+*Defined in [config/universal.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/config/universal.ts#L7)*
 
 ___
 

--- a/docs/modules/_manage_device_.md
+++ b/docs/modules/_manage_device_.md
@@ -23,7 +23,7 @@
 
 ▸ **createManagedDevice**(config: *[IDeviceInitConfig](../interfaces/_manage_device_.ideviceinitconfig.md)*): `IReader`<[ISystemConfig](../interfaces/_config_interfaces_.isystemconfig.md), [IManagedDevice](../interfaces/_manage_device_.imanageddevice.md)>
 
-*Defined in [manage/device.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/manage/device.ts#L18)*
+*Defined in [manage/device.ts:18](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/manage/device.ts#L18)*
 
 **Parameters:**
 

--- a/docs/modules/_node_.md
+++ b/docs/modules/_node_.md
@@ -18,7 +18,7 @@
 
 ▸ **createManagedDeviceInNode**(config: *[IDeviceInitConfig](../interfaces/_manage_device_.ideviceinitconfig.md)*): [IManagedDevice](../interfaces/_manage_device_.imanageddevice.md)
 
-*Defined in [node.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/node.ts#L7)*
+*Defined in [node.ts:7](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/node.ts#L7)*
 
 **Parameters:**
 

--- a/docs/modules/_soap_auth_.md
+++ b/docs/modules/_soap_auth_.md
@@ -28,7 +28,7 @@
 
 ▸ **createUserToken**(timeDifference?: *`number`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `IMaybe`<`string`>>
 
-*Defined in [soap/auth.ts:42](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L42)*
+*Defined in [soap/auth.ts:42](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L42)*
 
 **Parameters:**
 
@@ -45,7 +45,7 @@ ___
 
 ▸ **onvifDigest**(dateIsoString: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `IMaybe`<[IDigestBag](../interfaces/_soap_auth_.idigestbag.md)>>
 
-*Defined in [soap/auth.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L16)*
+*Defined in [soap/auth.ts:16](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L16)*
 
 **Parameters:**
 
@@ -65,7 +65,7 @@ ___
 
 **TOKENS**: *`object`*
 
-*Defined in [soap/auth.ts:33](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L33)*
+*Defined in [soap/auth.ts:33](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L33)*
 
 <a id="tokens.cr"></a>
 
@@ -73,7 +73,7 @@ ___
 
 **● cr**: *`string`* = "wsu:Created"
 
-*Defined in [soap/auth.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L39)*
+*Defined in [soap/auth.ts:39](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L39)*
 
 ___
 <a id="tokens.nc"></a>
@@ -82,7 +82,7 @@ ___
 
 **● nc**: *`string`* = "wsse:Nonce"
 
-*Defined in [soap/auth.ts:38](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L38)*
+*Defined in [soap/auth.ts:38](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L38)*
 
 ___
 <a id="tokens.pw"></a>
@@ -91,7 +91,7 @@ ___
 
 **● pw**: *`string`* = "wsse:Password"
 
-*Defined in [soap/auth.ts:37](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L37)*
+*Defined in [soap/auth.ts:37](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L37)*
 
 ___
 <a id="tokens.s"></a>
@@ -100,7 +100,7 @@ ___
 
 **● s**: *`string`* = "wsse:Security"
 
-*Defined in [soap/auth.ts:34](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L34)*
+*Defined in [soap/auth.ts:34](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L34)*
 
 ___
 <a id="tokens.un"></a>
@@ -109,7 +109,7 @@ ___
 
 **● un**: *`string`* = "wsse:Username"
 
-*Defined in [soap/auth.ts:36](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L36)*
+*Defined in [soap/auth.ts:36](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L36)*
 
 ___
 <a id="tokens.unt"></a>
@@ -118,7 +118,7 @@ ___
 
 **● unt**: *`string`* = "wsse:UsernameToken"
 
-*Defined in [soap/auth.ts:35](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/auth.ts#L35)*
+*Defined in [soap/auth.ts:35](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/auth.ts#L35)*
 
 ___
 

--- a/docs/modules/_soap_request_.md
+++ b/docs/modules/_soap_request_.md
@@ -42,7 +42,7 @@
 
 **Ƭ IOnvifNetworkResponse**: *`Observable`<`IResult`<`T`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>*
 
-*Defined in [soap/request.ts:50](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L50)*
+*Defined in [soap/request.ts:50](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L50)*
 
 ___
 <a id="ionvifresult"></a>
@@ -51,7 +51,7 @@ ___
 
 **Ƭ IOnvifResult**: *`IResult`<`Document`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>*
 
-*Defined in [soap/request.ts:107](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L107)*
+*Defined in [soap/request.ts:107](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L107)*
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 ▸ **createDeviceRequestBodyFromString**(key: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`Document`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [soap/request.ts:142](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L142)*
+*Defined in [soap/request.ts:142](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L142)*
 
 **Parameters:**
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **createMediaRequestBodyFromString**(key: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`Document`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [soap/request.ts:146](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L146)*
+*Defined in [soap/request.ts:146](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L146)*
 
 **Parameters:**
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **createSimpleRequestBodyFromString**(key: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`Document`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [soap/request.ts:138](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L138)*
+*Defined in [soap/request.ts:138](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L138)*
 
 **Parameters:**
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **createStandardRequestBody**(body: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`Document`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [soap/request.ts:109](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L109)*
+*Defined in [soap/request.ts:109](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L109)*
 
 **Parameters:**
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **createStandardRequestBodyFromString**(body: *`string`*): `IReader`<[IDeviceConfig](../interfaces/_config_interfaces_.ideviceconfig.md), `Observable`<`IResult`<`Document`, [ITransportPayloadXml](../interfaces/_soap_request_.itransportpayloadxml.md)>>>
 
-*Defined in [soap/request.ts:134](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L134)*
+*Defined in [soap/request.ts:134](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L134)*
 
 **Parameters:**
 
@@ -148,7 +148,7 @@ ___
 
 ▸ **generateRequestElements**(reqNode: *`string`*): `(Anonymous function)`
 
-*Defined in [soap/request.ts:151](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L151)*
+*Defined in [soap/request.ts:151](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L151)*
 
 **Parameters:**
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **mapResponseObsToProperty**<`A`,`B`,`E`>(propSelectFn: *`function`*): `(Anonymous function)`
 
-*Defined in [soap/request.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L102)*
+*Defined in [soap/request.ts:102](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L102)*
 
 **Type parameters:**
 
@@ -187,7 +187,7 @@ ___
 
 ▸ **mapResponseXmlToJson**<`T`>(node: *`string`*): `(Anonymous function)`
 
-*Defined in [soap/request.ts:79](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L79)*
+*Defined in [soap/request.ts:79](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L79)*
 
 **Type parameters:**
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **nsstr**(): `string`[]
 
-*Defined in [soap/request.ts:68](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L68)*
+*Defined in [soap/request.ts:68](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L68)*
 
 **Returns:** `string`[]
 
@@ -218,7 +218,7 @@ ___
 
 ▸ **parseXml**(parser: *`DOMParser`*): `(Anonymous function)`
 
-*Defined in [soap/request.ts:52](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L52)*
+*Defined in [soap/request.ts:52](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L52)*
 
 **Parameters:**
 
@@ -235,7 +235,7 @@ ___
 
 ▸ **soapShell**(rawBody: *`string`*): `(Anonymous function)`
 
-*Defined in [soap/request.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/1596479/src/soap/request.ts#L70)*
+*Defined in [soap/request.ts:70](https://github.com/patrickmichalina/onvif-rx/blob/d62cee9/src/soap/request.ts#L70)*
 
 **Parameters:**
 

--- a/scripts/api/ast.ts
+++ b/scripts/api/ast.ts
@@ -1,4 +1,4 @@
-import { Project, Scope, FunctionLikeDeclaration, ParameterDeclarationStructure } from 'ts-simple-ast'
+import { Project, Scope, ParameterDeclarationStructure } from 'ts-simple-ast'
 import { generateActions, generateTypes } from './exec'
 
 // initialize
@@ -61,7 +61,7 @@ generateTypes()
         ...actionTree.map(grp => {
           return {
             moduleSpecifier: `./${grp.type.toLowerCase()}`,
-            namedImports: [{ name: grp.type }]
+            namedImports: [{ name: `ONVIF${grp.type}` }]
           }
         }),
         {
@@ -77,7 +77,7 @@ generateTypes()
           return {
             name: group.type,
             scope: Scope.Public,
-            initializer: `new ${group.type}(this.config)`
+            initializer: `new ONVIF${group.type}(this.config)`
           }
         })
       }]
@@ -107,7 +107,7 @@ generateTypes()
         }],
         classes: [{
           isExported: true,
-          name: group.type,
+          name: `ONVIF${group.type}`,
           ctors: [{
             parameters: [{ name: 'config', type: 'IDeviceConfig', scope: Scope.Private }]
           }],
@@ -133,7 +133,7 @@ generateTypes()
             return {
               docs: [{ description: action.documentation.replace(/\*/g, '') }],
               name: action.actionName,
-              bodyText: `return ${group.type}.${action.actionName}(${action.input.parameters.map(a => a.name).join(',')}).run(this.config)`,
+              bodyText: `return ONVIF${group.type}.${action.actionName}(${action.input.parameters.map(a => a.name).join(',')}).run(this.config)`,
               parameters: action.input.parameters.map(p => {
                 return {
                   name: p.name,

--- a/src/api/advancedsecurity.ts
+++ b/src/api/advancedsecurity.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import "./types";
 
-export class AdvancedSecurity {
+export class ONVIFAdvancedSecurity {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -719,7 +719,7 @@ export class AdvancedSecurity {
      * Returns the capabilities of the security configuraiton service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return AdvancedSecurity.GetServiceCapabilities().run(this.config)
+        return ONVIFAdvancedSecurity.GetServiceCapabilities().run(this.config)
     }
 
     /**
@@ -737,7 +737,7 @@ export class AdvancedSecurity {
      *   
      */
     CreateRSAKeyPair() {
-        return AdvancedSecurity.CreateRSAKeyPair().run(this.config)
+        return ONVIFAdvancedSecurity.CreateRSAKeyPair().run(this.config)
     }
 
     /**
@@ -750,7 +750,7 @@ export class AdvancedSecurity {
      *         
      */
     UploadKeyPairInPKCS8() {
-        return AdvancedSecurity.UploadKeyPairInPKCS8().run(this.config)
+        return ONVIFAdvancedSecurity.UploadKeyPairInPKCS8().run(this.config)
     }
 
     /**
@@ -772,7 +772,7 @@ export class AdvancedSecurity {
      *         
      */
     UploadCertificateWithPrivateKeyInPKCS12() {
-        return AdvancedSecurity.UploadCertificateWithPrivateKeyInPKCS12().run(this.config)
+        return ONVIFAdvancedSecurity.UploadCertificateWithPrivateKeyInPKCS12().run(this.config)
     }
 
     /**
@@ -783,7 +783,7 @@ export class AdvancedSecurity {
      *   
      */
     GetKeyStatus() {
-        return AdvancedSecurity.GetKeyStatus().run(this.config)
+        return ONVIFAdvancedSecurity.GetKeyStatus().run(this.config)
     }
 
     /**
@@ -795,7 +795,7 @@ export class AdvancedSecurity {
      *   
      */
     GetPrivateKeyStatus() {
-        return AdvancedSecurity.GetPrivateKeyStatus().run(this.config)
+        return ONVIFAdvancedSecurity.GetPrivateKeyStatus().run(this.config)
     }
 
     /**
@@ -806,7 +806,7 @@ export class AdvancedSecurity {
      *   
      */
     GetAllKeys() {
-        return AdvancedSecurity.GetAllKeys().run(this.config)
+        return ONVIFAdvancedSecurity.GetAllKeys().run(this.config)
     }
 
     /**
@@ -820,7 +820,7 @@ export class AdvancedSecurity {
      *   
      */
     DeleteKey() {
-        return AdvancedSecurity.DeleteKey().run(this.config)
+        return ONVIFAdvancedSecurity.DeleteKey().run(this.config)
     }
 
     /**
@@ -840,7 +840,7 @@ export class AdvancedSecurity {
      *   
      */
     CreatePKCS10CSR() {
-        return AdvancedSecurity.CreatePKCS10CSR().run(this.config)
+        return ONVIFAdvancedSecurity.CreatePKCS10CSR().run(this.config)
     }
 
     /**
@@ -863,7 +863,7 @@ export class AdvancedSecurity {
      *   
      */
     CreateSelfSignedCertificate() {
-        return AdvancedSecurity.CreateSelfSignedCertificate().run(this.config)
+        return ONVIFAdvancedSecurity.CreateSelfSignedCertificate().run(this.config)
     }
 
     /**
@@ -900,7 +900,7 @@ export class AdvancedSecurity {
      *   
      */
     UploadCertificate() {
-        return AdvancedSecurity.UploadCertificate().run(this.config)
+        return ONVIFAdvancedSecurity.UploadCertificate().run(this.config)
     }
 
     /**
@@ -911,7 +911,7 @@ export class AdvancedSecurity {
      *   
      */
     GetCertificate() {
-        return AdvancedSecurity.GetCertificate().run(this.config)
+        return ONVIFAdvancedSecurity.GetCertificate().run(this.config)
     }
 
     /**
@@ -922,7 +922,7 @@ export class AdvancedSecurity {
      *   
      */
     GetAllCertificates() {
-        return AdvancedSecurity.GetAllCertificates().run(this.config)
+        return ONVIFAdvancedSecurity.GetAllCertificates().run(this.config)
     }
 
     /**
@@ -936,7 +936,7 @@ export class AdvancedSecurity {
      *   
      */
     DeleteCertificate() {
-        return AdvancedSecurity.DeleteCertificate().run(this.config)
+        return ONVIFAdvancedSecurity.DeleteCertificate().run(this.config)
     }
 
     /**
@@ -953,7 +953,7 @@ export class AdvancedSecurity {
      *   
      */
     CreateCertificationPath() {
-        return AdvancedSecurity.CreateCertificationPath().run(this.config)
+        return ONVIFAdvancedSecurity.CreateCertificationPath().run(this.config)
     }
 
     /**
@@ -964,7 +964,7 @@ export class AdvancedSecurity {
      *   
      */
     GetCertificationPath() {
-        return AdvancedSecurity.GetCertificationPath().run(this.config)
+        return ONVIFAdvancedSecurity.GetCertificationPath().run(this.config)
     }
 
     /**
@@ -975,7 +975,7 @@ export class AdvancedSecurity {
      *   
      */
     GetAllCertificationPaths() {
-        return AdvancedSecurity.GetAllCertificationPaths().run(this.config)
+        return ONVIFAdvancedSecurity.GetAllCertificationPaths().run(this.config)
     }
 
     /**
@@ -991,7 +991,7 @@ export class AdvancedSecurity {
      *   
      */
     DeleteCertificationPath() {
-        return AdvancedSecurity.DeleteCertificationPath().run(this.config)
+        return ONVIFAdvancedSecurity.DeleteCertificationPath().run(this.config)
     }
 
     /**
@@ -1000,7 +1000,7 @@ export class AdvancedSecurity {
      *         
      */
     UploadPassphrase() {
-        return AdvancedSecurity.UploadPassphrase().run(this.config)
+        return ONVIFAdvancedSecurity.UploadPassphrase().run(this.config)
     }
 
     /**
@@ -1011,7 +1011,7 @@ export class AdvancedSecurity {
      *         
      */
     GetAllPassphrases() {
-        return AdvancedSecurity.GetAllPassphrases().run(this.config)
+        return ONVIFAdvancedSecurity.GetAllPassphrases().run(this.config)
     }
 
     /**
@@ -1020,7 +1020,7 @@ export class AdvancedSecurity {
      *         
      */
     DeletePassphrase() {
-        return AdvancedSecurity.DeletePassphrase().run(this.config)
+        return ONVIFAdvancedSecurity.DeletePassphrase().run(this.config)
     }
 
     /**
@@ -1032,7 +1032,7 @@ export class AdvancedSecurity {
      *         
      */
     UploadCRL() {
-        return AdvancedSecurity.UploadCRL().run(this.config)
+        return ONVIFAdvancedSecurity.UploadCRL().run(this.config)
     }
 
     /**
@@ -1042,7 +1042,7 @@ export class AdvancedSecurity {
      *         
      */
     GetCRL() {
-        return AdvancedSecurity.GetCRL().run(this.config)
+        return ONVIFAdvancedSecurity.GetCRL().run(this.config)
     }
 
     /**
@@ -1052,7 +1052,7 @@ export class AdvancedSecurity {
      *         
      */
     GetAllCRLs() {
-        return AdvancedSecurity.GetAllCRLs().run(this.config)
+        return ONVIFAdvancedSecurity.GetAllCRLs().run(this.config)
     }
 
     /**
@@ -1064,7 +1064,7 @@ export class AdvancedSecurity {
      *         
      */
     DeleteCRL() {
-        return AdvancedSecurity.DeleteCRL().run(this.config)
+        return ONVIFAdvancedSecurity.DeleteCRL().run(this.config)
     }
 
     /**
@@ -1078,7 +1078,7 @@ export class AdvancedSecurity {
      *         
      */
     CreateCertPathValidationPolicy() {
-        return AdvancedSecurity.CreateCertPathValidationPolicy().run(this.config)
+        return ONVIFAdvancedSecurity.CreateCertPathValidationPolicy().run(this.config)
     }
 
     /**
@@ -1088,7 +1088,7 @@ export class AdvancedSecurity {
      *         
      */
     GetCertPathValidationPolicy() {
-        return AdvancedSecurity.GetCertPathValidationPolicy().run(this.config)
+        return ONVIFAdvancedSecurity.GetCertPathValidationPolicy().run(this.config)
     }
 
     /**
@@ -1098,7 +1098,7 @@ export class AdvancedSecurity {
      *         
      */
     GetAllCertPathValidationPolicies() {
-        return AdvancedSecurity.GetAllCertPathValidationPolicies().run(this.config)
+        return ONVIFAdvancedSecurity.GetAllCertPathValidationPolicies().run(this.config)
     }
 
     /**
@@ -1110,7 +1110,7 @@ export class AdvancedSecurity {
      *         
      */
     DeleteCertPathValidationPolicy() {
-        return AdvancedSecurity.DeleteCertPathValidationPolicy().run(this.config)
+        return ONVIFAdvancedSecurity.DeleteCertPathValidationPolicy().run(this.config)
     }
 
     /**
@@ -1133,7 +1133,7 @@ export class AdvancedSecurity {
      *   
      */
     AddServerCertificateAssignment() {
-        return AdvancedSecurity.AddServerCertificateAssignment().run(this.config)
+        return ONVIFAdvancedSecurity.AddServerCertificateAssignment().run(this.config)
     }
 
     /**
@@ -1143,7 +1143,7 @@ export class AdvancedSecurity {
      *   
      */
     RemoveServerCertificateAssignment() {
-        return AdvancedSecurity.RemoveServerCertificateAssignment().run(this.config)
+        return ONVIFAdvancedSecurity.RemoveServerCertificateAssignment().run(this.config)
     }
 
     /**
@@ -1167,7 +1167,7 @@ export class AdvancedSecurity {
      *   
      */
     ReplaceServerCertificateAssignment() {
-        return AdvancedSecurity.ReplaceServerCertificateAssignment().run(this.config)
+        return ONVIFAdvancedSecurity.ReplaceServerCertificateAssignment().run(this.config)
     }
 
     /**
@@ -1180,7 +1180,7 @@ export class AdvancedSecurity {
      *   
      */
     SetEnabledTLSVersions() {
-        return AdvancedSecurity.SetEnabledTLSVersions().run(this.config)
+        return ONVIFAdvancedSecurity.SetEnabledTLSVersions().run(this.config)
     }
 
     /**
@@ -1189,7 +1189,7 @@ export class AdvancedSecurity {
      *   
      */
     GetEnabledTLSVersions() {
-        return AdvancedSecurity.GetEnabledTLSVersions().run(this.config)
+        return ONVIFAdvancedSecurity.GetEnabledTLSVersions().run(this.config)
     }
 
     /**
@@ -1200,7 +1200,7 @@ export class AdvancedSecurity {
      *   
      */
     GetAssignedServerCertificates() {
-        return AdvancedSecurity.GetAssignedServerCertificates().run(this.config)
+        return ONVIFAdvancedSecurity.GetAssignedServerCertificates().run(this.config)
     }
 
     /**
@@ -1212,7 +1212,7 @@ export class AdvancedSecurity {
      *         
      */
     SetClientAuthenticationRequired() {
-        return AdvancedSecurity.SetClientAuthenticationRequired().run(this.config)
+        return ONVIFAdvancedSecurity.SetClientAuthenticationRequired().run(this.config)
     }
 
     /**
@@ -1221,7 +1221,7 @@ export class AdvancedSecurity {
      *         
      */
     GetClientAuthenticationRequired() {
-        return AdvancedSecurity.GetClientAuthenticationRequired().run(this.config)
+        return ONVIFAdvancedSecurity.GetClientAuthenticationRequired().run(this.config)
     }
 
     /**
@@ -1232,7 +1232,7 @@ export class AdvancedSecurity {
      *         
      */
     AddCertPathValidationPolicyAssignment() {
-        return AdvancedSecurity.AddCertPathValidationPolicyAssignment().run(this.config)
+        return ONVIFAdvancedSecurity.AddCertPathValidationPolicyAssignment().run(this.config)
     }
 
     /**
@@ -1242,7 +1242,7 @@ export class AdvancedSecurity {
      *         
      */
     RemoveCertPathValidationPolicyAssignment() {
-        return AdvancedSecurity.RemoveCertPathValidationPolicyAssignment().run(this.config)
+        return ONVIFAdvancedSecurity.RemoveCertPathValidationPolicyAssignment().run(this.config)
     }
 
     /**
@@ -1253,7 +1253,7 @@ export class AdvancedSecurity {
      *         
      */
     ReplaceCertPathValidationPolicyAssignment() {
-        return AdvancedSecurity.ReplaceCertPathValidationPolicyAssignment().run(this.config)
+        return ONVIFAdvancedSecurity.ReplaceCertPathValidationPolicyAssignment().run(this.config)
     }
 
     /**
@@ -1262,7 +1262,7 @@ export class AdvancedSecurity {
      *         
      */
     GetAssignedCertPathValidationPolicies() {
-        return AdvancedSecurity.GetAssignedCertPathValidationPolicies().run(this.config)
+        return ONVIFAdvancedSecurity.GetAssignedCertPathValidationPolicies().run(this.config)
     }
 
     /**
@@ -1271,7 +1271,7 @@ export class AdvancedSecurity {
      *   
      */
     AddDot1XConfiguration() {
-        return AdvancedSecurity.AddDot1XConfiguration().run(this.config)
+        return ONVIFAdvancedSecurity.AddDot1XConfiguration().run(this.config)
     }
 
     /**
@@ -1280,7 +1280,7 @@ export class AdvancedSecurity {
      *   
      */
     GetAllDot1XConfigurations() {
-        return AdvancedSecurity.GetAllDot1XConfigurations().run(this.config)
+        return ONVIFAdvancedSecurity.GetAllDot1XConfigurations().run(this.config)
     }
 
     /**
@@ -1289,7 +1289,7 @@ export class AdvancedSecurity {
      *   
      */
     GetDot1XConfiguration() {
-        return AdvancedSecurity.GetDot1XConfiguration().run(this.config)
+        return ONVIFAdvancedSecurity.GetDot1XConfiguration().run(this.config)
     }
 
     /**
@@ -1298,7 +1298,7 @@ export class AdvancedSecurity {
      *   
      */
     DeleteDot1XConfiguration() {
-        return AdvancedSecurity.DeleteDot1XConfiguration().run(this.config)
+        return ONVIFAdvancedSecurity.DeleteDot1XConfiguration().run(this.config)
     }
 
     /**
@@ -1307,7 +1307,7 @@ export class AdvancedSecurity {
      *   
      */
     SetNetworkInterfaceDot1XConfiguration() {
-        return AdvancedSecurity.SetNetworkInterfaceDot1XConfiguration().run(this.config)
+        return ONVIFAdvancedSecurity.SetNetworkInterfaceDot1XConfiguration().run(this.config)
     }
 
     /**
@@ -1316,7 +1316,7 @@ export class AdvancedSecurity {
      *   
      */
     GetNetworkInterfaceDot1XConfiguration() {
-        return AdvancedSecurity.GetNetworkInterfaceDot1XConfiguration().run(this.config)
+        return ONVIFAdvancedSecurity.GetNetworkInterfaceDot1XConfiguration().run(this.config)
     }
 
     /**
@@ -1325,6 +1325,6 @@ export class AdvancedSecurity {
      *   
      */
     DeleteNetworkInterfaceDot1XConfiguration() {
-        return AdvancedSecurity.DeleteNetworkInterfaceDot1XConfiguration().run(this.config)
+        return ONVIFAdvancedSecurity.DeleteNetworkInterfaceDot1XConfiguration().run(this.config)
     }
 }

--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { ReferenceToken, Config } from "./types";
 
-export class Analytics {
+export class ONVIFAnalytics {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -183,7 +183,7 @@ export class Analytics {
      *   
      */
     GetSupportedRules(ConfigurationToken: ReferenceToken) {
-        return Analytics.GetSupportedRules(ConfigurationToken).run(this.config)
+        return ONVIFAnalytics.GetSupportedRules(ConfigurationToken).run(this.config)
     }
 
     /**
@@ -200,7 +200,7 @@ export class Analytics {
      *   
      */
     CreateRules(ConfigurationToken: ReferenceToken, Rule: Config) {
-        return Analytics.CreateRules(ConfigurationToken,Rule).run(this.config)
+        return ONVIFAnalytics.CreateRules(ConfigurationToken,Rule).run(this.config)
     }
 
     /**
@@ -209,7 +209,7 @@ export class Analytics {
      *   
      */
     DeleteRules(ConfigurationToken: ReferenceToken, RuleName: string) {
-        return Analytics.DeleteRules(ConfigurationToken,RuleName).run(this.config)
+        return ONVIFAnalytics.DeleteRules(ConfigurationToken,RuleName).run(this.config)
     }
 
     /**
@@ -218,7 +218,7 @@ export class Analytics {
      *   
      */
     GetRules(ConfigurationToken: ReferenceToken) {
-        return Analytics.GetRules(ConfigurationToken).run(this.config)
+        return ONVIFAnalytics.GetRules(ConfigurationToken).run(this.config)
     }
 
     /**
@@ -227,7 +227,7 @@ export class Analytics {
      *   
      */
     GetRuleOptions(ConfigurationToken: ReferenceToken, RuleType: any) {
-        return Analytics.GetRuleOptions(ConfigurationToken,RuleType).run(this.config)
+        return ONVIFAnalytics.GetRuleOptions(ConfigurationToken,RuleType).run(this.config)
     }
 
     /**
@@ -236,14 +236,14 @@ export class Analytics {
      *   
      */
     ModifyRules(ConfigurationToken: ReferenceToken, Rule: Config) {
-        return Analytics.ModifyRules(ConfigurationToken,Rule).run(this.config)
+        return ONVIFAnalytics.ModifyRules(ConfigurationToken,Rule).run(this.config)
     }
 
     /**
      * Returns the capabilities of the analytics service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Analytics.GetServiceCapabilities().run(this.config)
+        return ONVIFAnalytics.GetServiceCapabilities().run(this.config)
     }
 
     /**
@@ -254,7 +254,7 @@ export class Analytics {
      *   
      */
     GetSupportedAnalyticsModules(ConfigurationToken: ReferenceToken) {
-        return Analytics.GetSupportedAnalyticsModules(ConfigurationToken).run(this.config)
+        return ONVIFAnalytics.GetSupportedAnalyticsModules(ConfigurationToken).run(this.config)
     }
 
     /**
@@ -263,7 +263,7 @@ export class Analytics {
      *   
      */
     GetAnalyticsModuleOptions(ConfigurationToken: ReferenceToken, Type: any) {
-        return Analytics.GetAnalyticsModuleOptions(ConfigurationToken,Type).run(this.config)
+        return ONVIFAnalytics.GetAnalyticsModuleOptions(ConfigurationToken,Type).run(this.config)
     }
 
     /**
@@ -287,7 +287,7 @@ export class Analytics {
      *   
      */
     CreateAnalyticsModules(ConfigurationToken: ReferenceToken, AnalyticsModule: Config) {
-        return Analytics.CreateAnalyticsModules(ConfigurationToken,AnalyticsModule).run(this.config)
+        return ONVIFAnalytics.CreateAnalyticsModules(ConfigurationToken,AnalyticsModule).run(this.config)
     }
 
     /**
@@ -296,7 +296,7 @@ export class Analytics {
      *   
      */
     DeleteAnalyticsModules(ConfigurationToken: ReferenceToken, AnalyticsModuleName: string) {
-        return Analytics.DeleteAnalyticsModules(ConfigurationToken,AnalyticsModuleName).run(this.config)
+        return ONVIFAnalytics.DeleteAnalyticsModules(ConfigurationToken,AnalyticsModuleName).run(this.config)
     }
 
     /**
@@ -305,7 +305,7 @@ export class Analytics {
      *   
      */
     GetAnalyticsModules(ConfigurationToken: ReferenceToken) {
-        return Analytics.GetAnalyticsModules(ConfigurationToken).run(this.config)
+        return ONVIFAnalytics.GetAnalyticsModules(ConfigurationToken).run(this.config)
     }
 
     /**
@@ -315,6 +315,6 @@ export class Analytics {
      *   
      */
     ModifyAnalyticsModules(ConfigurationToken: ReferenceToken, AnalyticsModule: Config) {
-        return Analytics.ModifyAnalyticsModules(ConfigurationToken,AnalyticsModule).run(this.config)
+        return ONVIFAnalytics.ModifyAnalyticsModules(ConfigurationToken,AnalyticsModule).run(this.config)
     }
 }

--- a/src/api/device.ts
+++ b/src/api/device.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { SetDateTimeType, TimeZone, DateTime, FactoryDefaultType, AttachmentData, BackupFile, SystemLogType, DiscoveryMode, NetworkHost, RemoteUser, User, CapabilityCategory, IPAddress, DynamicDNSType, DNSName, ReferenceToken, NetworkInterfaceSetConfiguration, NetworkProtocol, IPv4Address, IPv6Address, IPAddressFilter, BinaryData, CertificateStatus, Certificate, RelayOutputSettings, RelayLogicalState, AuxiliaryData, CertificateWithPrivateKey, Dot1XConfiguration, LocationEntity } from "./types";
 
-export class Device {
+export class ONVIFDevice {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -1124,21 +1124,21 @@ export class Device {
      * Returns information about services on the device.
      */
     GetServices(IncludeCapability: boolean) {
-        return Device.GetServices(IncludeCapability).run(this.config)
+        return ONVIFDevice.GetServices(IncludeCapability).run(this.config)
     }
 
     /**
      * Returns the capabilities of the device service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Device.GetServiceCapabilities().run(this.config)
+        return ONVIFDevice.GetServiceCapabilities().run(this.config)
     }
 
     /**
      * This operation gets basic device information from the device.
      */
     GetDeviceInformation() {
-        return Device.GetDeviceInformation().run(this.config)
+        return ONVIFDevice.GetDeviceInformation().run(this.config)
     }
 
     /**
@@ -1153,7 +1153,7 @@ export class Device {
      *   
      */
     SetSystemDateAndTime(DateTimeType: SetDateTimeType, DaylightSavings: boolean, TimeZone: TimeZone, UTCDateTime: DateTime) {
-        return Device.SetSystemDateAndTime(DateTimeType,DaylightSavings,TimeZone,UTCDateTime).run(this.config)
+        return ONVIFDevice.SetSystemDateAndTime(DateTimeType,DaylightSavings,TimeZone,UTCDateTime).run(this.config)
     }
 
     /**
@@ -1163,14 +1163,14 @@ export class Device {
      *   A device shall provide the UTCDateTime information.
      */
     GetSystemDateAndTime() {
-        return Device.GetSystemDateAndTime().run(this.config)
+        return ONVIFDevice.GetSystemDateAndTime().run(this.config)
     }
 
     /**
      * This operation reloads the parameters on the device to their factory default values.
      */
     SetSystemFactoryDefault(FactoryDefault: FactoryDefaultType) {
-        return Device.SetSystemFactoryDefault(FactoryDefault).run(this.config)
+        return ONVIFDevice.SetSystemFactoryDefault(FactoryDefault).run(this.config)
     }
 
     /**
@@ -1180,14 +1180,14 @@ export class Device {
      *   outside the scope of this standard.
      */
     UpgradeSystemFirmware(Firmware: AttachmentData) {
-        return Device.UpgradeSystemFirmware(Firmware).run(this.config)
+        return ONVIFDevice.UpgradeSystemFirmware(Firmware).run(this.config)
     }
 
     /**
      * This operation reboots the device.
      */
     SystemReboot() {
-        return Device.SystemReboot().run(this.config)
+        return ONVIFDevice.SystemReboot().run(this.config)
     }
 
     /**
@@ -1198,7 +1198,7 @@ export class Device {
      *   the GetSystemBackup command.
      */
     RestoreSystem(BackupFiles: BackupFile) {
-        return Device.RestoreSystem(BackupFiles).run(this.config)
+        return ONVIFDevice.RestoreSystem(BackupFiles).run(this.config)
     }
 
     /**
@@ -1208,21 +1208,21 @@ export class Device {
      *   The exact format of the backup configuration files is outside the scope of this standard.
      */
     GetSystemBackup() {
-        return Device.GetSystemBackup().run(this.config)
+        return ONVIFDevice.GetSystemBackup().run(this.config)
     }
 
     /**
      * This operation gets a system log from the device. The exact format of the system logs is outside the scope of this standard.
      */
     GetSystemLog(LogType: SystemLogType) {
-        return Device.GetSystemLog(LogType).run(this.config)
+        return ONVIFDevice.GetSystemLog(LogType).run(this.config)
     }
 
     /**
      * This operation gets arbitary device diagnostics information from the device.
      */
     GetSystemSupportInformation() {
-        return Device.GetSystemSupportInformation().run(this.config)
+        return ONVIFDevice.GetSystemSupportInformation().run(this.config)
     }
 
     /**
@@ -1238,7 +1238,7 @@ export class Device {
      *   the device shall return a non-empty scope list in the response.
      */
     GetScopes() {
-        return Device.GetScopes().run(this.config)
+        return ONVIFDevice.GetScopes().run(this.config)
     }
 
     /**
@@ -1249,7 +1249,7 @@ export class Device {
      *   support configuration of discovery scope parameters through the SetScopes command.
      */
     SetScopes(Scopes: string) {
-        return Device.SetScopes(Scopes).run(this.config)
+        return ONVIFDevice.SetScopes(Scopes).run(this.config)
     }
 
     /**
@@ -1258,7 +1258,7 @@ export class Device {
      *   support addition of discovery scope parameters through the AddScopes command.
      */
     AddScopes(ScopeItem: string) {
-        return Device.AddScopes(ScopeItem).run(this.config)
+        return ONVIFDevice.AddScopes(ScopeItem).run(this.config)
     }
 
     /**
@@ -1269,7 +1269,7 @@ export class Device {
      *   Table
      */
     RemoveScopes(ScopeItem: string) {
-        return Device.RemoveScopes(ScopeItem).run(this.config)
+        return ONVIFDevice.RemoveScopes(ScopeItem).run(this.config)
     }
 
     /**
@@ -1278,7 +1278,7 @@ export class Device {
      *   setting through the GetDiscoveryMode command.
      */
     GetDiscoveryMode() {
-        return Device.GetDiscoveryMode().run(this.config)
+        return ONVIFDevice.GetDiscoveryMode().run(this.config)
     }
 
     /**
@@ -1287,7 +1287,7 @@ export class Device {
      *   the discovery mode setting through the SetDiscoveryMode command.
      */
     SetDiscoveryMode(DiscoveryMode: DiscoveryMode) {
-        return Device.SetDiscoveryMode(DiscoveryMode).run(this.config)
+        return ONVIFDevice.SetDiscoveryMode(DiscoveryMode).run(this.config)
     }
 
     /**
@@ -1297,7 +1297,7 @@ export class Device {
      *   command.
      */
     GetRemoteDiscoveryMode() {
-        return Device.GetRemoteDiscoveryMode().run(this.config)
+        return ONVIFDevice.GetRemoteDiscoveryMode().run(this.config)
     }
 
     /**
@@ -1307,7 +1307,7 @@ export class Device {
      *   SetRemoteDiscoveryMode command.
      */
     SetRemoteDiscoveryMode(RemoteDiscoveryMode: DiscoveryMode) {
-        return Device.SetRemoteDiscoveryMode(RemoteDiscoveryMode).run(this.config)
+        return ONVIFDevice.SetRemoteDiscoveryMode(RemoteDiscoveryMode).run(this.config)
     }
 
     /**
@@ -1316,7 +1316,7 @@ export class Device {
      *   DP address(es) through the GetDPAddresses command.
      */
     GetDPAddresses() {
-        return Device.GetDPAddresses().run(this.config)
+        return ONVIFDevice.GetDPAddresses().run(this.config)
     }
 
     /**
@@ -1325,7 +1325,7 @@ export class Device {
      *   remote DP address(es) through the SetDPAddresses command.
      */
     SetDPAddresses(DPAddress: NetworkHost) {
-        return Device.SetDPAddresses(DPAddress).run(this.config)
+        return ONVIFDevice.SetDPAddresses(DPAddress).run(this.config)
     }
 
     /**
@@ -1335,7 +1335,7 @@ export class Device {
      *   endpoint reference.
      */
     GetEndpointReference() {
-        return Device.GetEndpointReference().run(this.config)
+        return ONVIFDevice.GetEndpointReference().run(this.config)
     }
 
     /**
@@ -1345,7 +1345,7 @@ export class Device {
      *   The algorithm to use for deriving the password is described in section 5.12.2.1 of the core specification.
      */
     GetRemoteUser() {
-        return Device.GetRemoteUser().run(this.config)
+        return ONVIFDevice.GetRemoteUser().run(this.config)
     }
 
     /**
@@ -1357,7 +1357,7 @@ export class Device {
      *   To remove the remote user SetRemoteUser should be called without the RemoteUser parameter.
      */
     SetRemoteUser(RemoteUser: RemoteUser) {
-        return Device.SetRemoteUser(RemoteUser).run(this.config)
+        return ONVIFDevice.SetRemoteUser(RemoteUser).run(this.config)
     }
 
     /**
@@ -1366,7 +1366,7 @@ export class Device {
      *   token through the GetUsers command.
      */
     GetUsers() {
-        return Device.GetUsers().run(this.config)
+        return ONVIFDevice.GetUsers().run(this.config)
     }
 
     /**
@@ -1379,7 +1379,7 @@ export class Device {
      *   equivalent' of length 28 bytes, as described in section 3.1.2 of the ONVIF security white paper.
      */
     CreateUsers(User: User) {
-        return Device.CreateUsers(User).run(this.config)
+        return ONVIFDevice.CreateUsers(User).run(this.config)
     }
 
     /**
@@ -1389,7 +1389,7 @@ export class Device {
      *   fault message shall be returned and no users be deleted.
      */
     DeleteUsers(Username: string) {
-        return Device.DeleteUsers(Username).run(this.config)
+        return ONVIFDevice.DeleteUsers(Username).run(this.config)
     }
 
     /**
@@ -1398,7 +1398,7 @@ export class Device {
      *   Either all change requests are processed successfully or a fault message shall be returned and no change requests be processed.
      */
     SetUser(User: User) {
-        return Device.SetUser(User).run(this.config)
+        return ONVIFDevice.SetUser(User).run(this.config)
     }
 
     /**
@@ -1408,7 +1408,7 @@ export class Device {
      *   device shall provide a URL for WSDL and schema download through the GetWsdlUrl command.
      */
     GetWsdlUrl() {
-        return Device.GetWsdlUrl().run(this.config)
+        return ONVIFDevice.GetWsdlUrl().run(this.config)
     }
 
     /**
@@ -1416,7 +1416,7 @@ export class Device {
      *    For capabilities of individual services refer to the GetServiceCapabilities methods.
      */
     GetCapabilities(Category: CapabilityCategory) {
-        return Device.GetCapabilities(Category).run(this.config)
+        return ONVIFDevice.GetCapabilities(Category).run(this.config)
     }
 
     /**
@@ -1424,7 +1424,7 @@ export class Device {
      *   return its hostname configurations through the GetHostname command.
      */
     GetHostname() {
-        return Device.GetHostname().run(this.config)
+        return ONVIFDevice.GetHostname().run(this.config)
     }
 
     /**
@@ -1435,14 +1435,14 @@ export class Device {
      *   
      */
     SetHostname(Name: string) {
-        return Device.SetHostname(Name).run(this.config)
+        return ONVIFDevice.SetHostname(Name).run(this.config)
     }
 
     /**
      * This operation controls whether the hostname is set manually or retrieved via DHCP.
      */
     SetHostnameFromDHCP(FromDHCP: boolean) {
-        return Device.SetHostnameFromDHCP(FromDHCP).run(this.config)
+        return ONVIFDevice.SetHostnameFromDHCP(FromDHCP).run(this.config)
     }
 
     /**
@@ -1450,7 +1450,7 @@ export class Device {
      *   configurations through the GetDNS command.
      */
     GetDNS() {
-        return Device.GetDNS().run(this.config)
+        return ONVIFDevice.GetDNS().run(this.config)
     }
 
     /**
@@ -1458,7 +1458,7 @@ export class Device {
      *   configurations through the SetDNS command.
      */
     SetDNS(FromDHCP: boolean, SearchDomain: string, DNSManual: IPAddress) {
-        return Device.SetDNS(FromDHCP,SearchDomain,DNSManual).run(this.config)
+        return ONVIFDevice.SetDNS(FromDHCP,SearchDomain,DNSManual).run(this.config)
     }
 
     /**
@@ -1466,7 +1466,7 @@ export class Device {
      *   possible to get the NTP server settings through the GetNTP command.
      */
     GetNTP() {
-        return Device.GetNTP().run(this.config)
+        return ONVIFDevice.GetNTP().run(this.config)
     }
 
     /**
@@ -1478,7 +1478,7 @@ export class Device {
      *   
      */
     SetNTP(FromDHCP: boolean, NTPManual: NetworkHost) {
-        return Device.SetNTP(FromDHCP,NTPManual).run(this.config)
+        return ONVIFDevice.SetNTP(FromDHCP,NTPManual).run(this.config)
     }
 
     /**
@@ -1487,7 +1487,7 @@ export class Device {
      *   and TTL through the GetDynamicDNS command.
      */
     GetDynamicDNS() {
-        return Device.GetDynamicDNS().run(this.config)
+        return ONVIFDevice.GetDynamicDNS().run(this.config)
     }
 
     /**
@@ -1496,7 +1496,7 @@ export class Device {
      *   and TTL through the SetDynamicDNS command.
      */
     SetDynamicDNS(Type: DynamicDNSType, Name: DNSName, TTL: string) {
-        return Device.SetDynamicDNS(Type,Name,TTL).run(this.config)
+        return ONVIFDevice.SetDynamicDNS(Type,Name,TTL).run(this.config)
     }
 
     /**
@@ -1505,7 +1505,7 @@ export class Device {
      *   type through the GetNetworkInterfaces command.
      */
     GetNetworkInterfaces() {
-        return Device.GetNetworkInterfaces().run(this.config)
+        return ONVIFDevice.GetNetworkInterfaces().run(this.config)
     }
 
     /**
@@ -1517,7 +1517,7 @@ export class Device {
      *   request.
      */
     SetNetworkInterfaces(InterfaceToken: ReferenceToken, NetworkInterface: NetworkInterfaceSetConfiguration) {
-        return Device.SetNetworkInterfaces(InterfaceToken,NetworkInterface).run(this.config)
+        return ONVIFDevice.SetNetworkInterfaces(InterfaceToken,NetworkInterface).run(this.config)
     }
 
     /**
@@ -1525,7 +1525,7 @@ export class Device {
      *   GetNetworkProtocols command returning configured network protocols.
      */
     GetNetworkProtocols() {
-        return Device.GetNetworkProtocols().run(this.config)
+        return ONVIFDevice.GetNetworkProtocols().run(this.config)
     }
 
     /**
@@ -1533,7 +1533,7 @@ export class Device {
      *   configuration of defined network protocols through the SetNetworkProtocols command.
      */
     SetNetworkProtocols(NetworkProtocols: NetworkProtocol) {
-        return Device.SetNetworkProtocols(NetworkProtocols).run(this.config)
+        return ONVIFDevice.SetNetworkProtocols(NetworkProtocols).run(this.config)
     }
 
     /**
@@ -1541,7 +1541,7 @@ export class Device {
      *   GetNetworkDefaultGateway command returning configured default gateway address(es).
      */
     GetNetworkDefaultGateway() {
-        return Device.GetNetworkDefaultGateway().run(this.config)
+        return ONVIFDevice.GetNetworkDefaultGateway().run(this.config)
     }
 
     /**
@@ -1549,7 +1549,7 @@ export class Device {
      *   configuration of default gateway through the SetNetworkDefaultGateway command.
      */
     SetNetworkDefaultGateway(IPv4Address: IPv4Address, IPv6Address: IPv6Address) {
-        return Device.SetNetworkDefaultGateway(IPv4Address,IPv6Address).run(this.config)
+        return ONVIFDevice.SetNetworkDefaultGateway(IPv4Address,IPv6Address).run(this.config)
     }
 
     /**
@@ -1559,14 +1559,14 @@ export class Device {
      *   Devices supporting zero configuration on more than one interface shall use the extension to list the additional interface settings.
      */
     GetZeroConfiguration() {
-        return Device.GetZeroConfiguration().run(this.config)
+        return ONVIFDevice.GetZeroConfiguration().run(this.config)
     }
 
     /**
      * This operation sets the zero-configuration. Use GetCapalities to get if zero-zero-configuration is supported or not.
      */
     SetZeroConfiguration(InterfaceToken: ReferenceToken, Enabled: boolean) {
-        return Device.SetZeroConfiguration(InterfaceToken,Enabled).run(this.config)
+        return ONVIFDevice.SetZeroConfiguration(InterfaceToken,Enabled).run(this.config)
     }
 
     /**
@@ -1575,7 +1575,7 @@ export class Device {
      *   device shall support the GetIPAddressFilter command.
      */
     GetIPAddressFilter() {
-        return Device.GetIPAddressFilter().run(this.config)
+        return ONVIFDevice.GetIPAddressFilter().run(this.config)
     }
 
     /**
@@ -1585,7 +1585,7 @@ export class Device {
      *   command.
      */
     SetIPAddressFilter(IPAddressFilter: IPAddressFilter) {
-        return Device.SetIPAddressFilter(IPAddressFilter).run(this.config)
+        return ONVIFDevice.SetIPAddressFilter(IPAddressFilter).run(this.config)
     }
 
     /**
@@ -1594,7 +1594,7 @@ export class Device {
      *   shall support adding of IP filtering addresses through the AddIPAddressFilter command.
      */
     AddIPAddressFilter(IPAddressFilter: IPAddressFilter) {
-        return Device.AddIPAddressFilter(IPAddressFilter).run(this.config)
+        return ONVIFDevice.AddIPAddressFilter(IPAddressFilter).run(this.config)
     }
 
     /**
@@ -1603,7 +1603,7 @@ export class Device {
      *   shall support deletion of IP filtering addresses through the RemoveIPAddressFilter command.
      */
     RemoveIPAddressFilter(IPAddressFilter: IPAddressFilter) {
-        return Device.RemoveIPAddressFilter(IPAddressFilter).run(this.config)
+        return ONVIFDevice.RemoveIPAddressFilter(IPAddressFilter).run(this.config)
     }
 
     /**
@@ -1617,7 +1617,7 @@ export class Device {
      *   shall support this command.
      */
     GetAccessPolicy() {
-        return Device.GetAccessPolicy().run(this.config)
+        return ONVIFDevice.GetAccessPolicy().run(this.config)
     }
 
     /**
@@ -1626,7 +1626,7 @@ export class Device {
      *   based on WS-Security authentication, then the device shall support this command.
      */
     SetAccessPolicy(PolicyFile: BinaryData) {
-        return Device.SetAccessPolicy(PolicyFile).run(this.config)
+        return ONVIFDevice.SetAccessPolicy(PolicyFile).run(this.config)
     }
 
     /**
@@ -1641,7 +1641,7 @@ export class Device {
      *   given).
      */
     CreateCertificate(CertificateID: string, Subject: string, ValidNotBefore: string, ValidNotAfter: string) {
-        return Device.CreateCertificate(CertificateID,Subject,ValidNotBefore,ValidNotAfter).run(this.config)
+        return ONVIFDevice.CreateCertificate(CertificateID,Subject,ValidNotBefore,ValidNotAfter).run(this.config)
     }
 
     /**
@@ -1654,7 +1654,7 @@ export class Device {
      *   rules.
      */
     GetCertificates() {
-        return Device.GetCertificates().run(this.config)
+        return ONVIFDevice.GetCertificates().run(this.config)
     }
 
     /**
@@ -1663,7 +1663,7 @@ export class Device {
      *   support this command.
      */
     GetCertificatesStatus() {
-        return Device.GetCertificatesStatus().run(this.config)
+        return ONVIFDevice.GetCertificatesStatus().run(this.config)
     }
 
     /**
@@ -1672,7 +1672,7 @@ export class Device {
      *   Typically only one device server certificate is allowed to be enabled at a time.
      */
     SetCertificatesStatus(CertificateStatus: CertificateStatus) {
-        return Device.SetCertificatesStatus(CertificateStatus).run(this.config)
+        return ONVIFDevice.SetCertificatesStatus(CertificateStatus).run(this.config)
     }
 
     /**
@@ -1683,7 +1683,7 @@ export class Device {
      *   message shall be returned without deleting any certificate.
      */
     DeleteCertificates(CertificateID: string) {
-        return Device.DeleteCertificates(CertificateID).run(this.config)
+        return ONVIFDevice.DeleteCertificates(CertificateID).run(this.config)
     }
 
     /**
@@ -1697,7 +1697,7 @@ export class Device {
      *   using client certificate shall support this command.
      */
     GetPkcs10Request(CertificateID: string, Subject: string, Attributes: BinaryData) {
-        return Device.GetPkcs10Request(CertificateID,Subject,Attributes).run(this.config)
+        return ONVIFDevice.GetPkcs10Request(CertificateID,Subject,Attributes).run(this.config)
     }
 
     /**
@@ -1717,7 +1717,7 @@ export class Device {
      *   historical reasons NVTCertificate.
      */
     LoadCertificates(NVTCertificate: Certificate) {
-        return Device.LoadCertificates(NVTCertificate).run(this.config)
+        return ONVIFDevice.LoadCertificates(NVTCertificate).run(this.config)
     }
 
     /**
@@ -1726,7 +1726,7 @@ export class Device {
      *   support this command.
      */
     GetClientCertificateMode() {
-        return Device.GetClientCertificateMode().run(this.config)
+        return ONVIFDevice.GetClientCertificateMode().run(this.config)
     }
 
     /**
@@ -1735,7 +1735,7 @@ export class Device {
      *   support this command.
      */
     SetClientCertificateMode(Enabled: boolean) {
-        return Device.SetClientCertificateMode(Enabled).run(this.config)
+        return ONVIFDevice.SetClientCertificateMode(Enabled).run(this.config)
     }
 
     /**
@@ -1743,7 +1743,7 @@ export class Device {
      *   This method has been depricated with version 2.0. Refer to the DeviceIO service.
      */
     GetRelayOutputs() {
-        return Device.GetRelayOutputs().run(this.config)
+        return ONVIFDevice.GetRelayOutputs().run(this.config)
     }
 
     /**
@@ -1751,7 +1751,7 @@ export class Device {
      *   This method has been depricated with version 2.0. Refer to the DeviceIO service.
      */
     SetRelayOutputSettings(RelayOutputToken: ReferenceToken, Properties: RelayOutputSettings) {
-        return Device.SetRelayOutputSettings(RelayOutputToken,Properties).run(this.config)
+        return ONVIFDevice.SetRelayOutputSettings(RelayOutputToken,Properties).run(this.config)
     }
 
     /**
@@ -1759,7 +1759,7 @@ export class Device {
      *   This method has been depricated with version 2.0. Refer to the DeviceIO service.
      */
     SetRelayOutputState(RelayOutputToken: ReferenceToken, LogicalState: RelayLogicalState) {
-        return Device.SetRelayOutputState(RelayOutputToken,LogicalState).run(this.config)
+        return ONVIFDevice.SetRelayOutputState(RelayOutputToken,LogicalState).run(this.config)
     }
 
     /**
@@ -1782,7 +1782,7 @@ export class Device {
      *   A device that indicates auxiliary service capability shall support this command.
      */
     SendAuxiliaryCommand(AuxiliaryCommand: AuxiliaryData) {
-        return Device.SendAuxiliaryCommand(AuxiliaryCommand).run(this.config)
+        return ONVIFDevice.SendAuxiliaryCommand(AuxiliaryCommand).run(this.config)
     }
 
     /**
@@ -1794,7 +1794,7 @@ export class Device {
      *   be encoded using ASN.1 [X.681], [X.682], [X.683] DER [X.690] encoding rules.
      */
     GetCACertificates() {
-        return Device.GetCACertificates().run(this.config)
+        return ONVIFDevice.GetCACertificates().run(this.config)
     }
 
     /**
@@ -1813,7 +1813,7 @@ export class Device {
      *   operation should make sure that the private key is sufficiently protected.
      */
     LoadCertificateWithPrivateKey(CertificateWithPrivateKey: CertificateWithPrivateKey) {
-        return Device.LoadCertificateWithPrivateKey(CertificateWithPrivateKey).run(this.config)
+        return ONVIFDevice.LoadCertificateWithPrivateKey(CertificateWithPrivateKey).run(this.config)
     }
 
     /**
@@ -1825,7 +1825,7 @@ export class Device {
      *   A device that supports either TLS or IEEE 802.1X should support this command.
      */
     GetCertificateInformation(CertificateID: string) {
-        return Device.GetCertificateInformation(CertificateID).run(this.config)
+        return ONVIFDevice.GetCertificateInformation(CertificateID).run(this.config)
     }
 
     /**
@@ -1840,7 +1840,7 @@ export class Device {
      *   message shall be returned without loading any CA certificate.
      */
     LoadCACertificates(CACertificate: Certificate) {
-        return Device.LoadCACertificates(CACertificate).run(this.config)
+        return ONVIFDevice.LoadCACertificates(CACertificate).run(this.config)
     }
 
     /**
@@ -1851,7 +1851,7 @@ export class Device {
      *   conflict.
      */
     CreateDot1XConfiguration(Dot1XConfiguration: Dot1XConfiguration) {
-        return Device.CreateDot1XConfiguration(Dot1XConfiguration).run(this.config)
+        return ONVIFDevice.CreateDot1XConfiguration(Dot1XConfiguration).run(this.config)
     }
 
     /**
@@ -1860,7 +1860,7 @@ export class Device {
      *   the device. A device that support IEEE 802.1X shall support this command.
      */
     SetDot1XConfiguration(Dot1XConfiguration: Dot1XConfiguration) {
-        return Device.SetDot1XConfiguration(Dot1XConfiguration).run(this.config)
+        return ONVIFDevice.SetDot1XConfiguration(Dot1XConfiguration).run(this.config)
     }
 
     /**
@@ -1871,7 +1871,7 @@ export class Device {
      *   not, the device shall not include the Password element in the response.
      */
     GetDot1XConfiguration(Dot1XConfigurationToken: ReferenceToken) {
-        return Device.GetDot1XConfiguration(Dot1XConfigurationToken).run(this.config)
+        return ONVIFDevice.GetDot1XConfiguration(Dot1XConfigurationToken).run(this.config)
     }
 
     /**
@@ -1883,7 +1883,7 @@ export class Device {
      *   not, the device shall not include the Password element in the response.
      */
     GetDot1XConfigurations() {
-        return Device.GetDot1XConfigurations().run(this.config)
+        return ONVIFDevice.GetDot1XConfigurations().run(this.config)
     }
 
     /**
@@ -1892,7 +1892,7 @@ export class Device {
      *   A device that support IEEE 802.1X shall support this command.
      */
     DeleteDot1XConfiguration(Dot1XConfigurationToken: ReferenceToken) {
-        return Device.DeleteDot1XConfiguration(Dot1XConfigurationToken).run(this.config)
+        return ONVIFDevice.DeleteDot1XConfiguration(Dot1XConfigurationToken).run(this.config)
     }
 
     /**
@@ -1900,7 +1900,7 @@ export class Device {
      *   this operation.
      */
     GetDot11Capabilities() {
-        return Device.GetDot11Capabilities().run(this.config)
+        return ONVIFDevice.GetDot11Capabilities().run(this.config)
     }
 
     /**
@@ -1908,7 +1908,7 @@ export class Device {
      *   command.
      */
     GetDot11Status(InterfaceToken: ReferenceToken) {
-        return Device.GetDot11Status(InterfaceToken).run(this.config)
+        return ONVIFDevice.GetDot11Status(InterfaceToken).run(this.config)
     }
 
     /**
@@ -1916,7 +1916,7 @@ export class Device {
      *   support this operation.
      */
     ScanAvailableDot11Networks(InterfaceToken: ReferenceToken) {
-        return Device.ScanAvailableDot11Networks(InterfaceToken).run(this.config)
+        return ONVIFDevice.ScanAvailableDot11Networks(InterfaceToken).run(this.config)
     }
 
     /**
@@ -1934,7 +1934,7 @@ export class Device {
      *   command.
      */
     GetSystemUris() {
-        return Device.GetSystemUris().run(this.config)
+        return ONVIFDevice.GetSystemUris().run(this.config)
     }
 
     /**
@@ -1956,7 +1956,7 @@ export class Device {
      *   The value of the Content-Type header in the HTTP POST request shall be “application/octetstream”.
      */
     StartFirmwareUpgrade() {
-        return Device.StartFirmwareUpgrade().run(this.config)
+        return ONVIFDevice.StartFirmwareUpgrade().run(this.config)
     }
 
     /**
@@ -1978,7 +1978,7 @@ export class Device {
      *   The value of the Content-Type header in the HTTP POST request shall be “application/octetstream”.
      */
     StartSystemRestore() {
-        return Device.StartSystemRestore().run(this.config)
+        return ONVIFDevice.StartSystemRestore().run(this.config)
     }
 
     /**
@@ -1987,7 +1987,7 @@ export class Device {
      *   
      */
     GetStorageConfigurations() {
-        return Device.GetStorageConfigurations().run(this.config)
+        return ONVIFDevice.GetStorageConfigurations().run(this.config)
     }
 
     /**
@@ -1997,7 +1997,7 @@ export class Device {
      *   
      */
     CreateStorageConfiguration(StorageConfiguration: any) {
-        return Device.CreateStorageConfiguration(StorageConfiguration).run(this.config)
+        return ONVIFDevice.CreateStorageConfiguration(StorageConfiguration).run(this.config)
     }
 
     /**
@@ -2006,7 +2006,7 @@ export class Device {
      *   
      */
     GetStorageConfiguration(Token: ReferenceToken) {
-        return Device.GetStorageConfiguration(Token).run(this.config)
+        return ONVIFDevice.GetStorageConfiguration(Token).run(this.config)
     }
 
     /**
@@ -2015,7 +2015,7 @@ export class Device {
      *   
      */
     SetStorageConfiguration(StorageConfiguration: any) {
-        return Device.SetStorageConfiguration(StorageConfiguration).run(this.config)
+        return ONVIFDevice.SetStorageConfiguration(StorageConfiguration).run(this.config)
     }
 
     /**
@@ -2024,7 +2024,7 @@ export class Device {
      *   
      */
     DeleteStorageConfiguration(Token: ReferenceToken) {
-        return Device.DeleteStorageConfiguration(Token).run(this.config)
+        return ONVIFDevice.DeleteStorageConfiguration(Token).run(this.config)
     }
 
     /**
@@ -2033,7 +2033,7 @@ export class Device {
      *   
      */
     GetGeoLocation() {
-        return Device.GetGeoLocation().run(this.config)
+        return ONVIFDevice.GetGeoLocation().run(this.config)
     }
 
     /**
@@ -2042,7 +2042,7 @@ export class Device {
      *   
      */
     SetGeoLocation(Location: LocationEntity) {
-        return Device.SetGeoLocation(Location).run(this.config)
+        return ONVIFDevice.SetGeoLocation(Location).run(this.config)
     }
 
     /**
@@ -2051,6 +2051,6 @@ export class Device {
      *   
      */
     DeleteGeoLocation(Location: LocationEntity) {
-        return Device.DeleteGeoLocation(Location).run(this.config)
+        return ONVIFDevice.DeleteGeoLocation(Location).run(this.config)
     }
 }

--- a/src/api/display.ts
+++ b/src/api/display.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { ReferenceToken, Layout, PaneConfiguration } from "./types";
 
-export class Display {
+export class ONVIFDisplay {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -121,7 +121,7 @@ export class Display {
      * Returns the capabilities of the display service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Display.GetServiceCapabilities().run(this.config)
+        return ONVIFDisplay.GetServiceCapabilities().run(this.config)
     }
 
     /**
@@ -130,7 +130,7 @@ export class Display {
      *   their associated display areas.
      */
     GetLayout(VideoOutput: ReferenceToken) {
-        return Display.GetLayout(VideoOutput).run(this.config)
+        return ONVIFDisplay.GetLayout(VideoOutput).run(this.config)
     }
 
     /**
@@ -142,7 +142,7 @@ export class Display {
      *   
      */
     SetLayout(VideoOutput: ReferenceToken, Layout: Layout) {
-        return Display.SetLayout(VideoOutput,Layout).run(this.config)
+        return ONVIFDisplay.SetLayout(VideoOutput,Layout).run(this.config)
     }
 
     /**
@@ -151,7 +151,7 @@ export class Display {
      *   returns both, Layout and Coding Capabilities, of a VideoOutput.
      */
     GetDisplayOptions(VideoOutput: ReferenceToken) {
-        return Display.GetDisplayOptions(VideoOutput).run(this.config)
+        return ONVIFDisplay.GetDisplayOptions(VideoOutput).run(this.config)
     }
 
     /**
@@ -162,14 +162,14 @@ export class Display {
      *   not be established.
      */
     GetPaneConfigurations(VideoOutput: ReferenceToken) {
-        return Display.GetPaneConfigurations(VideoOutput).run(this.config)
+        return ONVIFDisplay.GetPaneConfigurations(VideoOutput).run(this.config)
     }
 
     /**
      * Retrieve the pane configuration for a pane token.
      */
     GetPaneConfiguration(VideoOutput: ReferenceToken, Pane: ReferenceToken) {
-        return Display.GetPaneConfiguration(VideoOutput,Pane).run(this.config)
+        return ONVIFDisplay.GetPaneConfiguration(VideoOutput,Pane).run(this.config)
     }
 
     /**
@@ -178,14 +178,14 @@ export class Display {
      *   Use DeletePaneConfiguration to remove pane configurations.
      */
     SetPaneConfigurations(VideoOutput: ReferenceToken, PaneConfiguration: PaneConfiguration) {
-        return Display.SetPaneConfigurations(VideoOutput,PaneConfiguration).run(this.config)
+        return ONVIFDisplay.SetPaneConfigurations(VideoOutput,PaneConfiguration).run(this.config)
     }
 
     /**
      * This command changes the configuration of the specified pane (tbd)
      */
     SetPaneConfiguration(VideoOutput: ReferenceToken, PaneConfiguration: PaneConfiguration) {
-        return Display.SetPaneConfiguration(VideoOutput,PaneConfiguration).run(this.config)
+        return ONVIFDisplay.SetPaneConfiguration(VideoOutput,PaneConfiguration).run(this.config)
     }
 
     /**
@@ -195,7 +195,7 @@ export class Display {
      *   
      */
     CreatePaneConfiguration(VideoOutput: ReferenceToken, PaneConfiguration: PaneConfiguration) {
-        return Display.CreatePaneConfiguration(VideoOutput,PaneConfiguration).run(this.config)
+        return ONVIFDisplay.CreatePaneConfiguration(VideoOutput,PaneConfiguration).run(this.config)
     }
 
     /**
@@ -205,6 +205,6 @@ export class Display {
      *   
      */
     DeletePaneConfiguration(VideoOutput: ReferenceToken, PaneToken: ReferenceToken) {
-        return Display.DeletePaneConfiguration(VideoOutput,PaneToken).run(this.config)
+        return ONVIFDisplay.DeletePaneConfiguration(VideoOutput,PaneToken).run(this.config)
     }
 }

--- a/src/api/imaging.ts
+++ b/src/api/imaging.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { ReferenceToken, ImagingSettings20, FocusMove } from "./types";
 
-export class Imaging {
+export class ONVIFImaging {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -128,21 +128,21 @@ export class Imaging {
      * Returns the capabilities of the imaging service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Imaging.GetServiceCapabilities().run(this.config)
+        return ONVIFImaging.GetServiceCapabilities().run(this.config)
     }
 
     /**
      * Get the ImagingConfiguration for the requested VideoSource.
      */
     GetImagingSettings(VideoSourceToken: ReferenceToken) {
-        return Imaging.GetImagingSettings(VideoSourceToken).run(this.config)
+        return ONVIFImaging.GetImagingSettings(VideoSourceToken).run(this.config)
     }
 
     /**
      * Set the ImagingConfiguration for the requested VideoSource.
      */
     SetImagingSettings(VideoSourceToken: ReferenceToken, ImagingSettings: ImagingSettings20, ForcePersistence: boolean) {
-        return Imaging.SetImagingSettings(VideoSourceToken,ImagingSettings,ForcePersistence).run(this.config)
+        return ONVIFImaging.SetImagingSettings(VideoSourceToken,ImagingSettings,ForcePersistence).run(this.config)
     }
 
     /**
@@ -153,7 +153,7 @@ export class Imaging {
      *   is provided.
      */
     GetOptions(VideoSourceToken: ReferenceToken) {
-        return Imaging.GetOptions(VideoSourceToken).run(this.config)
+        return ONVIFImaging.GetOptions(VideoSourceToken).run(this.config)
     }
 
     /**
@@ -169,14 +169,14 @@ export class Imaging {
      *   
      */
     Move(VideoSourceToken: ReferenceToken, Focus: FocusMove) {
-        return Imaging.Move(VideoSourceToken,Focus).run(this.config)
+        return ONVIFImaging.Move(VideoSourceToken,Focus).run(this.config)
     }
 
     /**
      * Imaging move operation options supported for the Video source.
      */
     GetMoveOptions(VideoSourceToken: ReferenceToken) {
-        return Imaging.GetMoveOptions(VideoSourceToken).run(this.config)
+        return ONVIFImaging.GetMoveOptions(VideoSourceToken).run(this.config)
     }
 
     /**
@@ -184,21 +184,21 @@ export class Imaging {
      *   the GetMoveOptions supports this command. The operation will not affect ongoing autofocus operation.
      */
     Stop(VideoSourceToken: ReferenceToken) {
-        return Imaging.Stop(VideoSourceToken).run(this.config)
+        return ONVIFImaging.Stop(VideoSourceToken).run(this.config)
     }
 
     /**
      * Via this command the current status of the Move operation can be requested. Supported for this command is available if the support for the Move operation is signalled via GetMoveOptions.
      */
     GetStatus(VideoSourceToken: ReferenceToken) {
-        return Imaging.GetStatus(VideoSourceToken).run(this.config)
+        return ONVIFImaging.GetStatus(VideoSourceToken).run(this.config)
     }
 
     /**
      * Via this command the list of available Imaging Presets can be requested.
      */
     GetPresets(VideoSourceToken: ReferenceToken) {
-        return Imaging.GetPresets(VideoSourceToken).run(this.config)
+        return ONVIFImaging.GetPresets(VideoSourceToken).run(this.config)
     }
 
     /**
@@ -207,7 +207,7 @@ export class Imaging {
      *   GetCurrentPreset shall return 0 if Imaging Presets are not supported by the Video Source.
      */
     GetCurrentPreset(VideoSourceToken: ReferenceToken) {
-        return Imaging.GetCurrentPreset(VideoSourceToken).run(this.config)
+        return ONVIFImaging.GetCurrentPreset(VideoSourceToken).run(this.config)
     }
 
     /**
@@ -217,6 +217,6 @@ export class Imaging {
      *   When the new Imaging Preset is applied by SetCurrentPreset, the Device shall adjust the Video Source settings to match those defined by the specified Imaging Preset.
      */
     SetCurrentPreset(VideoSourceToken: ReferenceToken, PresetToken: ReferenceToken) {
-        return Imaging.SetCurrentPreset(VideoSourceToken,PresetToken).run(this.config)
+        return ONVIFImaging.SetCurrentPreset(VideoSourceToken,PresetToken).run(this.config)
     }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,30 +1,30 @@
-import { Device } from "./device";
-import { Media } from "./media";
-import { Analytics } from "./analytics";
-import { Display } from "./display";
-import { Imaging } from "./imaging";
-import { Provisioning } from "./provisioning";
-import { PTZ } from "./ptz";
-import { Receiver } from "./receiver";
-import { Recording } from "./recording";
-import { Replay } from "./replay";
-import { Search } from "./search";
-import { AdvancedSecurity } from "./advancedsecurity";
+import { ONVIFDevice } from "./device";
+import { ONVIFMedia } from "./media";
+import { ONVIFAnalytics } from "./analytics";
+import { ONVIFDisplay } from "./display";
+import { ONVIFImaging } from "./imaging";
+import { ONVIFProvisioning } from "./provisioning";
+import { ONVIFPTZ } from "./ptz";
+import { ONVIFReceiver } from "./receiver";
+import { ONVIFRecording } from "./recording";
+import { ONVIFReplay } from "./replay";
+import { ONVIFSearch } from "./search";
+import { ONVIFAdvancedSecurity } from "./advancedsecurity";
 import { IDeviceConfig } from "../config";
 
 export class ManagedONVIFApi {
-    public Device = new Device(this.config);
-    public Media = new Media(this.config);
-    public Analytics = new Analytics(this.config);
-    public Display = new Display(this.config);
-    public Imaging = new Imaging(this.config);
-    public Provisioning = new Provisioning(this.config);
-    public PTZ = new PTZ(this.config);
-    public Receiver = new Receiver(this.config);
-    public Recording = new Recording(this.config);
-    public Replay = new Replay(this.config);
-    public Search = new Search(this.config);
-    public AdvancedSecurity = new AdvancedSecurity(this.config);
+    public Device = new ONVIFDevice(this.config);
+    public Media = new ONVIFMedia(this.config);
+    public Analytics = new ONVIFAnalytics(this.config);
+    public Display = new ONVIFDisplay(this.config);
+    public Imaging = new ONVIFImaging(this.config);
+    public Provisioning = new ONVIFProvisioning(this.config);
+    public PTZ = new ONVIFPTZ(this.config);
+    public Receiver = new ONVIFReceiver(this.config);
+    public Recording = new ONVIFRecording(this.config);
+    public Replay = new ONVIFReplay(this.config);
+    public Search = new ONVIFSearch(this.config);
+    public AdvancedSecurity = new ONVIFAdvancedSecurity(this.config);
 
     constructor(private config: IDeviceConfig) {
     }

--- a/src/api/media.ts
+++ b/src/api/media.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { Name, ReferenceToken, VideoSourceConfiguration, VideoEncoderConfiguration, AudioSourceConfiguration, AudioEncoderConfiguration, VideoAnalyticsConfiguration, MetadataConfiguration, AudioOutputConfiguration, AudioDecoderConfiguration, StreamSetup, OSDConfiguration } from "./types";
 
-export class Media {
+export class ONVIFMedia {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -830,28 +830,28 @@ export class Media {
      * Returns the capabilities of the media service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Media.GetServiceCapabilities().run(this.config)
+        return ONVIFMedia.GetServiceCapabilities().run(this.config)
     }
 
     /**
      * This command lists all available physical video inputs of the device.
      */
     GetVideoSources() {
-        return Media.GetVideoSources().run(this.config)
+        return ONVIFMedia.GetVideoSources().run(this.config)
     }
 
     /**
      * This command lists all available physical audio inputs of the device.
      */
     GetAudioSources() {
-        return Media.GetAudioSources().run(this.config)
+        return ONVIFMedia.GetAudioSources().run(this.config)
     }
 
     /**
      * This command lists all available physical audio outputs of the device.
      */
     GetAudioOutputs() {
-        return Media.GetAudioOutputs().run(this.config)
+        return ONVIFMedia.GetAudioOutputs().run(this.config)
     }
 
     /**
@@ -860,14 +860,14 @@ export class Media {
      *   returned Profile.
      */
     CreateProfile(Name: Name, Token: ReferenceToken) {
-        return Media.CreateProfile(Name,Token).run(this.config)
+        return ONVIFMedia.CreateProfile(Name,Token).run(this.config)
     }
 
     /**
      * If the profile token is already known, a profile can be fetched through the GetProfile command.
      */
     GetProfile(ProfileToken: ReferenceToken) {
-        return Media.GetProfile(ProfileToken).run(this.config)
+        return ONVIFMedia.GetProfile(ProfileToken).run(this.config)
     }
 
     /**
@@ -877,7 +877,7 @@ export class Media {
      *   know the media profile in order to use the command.
      */
     GetProfiles() {
-        return Media.GetProfiles().run(this.config)
+        return ONVIFMedia.GetProfiles().run(this.config)
     }
 
     /**
@@ -888,7 +888,7 @@ export class Media {
      *   
      */
     AddVideoEncoderConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddVideoEncoderConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddVideoEncoderConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
@@ -896,7 +896,7 @@ export class Media {
      *   media profile does not contain a VideoEncoderConfiguration, the operation has no effect. The removal shall be persistent.
      */
     RemoveVideoEncoderConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemoveVideoEncoderConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemoveVideoEncoderConfiguration(ProfileToken).run(this.config)
     }
 
     /**
@@ -904,7 +904,7 @@ export class Media {
      *   configuration exists in the media profile, it will be replaced. The change shall be persistent.
      */
     AddVideoSourceConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddVideoSourceConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddVideoSourceConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
@@ -913,7 +913,7 @@ export class Media {
      *   VideoEncoderConfiguration from the media profile.
      */
     RemoveVideoSourceConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemoveVideoSourceConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemoveVideoSourceConfiguration(ProfileToken).run(this.config)
     }
 
     /**
@@ -924,7 +924,7 @@ export class Media {
      *   
      */
     AddAudioEncoderConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddAudioEncoderConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddAudioEncoderConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
@@ -933,7 +933,7 @@ export class Media {
      *   The removal shall be persistent.
      */
     RemoveAudioEncoderConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemoveAudioEncoderConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemoveAudioEncoderConfiguration(ProfileToken).run(this.config)
     }
 
     /**
@@ -941,7 +941,7 @@ export class Media {
      *   configuration exists in the media profile, it will be replaced. The change shall be persistent.
      */
     AddAudioSourceConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddAudioSourceConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddAudioSourceConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
@@ -951,7 +951,7 @@ export class Media {
      *   AudioEncoderConfiguration from the media profile.
      */
     RemoveAudioSourceConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemoveAudioSourceConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemoveAudioSourceConfiguration(ProfileToken).run(this.config)
     }
 
     /**
@@ -961,7 +961,7 @@ export class Media {
      *   PTZ movement.
      */
     AddPTZConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddPTZConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddPTZConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
@@ -969,7 +969,7 @@ export class Media {
      *   does not contain a PTZConfiguration, the operation has no effect. The removal shall be persistent.
      */
     RemovePTZConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemovePTZConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemovePTZConfiguration(ProfileToken).run(this.config)
     }
 
     /**
@@ -979,7 +979,7 @@ export class Media {
      *   configuration before a video source configuration.
      */
     AddVideoAnalyticsConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddVideoAnalyticsConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddVideoAnalyticsConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
@@ -987,105 +987,105 @@ export class Media {
      *   The removal shall be persistent.
      */
     RemoveVideoAnalyticsConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemoveVideoAnalyticsConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemoveVideoAnalyticsConfiguration(ProfileToken).run(this.config)
     }
 
     /**
      * This operation adds a Metadata configuration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a MetadataConfiguration to a Profile means that streams using that profile contain metadata. Metadata can consist of events, PTZ status, and/or video analytics data.
      */
     AddMetadataConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddMetadataConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddMetadataConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
      * This operation removes a MetadataConfiguration from an existing media profile. If the media profile does not contain a MetadataConfiguration, the operation has no effect. The removal shall be persistent.
      */
     RemoveMetadataConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemoveMetadataConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemoveMetadataConfiguration(ProfileToken).run(this.config)
     }
 
     /**
      * This operation adds an AudioOutputConfiguration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent.
      */
     AddAudioOutputConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddAudioOutputConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddAudioOutputConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
      * This operation removes an AudioOutputConfiguration from an existing media profile. If the media profile does not contain an AudioOutputConfiguration, the operation has no effect. The removal shall be persistent.
      */
     RemoveAudioOutputConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemoveAudioOutputConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemoveAudioOutputConfiguration(ProfileToken).run(this.config)
     }
 
     /**
      * This operation adds an AudioDecoderConfiguration to an existing media profile. If a configuration exists in the media profile, it shall be replaced. The change shall be persistent.
      */
     AddAudioDecoderConfiguration(ProfileToken: ReferenceToken, ConfigurationToken: ReferenceToken) {
-        return Media.AddAudioDecoderConfiguration(ProfileToken,ConfigurationToken).run(this.config)
+        return ONVIFMedia.AddAudioDecoderConfiguration(ProfileToken,ConfigurationToken).run(this.config)
     }
 
     /**
      * This operation removes an AudioDecoderConfiguration from an existing media profile. If the media profile does not contain an AudioDecoderConfiguration, the operation has no effect. The removal shall be persistent.
      */
     RemoveAudioDecoderConfiguration(ProfileToken: ReferenceToken) {
-        return Media.RemoveAudioDecoderConfiguration(ProfileToken).run(this.config)
+        return ONVIFMedia.RemoveAudioDecoderConfiguration(ProfileToken).run(this.config)
     }
 
     /**
      * This operation deletes a profile. This change shall always be persistent. Deletion of a profile is only possible for non-fixed profiles
      */
     DeleteProfile(ProfileToken: ReferenceToken) {
-        return Media.DeleteProfile(ProfileToken).run(this.config)
+        return ONVIFMedia.DeleteProfile(ProfileToken).run(this.config)
     }
 
     /**
      * This operation lists all existing video source configurations for a device. The client need not know anything about the video source configurations in order to use the command.
      */
     GetVideoSourceConfigurations() {
-        return Media.GetVideoSourceConfigurations().run(this.config)
+        return ONVIFMedia.GetVideoSourceConfigurations().run(this.config)
     }
 
     /**
      * This operation lists all existing video encoder configurations of a device. This command lists all configured video encoder configurations in a device. The client need not know anything apriori about the video encoder configurations in order to use the command.
      */
     GetVideoEncoderConfigurations() {
-        return Media.GetVideoEncoderConfigurations().run(this.config)
+        return ONVIFMedia.GetVideoEncoderConfigurations().run(this.config)
     }
 
     /**
      * This operation lists all existing audio source configurations of a device. This command lists all audio source configurations in a device. The client need not know anything apriori about the audio source configurations in order to use the command.
      */
     GetAudioSourceConfigurations() {
-        return Media.GetAudioSourceConfigurations().run(this.config)
+        return ONVIFMedia.GetAudioSourceConfigurations().run(this.config)
     }
 
     /**
      * This operation lists all existing device audio encoder configurations. The client need not know anything apriori about the audio encoder configurations in order to use the command.
      */
     GetAudioEncoderConfigurations() {
-        return Media.GetAudioEncoderConfigurations().run(this.config)
+        return ONVIFMedia.GetAudioEncoderConfigurations().run(this.config)
     }
 
     /**
      * This operation lists all video analytics configurations of a device. This command lists all configured video analytics in a device. The client need not know anything apriori about the video analytics in order to use the command.
      */
     GetVideoAnalyticsConfigurations() {
-        return Media.GetVideoAnalyticsConfigurations().run(this.config)
+        return ONVIFMedia.GetVideoAnalyticsConfigurations().run(this.config)
     }
 
     /**
      * This operation lists all existing metadata configurations. The client need not know anything apriori about the metadata in order to use the command.
      */
     GetMetadataConfigurations() {
-        return Media.GetMetadataConfigurations().run(this.config)
+        return ONVIFMedia.GetMetadataConfigurations().run(this.config)
     }
 
     /**
      * This command lists all existing AudioOutputConfigurations of a device. The NVC need not know anything apriori about the audio configurations to use this command.
      */
     GetAudioOutputConfigurations() {
-        return Media.GetAudioOutputConfigurations().run(this.config)
+        return ONVIFMedia.GetAudioOutputConfigurations().run(this.config)
     }
 
     /**
@@ -1093,70 +1093,70 @@ export class Media {
      *   use this command.
      */
     GetAudioDecoderConfigurations() {
-        return Media.GetAudioDecoderConfigurations().run(this.config)
+        return ONVIFMedia.GetAudioDecoderConfigurations().run(this.config)
     }
 
     /**
      * If the video source configuration token is already known, the video source configuration can be fetched through the GetVideoSourceConfiguration command.
      */
     GetVideoSourceConfiguration(ConfigurationToken: ReferenceToken) {
-        return Media.GetVideoSourceConfiguration(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetVideoSourceConfiguration(ConfigurationToken).run(this.config)
     }
 
     /**
      * If the video encoder configuration token is already known, the encoder configuration can be fetched through the GetVideoEncoderConfiguration command.
      */
     GetVideoEncoderConfiguration(ConfigurationToken: ReferenceToken) {
-        return Media.GetVideoEncoderConfiguration(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetVideoEncoderConfiguration(ConfigurationToken).run(this.config)
     }
 
     /**
      * The GetAudioSourceConfiguration command fetches the audio source configurations if the audio source configuration token is already known. An
      */
     GetAudioSourceConfiguration(ConfigurationToken: ReferenceToken) {
-        return Media.GetAudioSourceConfiguration(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetAudioSourceConfiguration(ConfigurationToken).run(this.config)
     }
 
     /**
      * The GetAudioEncoderConfiguration command fetches the encoder configuration if the audio encoder configuration token is known.
      */
     GetAudioEncoderConfiguration(ConfigurationToken: ReferenceToken) {
-        return Media.GetAudioEncoderConfiguration(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetAudioEncoderConfiguration(ConfigurationToken).run(this.config)
     }
 
     /**
      * The GetVideoAnalyticsConfiguration command fetches the video analytics configuration if the video analytics token is known.
      */
     GetVideoAnalyticsConfiguration(ConfigurationToken: ReferenceToken) {
-        return Media.GetVideoAnalyticsConfiguration(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetVideoAnalyticsConfiguration(ConfigurationToken).run(this.config)
     }
 
     /**
      * The GetMetadataConfiguration command fetches the metadata configuration if the metadata token is known.
      */
     GetMetadataConfiguration(ConfigurationToken: ReferenceToken) {
-        return Media.GetMetadataConfiguration(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetMetadataConfiguration(ConfigurationToken).run(this.config)
     }
 
     /**
      * If the audio output configuration token is already known, the output configuration can be fetched through the GetAudioOutputConfiguration command.
      */
     GetAudioOutputConfiguration(ConfigurationToken: ReferenceToken) {
-        return Media.GetAudioOutputConfiguration(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetAudioOutputConfiguration(ConfigurationToken).run(this.config)
     }
 
     /**
      * If the audio decoder configuration token is already known, the decoder configuration can be fetched through the GetAudioDecoderConfiguration command.
      */
     GetAudioDecoderConfiguration(ConfigurationToken: ReferenceToken) {
-        return Media.GetAudioDecoderConfiguration(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetAudioDecoderConfiguration(ConfigurationToken).run(this.config)
     }
 
     /**
      * This operation lists all the video encoder configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddVideoEncoderConfiguration command on the media profile. The result will vary depending on the capabilities, configurations and settings in the device.
      */
     GetCompatibleVideoEncoderConfigurations(ProfileToken: ReferenceToken) {
-        return Media.GetCompatibleVideoEncoderConfigurations(ProfileToken).run(this.config)
+        return ONVIFMedia.GetCompatibleVideoEncoderConfigurations(ProfileToken).run(this.config)
     }
 
     /**
@@ -1166,35 +1166,35 @@ export class Media {
      *   will vary depending on the capabilities, configurations and settings in the device.
      */
     GetCompatibleVideoSourceConfigurations(ProfileToken: ReferenceToken) {
-        return Media.GetCompatibleVideoSourceConfigurations(ProfileToken).run(this.config)
+        return ONVIFMedia.GetCompatibleVideoSourceConfigurations(ProfileToken).run(this.config)
     }
 
     /**
      * This operation requests all audio encoder configurations of a device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioSourceConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
      */
     GetCompatibleAudioEncoderConfigurations(ProfileToken: ReferenceToken) {
-        return Media.GetCompatibleAudioEncoderConfigurations(ProfileToken).run(this.config)
+        return ONVIFMedia.GetCompatibleAudioEncoderConfigurations(ProfileToken).run(this.config)
     }
 
     /**
      * This operation requests all audio source configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioEncoderConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
      */
     GetCompatibleAudioSourceConfigurations(ProfileToken: ReferenceToken) {
-        return Media.GetCompatibleAudioSourceConfigurations(ProfileToken).run(this.config)
+        return ONVIFMedia.GetCompatibleAudioSourceConfigurations(ProfileToken).run(this.config)
     }
 
     /**
      * This operation requests all video analytic configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddVideoAnalyticsConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
      */
     GetCompatibleVideoAnalyticsConfigurations(ProfileToken: ReferenceToken) {
-        return Media.GetCompatibleVideoAnalyticsConfigurations(ProfileToken).run(this.config)
+        return ONVIFMedia.GetCompatibleVideoAnalyticsConfigurations(ProfileToken).run(this.config)
     }
 
     /**
      * This operation requests all the metadata configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddMetadataConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
      */
     GetCompatibleMetadataConfigurations(ProfileToken: ReferenceToken) {
-        return Media.GetCompatibleMetadataConfigurations(ProfileToken).run(this.config)
+        return ONVIFMedia.GetCompatibleMetadataConfigurations(ProfileToken).run(this.config)
     }
 
     /**
@@ -1202,28 +1202,28 @@ export class Media {
      *   AddAudioOutputConfiguration command.
      */
     GetCompatibleAudioOutputConfigurations(ProfileToken: ReferenceToken) {
-        return Media.GetCompatibleAudioOutputConfigurations(ProfileToken).run(this.config)
+        return ONVIFMedia.GetCompatibleAudioOutputConfigurations(ProfileToken).run(this.config)
     }
 
     /**
      * This operation lists all the audio decoder configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddAudioDecoderConfiguration command on the media profile.
      */
     GetCompatibleAudioDecoderConfigurations(ProfileToken: ReferenceToken) {
-        return Media.GetCompatibleAudioDecoderConfigurations(ProfileToken).run(this.config)
+        return ONVIFMedia.GetCompatibleAudioDecoderConfigurations(ProfileToken).run(this.config)
     }
 
     /**
      * This operation modifies a video source configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification.
      */
     SetVideoSourceConfiguration(Configuration: VideoSourceConfiguration, ForcePersistence: boolean) {
-        return Media.SetVideoSourceConfiguration(Configuration,ForcePersistence).run(this.config)
+        return ONVIFMedia.SetVideoSourceConfiguration(Configuration,ForcePersistence).run(this.config)
     }
 
     /**
      * This operation modifies a video encoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification. SessionTimeout is provided as a hint for keeping rtsp session by a device. If necessary the device may adapt parameter values for SessionTimeout elements without returning an error. For the time between keep alive calls the client shall adhere to the timeout value signaled via RTSP.
      */
     SetVideoEncoderConfiguration(Configuration: VideoEncoderConfiguration, ForcePersistence: boolean) {
-        return Media.SetVideoEncoderConfiguration(Configuration,ForcePersistence).run(this.config)
+        return ONVIFMedia.SetVideoEncoderConfiguration(Configuration,ForcePersistence).run(this.config)
     }
 
     /**
@@ -1234,7 +1234,7 @@ export class Media {
      *   NVC methods for changing a running stream are out of scope for this specification.
      */
     SetAudioSourceConfiguration(Configuration: AudioSourceConfiguration, ForcePersistence: boolean) {
-        return Media.SetAudioSourceConfiguration(Configuration,ForcePersistence).run(this.config)
+        return ONVIFMedia.SetAudioSourceConfiguration(Configuration,ForcePersistence).run(this.config)
     }
 
     /**
@@ -1245,7 +1245,7 @@ export class Media {
      *   running stream are out of scope for this specification.
      */
     SetAudioEncoderConfiguration(Configuration: AudioEncoderConfiguration, ForcePersistence: boolean) {
-        return Media.SetAudioEncoderConfiguration(Configuration,ForcePersistence).run(this.config)
+        return ONVIFMedia.SetAudioEncoderConfiguration(Configuration,ForcePersistence).run(this.config)
     }
 
     /**
@@ -1257,7 +1257,7 @@ export class Media {
      *   video analytics configuration token.
      */
     SetVideoAnalyticsConfiguration(Configuration: VideoAnalyticsConfiguration, ForcePersistence: boolean) {
-        return Media.SetVideoAnalyticsConfiguration(Configuration,ForcePersistence).run(this.config)
+        return ONVIFMedia.SetVideoAnalyticsConfiguration(Configuration,ForcePersistence).run(this.config)
     }
 
     /**
@@ -1269,7 +1269,7 @@ export class Media {
      *   running stream are out of scope for this specification.
      */
     SetMetadataConfiguration(Configuration: MetadataConfiguration, ForcePersistence: boolean) {
-        return Media.SetMetadataConfiguration(Configuration,ForcePersistence).run(this.config)
+        return ONVIFMedia.SetMetadataConfiguration(Configuration,ForcePersistence).run(this.config)
     }
 
     /**
@@ -1277,7 +1277,7 @@ export class Media {
      *   the changes shall remain after reboot of the device.
      */
     SetAudioOutputConfiguration(Configuration: AudioOutputConfiguration, ForcePersistence: boolean) {
-        return Media.SetAudioOutputConfiguration(Configuration,ForcePersistence).run(this.config)
+        return ONVIFMedia.SetAudioOutputConfiguration(Configuration,ForcePersistence).run(this.config)
     }
 
     /**
@@ -1285,7 +1285,7 @@ export class Media {
      *   the changes shall remain after reboot of the device.
      */
     SetAudioDecoderConfiguration(Configuration: AudioDecoderConfiguration, ForcePersistence: boolean) {
-        return Media.SetAudioDecoderConfiguration(Configuration,ForcePersistence).run(this.config)
+        return ONVIFMedia.SetAudioDecoderConfiguration(Configuration,ForcePersistence).run(this.config)
     }
 
     /**
@@ -1295,7 +1295,7 @@ export class Media {
      *   that media profile.
      */
     GetVideoSourceConfigurationOptions(ConfigurationToken: ReferenceToken, ProfileToken: ReferenceToken) {
-        return Media.GetVideoSourceConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
+        return ONVIFMedia.GetVideoSourceConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
     }
 
     /**
@@ -1309,7 +1309,7 @@ export class Media {
      *   
      */
     GetVideoEncoderConfigurationOptions(ConfigurationToken: ReferenceToken, ProfileToken: ReferenceToken) {
-        return Media.GetVideoEncoderConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
+        return ONVIFMedia.GetVideoEncoderConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
     }
 
     /**
@@ -1319,7 +1319,7 @@ export class Media {
      *   that media profile.
      */
     GetAudioSourceConfigurationOptions(ConfigurationToken: ReferenceToken, ProfileToken: ReferenceToken) {
-        return Media.GetAudioSourceConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
+        return ONVIFMedia.GetAudioSourceConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
     }
 
     /**
@@ -1327,21 +1327,21 @@ export class Media {
      *   reconfigured.
      */
     GetAudioEncoderConfigurationOptions(ConfigurationToken: ReferenceToken, ProfileToken: ReferenceToken) {
-        return Media.GetAudioEncoderConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
+        return ONVIFMedia.GetAudioEncoderConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
     }
 
     /**
      * This operation returns the available options (supported values and ranges for metadata configuration parameters) for changing the metadata configuration.
      */
     GetMetadataConfigurationOptions(ConfigurationToken: ReferenceToken, ProfileToken: ReferenceToken) {
-        return Media.GetMetadataConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
+        return ONVIFMedia.GetMetadataConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
     }
 
     /**
      * This operation returns the available options (supported values and ranges for audio output configuration parameters) for configuring an audio output.
      */
     GetAudioOutputConfigurationOptions(ConfigurationToken: ReferenceToken, ProfileToken: ReferenceToken) {
-        return Media.GetAudioOutputConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
+        return ONVIFMedia.GetAudioOutputConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
     }
 
     /**
@@ -1349,7 +1349,7 @@ export class Media {
      *   device.
      */
     GetAudioDecoderConfigurationOptions(ConfigurationToken: ReferenceToken, ProfileToken: ReferenceToken) {
-        return Media.GetAudioDecoderConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
+        return ONVIFMedia.GetAudioDecoderConfigurationOptions(ConfigurationToken,ProfileToken).run(this.config)
     }
 
     /**
@@ -1358,7 +1358,7 @@ export class Media {
      *   Configuration.
      */
     GetGuaranteedNumberOfVideoEncoderInstances(ConfigurationToken: ReferenceToken) {
-        return Media.GetGuaranteedNumberOfVideoEncoderInstances(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetGuaranteedNumberOfVideoEncoderInstances(ConfigurationToken).run(this.config)
     }
 
     /**
@@ -1379,7 +1379,7 @@ export class Media {
      *   128 octets.
      */
     GetStreamUri(StreamSetup: StreamSetup, ProfileToken: ReferenceToken) {
-        return Media.GetStreamUri(StreamSetup,ProfileToken).run(this.config)
+        return ONVIFMedia.GetStreamUri(StreamSetup,ProfileToken).run(this.config)
     }
 
     /**
@@ -1391,14 +1391,14 @@ export class Media {
      *   respectively.
      */
     StartMulticastStreaming(ProfileToken: ReferenceToken) {
-        return Media.StartMulticastStreaming(ProfileToken).run(this.config)
+        return ONVIFMedia.StartMulticastStreaming(ProfileToken).run(this.config)
     }
 
     /**
      * This command stop multicast streaming using a specified media profile of a device
      */
     StopMulticastStreaming(ProfileToken: ReferenceToken) {
-        return Media.StopMulticastStreaming(ProfileToken).run(this.config)
+        return ONVIFMedia.StopMulticastStreaming(ProfileToken).run(this.config)
     }
 
     /**
@@ -1415,7 +1415,7 @@ export class Media {
      *   the PTZ position shall be repeated within the metadata stream.
      */
     SetSynchronizationPoint(ProfileToken: ReferenceToken) {
-        return Media.SetSynchronizationPoint(ProfileToken).run(this.config)
+        return ONVIFMedia.SetSynchronizationPoint(ProfileToken).run(this.config)
     }
 
     /**
@@ -1429,62 +1429,62 @@ export class Media {
      *   image will be updated automatically and independent from calls to GetSnapshotUri.
      */
     GetSnapshotUri(ProfileToken: ReferenceToken) {
-        return Media.GetSnapshotUri(ProfileToken).run(this.config)
+        return ONVIFMedia.GetSnapshotUri(ProfileToken).run(this.config)
     }
 
     /**
      * A device returns the information for current video source mode and settable video source modes of specified video source. A device that indicates a capability of  VideoSourceModes shall support this command.
      */
     GetVideoSourceModes(VideoSourceToken: ReferenceToken) {
-        return Media.GetVideoSourceModes(VideoSourceToken).run(this.config)
+        return ONVIFMedia.GetVideoSourceModes(VideoSourceToken).run(this.config)
     }
 
     /**
      * SetVideoSourceMode changes the media profile structure relating to video source for the specified video source mode. A device that indicates a capability of VideoSourceModes shall support this command. The behavior after changing the mode is not defined in this specification.
      */
     SetVideoSourceMode(VideoSourceToken: ReferenceToken, VideoSourceModeToken: ReferenceToken) {
-        return Media.SetVideoSourceMode(VideoSourceToken,VideoSourceModeToken).run(this.config)
+        return ONVIFMedia.SetVideoSourceMode(VideoSourceToken,VideoSourceModeToken).run(this.config)
     }
 
     /**
      * Get the OSDs.
      */
     GetOSDs(ConfigurationToken: ReferenceToken) {
-        return Media.GetOSDs(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetOSDs(ConfigurationToken).run(this.config)
     }
 
     /**
      * Get the OSD.
      */
     GetOSD(OSDToken: ReferenceToken) {
-        return Media.GetOSD(OSDToken).run(this.config)
+        return ONVIFMedia.GetOSD(OSDToken).run(this.config)
     }
 
     /**
      * Get the OSD Options.
      */
     GetOSDOptions(ConfigurationToken: ReferenceToken) {
-        return Media.GetOSDOptions(ConfigurationToken).run(this.config)
+        return ONVIFMedia.GetOSDOptions(ConfigurationToken).run(this.config)
     }
 
     /**
      * Set the OSD
      */
     SetOSD(OSD: OSDConfiguration) {
-        return Media.SetOSD(OSD).run(this.config)
+        return ONVIFMedia.SetOSD(OSD).run(this.config)
     }
 
     /**
      * Create the OSD.
      */
     CreateOSD(OSD: OSDConfiguration) {
-        return Media.CreateOSD(OSD).run(this.config)
+        return ONVIFMedia.CreateOSD(OSD).run(this.config)
     }
 
     /**
      * Delete the OSD.
      */
     DeleteOSD(OSDToken: ReferenceToken) {
-        return Media.DeleteOSD(OSDToken).run(this.config)
+        return ONVIFMedia.DeleteOSD(OSDToken).run(this.config)
     }
 }

--- a/src/api/provisioning.ts
+++ b/src/api/provisioning.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import "./types";
 
-export class Provisioning {
+export class ONVIFProvisioning {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -82,55 +82,55 @@ export class Provisioning {
      * Returns the capabilities of the provisioning service.
      */
     GetServiceCapabilities() {
-        return Provisioning.GetServiceCapabilities().run(this.config)
+        return ONVIFProvisioning.GetServiceCapabilities().run(this.config)
     }
 
     /**
      * Moves device on the pan axis.
      */
     PanMove() {
-        return Provisioning.PanMove().run(this.config)
+        return ONVIFProvisioning.PanMove().run(this.config)
     }
 
     /**
      * Moves device on the tilt axis.
      */
     TiltMove() {
-        return Provisioning.TiltMove().run(this.config)
+        return ONVIFProvisioning.TiltMove().run(this.config)
     }
 
     /**
      * Moves device on the zoom axis.
      */
     ZoomMove() {
-        return Provisioning.ZoomMove().run(this.config)
+        return ONVIFProvisioning.ZoomMove().run(this.config)
     }
 
     /**
      * Moves device on the roll axis.
      */
     RollMove() {
-        return Provisioning.RollMove().run(this.config)
+        return ONVIFProvisioning.RollMove().run(this.config)
     }
 
     /**
      * Moves device on the focus axis.
      */
     FocusMove() {
-        return Provisioning.FocusMove().run(this.config)
+        return ONVIFProvisioning.FocusMove().run(this.config)
     }
 
     /**
      * Stops device motion on all axes.
      */
     Stop() {
-        return Provisioning.Stop().run(this.config)
+        return ONVIFProvisioning.Stop().run(this.config)
     }
 
     /**
      * Returns the lifetime move counts.
      */
     GetUsage() {
-        return Provisioning.GetUsage().run(this.config)
+        return ONVIFProvisioning.GetUsage().run(this.config)
     }
 }

--- a/src/api/ptz.ts
+++ b/src/api/ptz.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { ReferenceToken, PTZConfiguration, AuxiliaryData, PTZSpeed, PTZVector, GeoLocation, PresetTour, PTZPresetTourOperation } from "./types";
 
-export class PTZ {
+export class ONVIFPTZ {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -365,7 +365,7 @@ export class PTZ {
      * Returns the capabilities of the PTZ service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return PTZ.GetServiceCapabilities().run(this.config)
+        return ONVIFPTZ.GetServiceCapabilities().run(this.config)
     }
 
     /**
@@ -379,7 +379,7 @@ export class PTZ {
      *         
      */
     GetNodes() {
-        return PTZ.GetNodes().run(this.config)
+        return ONVIFPTZ.GetNodes().run(this.config)
     }
 
     /**
@@ -388,7 +388,7 @@ export class PTZ {
      *     
      */
     GetNode(NodeToken: ReferenceToken) {
-        return PTZ.GetNode(NodeToken).run(this.config)
+        return ONVIFPTZ.GetNode(NodeToken).run(this.config)
     }
 
     /**
@@ -411,7 +411,7 @@ export class PTZ {
      *   
      */
     GetConfiguration(PTZConfigurationToken: ReferenceToken) {
-        return PTZ.GetConfiguration(PTZConfigurationToken).run(this.config)
+        return ONVIFPTZ.GetConfiguration(PTZConfigurationToken).run(this.config)
     }
 
     /**
@@ -435,7 +435,7 @@ export class PTZ {
      *   
      */
     GetConfigurations() {
-        return PTZ.GetConfigurations().run(this.config)
+        return ONVIFPTZ.GetConfigurations().run(this.config)
     }
 
     /**
@@ -444,7 +444,7 @@ export class PTZ {
      *         
      */
     SetConfiguration(PTZConfiguration: PTZConfiguration, ForcePersistence: boolean) {
-        return PTZ.SetConfiguration(PTZConfiguration,ForcePersistence).run(this.config)
+        return ONVIFPTZ.SetConfiguration(PTZConfiguration,ForcePersistence).run(this.config)
     }
 
     /**
@@ -458,7 +458,7 @@ export class PTZ {
      *   
      */
     GetConfigurationOptions(ConfigurationToken: ReferenceToken) {
-        return PTZ.GetConfigurationOptions(ConfigurationToken).run(this.config)
+        return ONVIFPTZ.GetConfigurationOptions(ConfigurationToken).run(this.config)
     }
 
     /**
@@ -470,7 +470,7 @@ export class PTZ {
      *         
      */
     SendAuxiliaryCommand(ProfileToken: ReferenceToken, AuxiliaryData: AuxiliaryData) {
-        return PTZ.SendAuxiliaryCommand(ProfileToken,AuxiliaryData).run(this.config)
+        return ONVIFPTZ.SendAuxiliaryCommand(ProfileToken,AuxiliaryData).run(this.config)
     }
 
     /**
@@ -480,7 +480,7 @@ export class PTZ {
      *           for at least on PTZ preset by the PTZNode.
      */
     GetPresets(ProfileToken: ReferenceToken) {
-        return PTZ.GetPresets(ProfileToken).run(this.config)
+        return ONVIFPTZ.GetPresets(ProfileToken).run(this.config)
     }
 
     /**
@@ -496,7 +496,7 @@ export class PTZ {
      *   Preset which then should be recalled in the GotoPreset operation.      
      */
     SetPreset(ProfileToken: ReferenceToken, PresetName: string, PresetToken: ReferenceToken) {
-        return PTZ.SetPreset(ProfileToken,PresetName,PresetToken).run(this.config)
+        return ONVIFPTZ.SetPreset(ProfileToken,PresetName,PresetToken).run(this.config)
     }
 
     /**
@@ -510,7 +510,7 @@ export class PTZ {
      *         
      */
     RemovePreset(ProfileToken: ReferenceToken, PresetToken: ReferenceToken) {
-        return PTZ.RemovePreset(ProfileToken,PresetToken).run(this.config)
+        return ONVIFPTZ.RemovePreset(ProfileToken,PresetToken).run(this.config)
     }
 
     /**
@@ -520,7 +520,7 @@ export class PTZ {
      *           support for at least on PTZ preset by the PTZNode.
      */
     GotoPreset(ProfileToken: ReferenceToken, PresetToken: ReferenceToken, Speed: PTZSpeed) {
-        return PTZ.GotoPreset(ProfileToken,PresetToken,Speed).run(this.config)
+        return ONVIFPTZ.GotoPreset(ProfileToken,PresetToken,Speed).run(this.config)
     }
 
     /**
@@ -528,7 +528,7 @@ export class PTZ {
      *           Operation to move the PTZ device to it's "home" position. The operation is supported if the HomeSupported element in the PTZNode is true.
      */
     GotoHomePosition(ProfileToken: ReferenceToken, Speed: PTZSpeed) {
-        return PTZ.GotoHomePosition(ProfileToken,Speed).run(this.config)
+        return ONVIFPTZ.GotoHomePosition(ProfileToken,Speed).run(this.config)
     }
 
     /**
@@ -538,14 +538,14 @@ export class PTZ {
      *   Home Position with the GotoHomePosition command.
      */
     SetHomePosition(ProfileToken: ReferenceToken) {
-        return PTZ.SetHomePosition(ProfileToken).run(this.config)
+        return ONVIFPTZ.SetHomePosition(ProfileToken).run(this.config)
     }
 
     /**
      * Operation for continuous Pan/Tilt and Zoom movements. The operation is supported if the PTZNode supports at least one continuous Pan/Tilt or Zoom space. If the space argument is omitted, the default space set by the PTZConfiguration will be used.
      */
     ContinuousMove(ProfileToken: ReferenceToken, Velocity: PTZSpeed, Timeout: string) {
-        return PTZ.ContinuousMove(ProfileToken,Velocity,Timeout).run(this.config)
+        return ONVIFPTZ.ContinuousMove(ProfileToken,Velocity,Timeout).run(this.config)
     }
 
     /**
@@ -556,7 +556,7 @@ export class PTZ {
      *   
      */
     RelativeMove(ProfileToken: ReferenceToken, Translation: PTZVector, Speed: PTZSpeed) {
-        return PTZ.RelativeMove(ProfileToken,Translation,Speed).run(this.config)
+        return ONVIFPTZ.RelativeMove(ProfileToken,Translation,Speed).run(this.config)
     }
 
     /**
@@ -565,7 +565,7 @@ export class PTZ {
      *   selected profile.
      */
     GetStatus(ProfileToken: ReferenceToken) {
-        return PTZ.GetStatus(ProfileToken).run(this.config)
+        return ONVIFPTZ.GetStatus(ProfileToken).run(this.config)
     }
 
     /**
@@ -576,7 +576,7 @@ export class PTZ {
      *   
      */
     AbsoluteMove(ProfileToken: ReferenceToken, Position: PTZVector, Speed: PTZSpeed) {
-        return PTZ.AbsoluteMove(ProfileToken,Position,Speed).run(this.config)
+        return ONVIFPTZ.AbsoluteMove(ProfileToken,Position,Speed).run(this.config)
     }
 
     /**
@@ -589,7 +589,7 @@ export class PTZ {
      *   
      */
     GeoMove(ProfileToken: ReferenceToken, Target: GeoLocation, Speed: PTZSpeed, AreaHeight: number, AreaWidth: number) {
-        return PTZ.GeoMove(ProfileToken,Target,Speed,AreaHeight,AreaWidth).run(this.config)
+        return ONVIFPTZ.GeoMove(ProfileToken,Target,Speed,AreaHeight,AreaWidth).run(this.config)
     }
 
     /**
@@ -597,56 +597,56 @@ export class PTZ {
      *   If no stop argument for pan, tilt or zoom is set, the device will stop all ongoing pan, tilt and zoom movements.
      */
     Stop(ProfileToken: ReferenceToken, PanTilt: boolean, Zoom: boolean) {
-        return PTZ.Stop(ProfileToken,PanTilt,Zoom).run(this.config)
+        return ONVIFPTZ.Stop(ProfileToken,PanTilt,Zoom).run(this.config)
     }
 
     /**
      * Operation to request PTZ preset tours in the selected media profiles.
      */
     GetPresetTours(ProfileToken: ReferenceToken) {
-        return PTZ.GetPresetTours(ProfileToken).run(this.config)
+        return ONVIFPTZ.GetPresetTours(ProfileToken).run(this.config)
     }
 
     /**
      * Operation to request a specific PTZ preset tour in the selected media profile.
      */
     GetPresetTour(ProfileToken: ReferenceToken, PresetTourToken: ReferenceToken) {
-        return PTZ.GetPresetTour(ProfileToken,PresetTourToken).run(this.config)
+        return ONVIFPTZ.GetPresetTour(ProfileToken,PresetTourToken).run(this.config)
     }
 
     /**
      * Operation to request available options to configure PTZ preset tour.
      */
     GetPresetTourOptions(ProfileToken: ReferenceToken, PresetTourToken: ReferenceToken) {
-        return PTZ.GetPresetTourOptions(ProfileToken,PresetTourToken).run(this.config)
+        return ONVIFPTZ.GetPresetTourOptions(ProfileToken,PresetTourToken).run(this.config)
     }
 
     /**
      * Operation to create a preset tour for the selected media profile.
      */
     CreatePresetTour(ProfileToken: ReferenceToken) {
-        return PTZ.CreatePresetTour(ProfileToken).run(this.config)
+        return ONVIFPTZ.CreatePresetTour(ProfileToken).run(this.config)
     }
 
     /**
      * Operation to modify a preset tour for the selected media profile.
      */
     ModifyPresetTour(ProfileToken: ReferenceToken, PresetTour: PresetTour) {
-        return PTZ.ModifyPresetTour(ProfileToken,PresetTour).run(this.config)
+        return ONVIFPTZ.ModifyPresetTour(ProfileToken,PresetTour).run(this.config)
     }
 
     /**
      * Operation to perform specific operation on the preset tour in selected media profile.
      */
     OperatePresetTour(ProfileToken: ReferenceToken, PresetTourToken: ReferenceToken, Operation: PTZPresetTourOperation) {
-        return PTZ.OperatePresetTour(ProfileToken,PresetTourToken,Operation).run(this.config)
+        return ONVIFPTZ.OperatePresetTour(ProfileToken,PresetTourToken,Operation).run(this.config)
     }
 
     /**
      * Operation to delete a specific preset tour from the media profile.
      */
     RemovePresetTour(ProfileToken: ReferenceToken, PresetTourToken: ReferenceToken) {
-        return PTZ.RemovePresetTour(ProfileToken,PresetTourToken).run(this.config)
+        return ONVIFPTZ.RemovePresetTour(ProfileToken,PresetTourToken).run(this.config)
     }
 
     /**
@@ -657,6 +657,6 @@ export class PTZ {
      *   
      */
     GetCompatibleConfigurations(ProfileToken: ReferenceToken) {
-        return PTZ.GetCompatibleConfigurations(ProfileToken).run(this.config)
+        return ONVIFPTZ.GetCompatibleConfigurations(ProfileToken).run(this.config)
     }
 }

--- a/src/api/receiver.ts
+++ b/src/api/receiver.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { ReferenceToken, ReceiverConfiguration, ReceiverMode } from "./types";
 
-export class Receiver {
+export class ONVIFReceiver {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -102,7 +102,7 @@ export class Receiver {
      * Returns the capabilities of the receiver service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Receiver.GetServiceCapabilities().run(this.config)
+        return ONVIFReceiver.GetServiceCapabilities().run(this.config)
     }
 
     /**
@@ -111,7 +111,7 @@ export class Receiver {
      *   
      */
     GetReceivers() {
-        return Receiver.GetReceivers().run(this.config)
+        return ONVIFReceiver.GetReceivers().run(this.config)
     }
 
     /**
@@ -120,7 +120,7 @@ export class Receiver {
      *   
      */
     GetReceiver(ReceiverToken: ReferenceToken) {
-        return Receiver.GetReceiver(ReceiverToken).run(this.config)
+        return ONVIFReceiver.GetReceiver(ReceiverToken).run(this.config)
     }
 
     /**
@@ -130,7 +130,7 @@ export class Receiver {
      *   
      */
     CreateReceiver(Configuration: ReceiverConfiguration) {
-        return Receiver.CreateReceiver(Configuration).run(this.config)
+        return ONVIFReceiver.CreateReceiver(Configuration).run(this.config)
     }
 
     /**
@@ -141,7 +141,7 @@ export class Receiver {
      *   
      */
     DeleteReceiver(ReceiverToken: ReferenceToken) {
-        return Receiver.DeleteReceiver(ReceiverToken).run(this.config)
+        return ONVIFReceiver.DeleteReceiver(ReceiverToken).run(this.config)
     }
 
     /**
@@ -150,7 +150,7 @@ export class Receiver {
      *   
      */
     ConfigureReceiver(ReceiverToken: ReferenceToken, Configuration: ReceiverConfiguration) {
-        return Receiver.ConfigureReceiver(ReceiverToken,Configuration).run(this.config)
+        return ONVIFReceiver.ConfigureReceiver(ReceiverToken,Configuration).run(this.config)
     }
 
     /**
@@ -160,7 +160,7 @@ export class Receiver {
      *   
      */
     SetReceiverMode(ReceiverToken: ReferenceToken, Mode: ReceiverMode) {
-        return Receiver.SetReceiverMode(ReceiverToken,Mode).run(this.config)
+        return ONVIFReceiver.SetReceiverMode(ReceiverToken,Mode).run(this.config)
     }
 
     /**
@@ -171,6 +171,6 @@ export class Receiver {
      *   
      */
     GetReceiverState(ReceiverToken: ReferenceToken) {
-        return Receiver.GetReceiverState(ReceiverToken).run(this.config)
+        return ONVIFReceiver.GetReceiverState(ReceiverToken).run(this.config)
     }
 }

--- a/src/api/recording.ts
+++ b/src/api/recording.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { RecordingConfiguration, RecordingReference, TrackConfiguration, TrackReference, RecordingJobConfiguration, RecordingJobReference, RecordingJobMode, SearchScope, StorageReferencePath, ReferenceToken } from "./types";
 
-export class Recording {
+export class ONVIFRecording {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -248,7 +248,7 @@ export class Recording {
      * Returns the capabilities of the recording service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Recording.GetServiceCapabilities().run(this.config)
+        return ONVIFRecording.GetServiceCapabilities().run(this.config)
     }
 
     /**
@@ -270,7 +270,7 @@ export class Recording {
      *   
      */
     CreateRecording(RecordingConfiguration: RecordingConfiguration) {
-        return Recording.CreateRecording(RecordingConfiguration).run(this.config)
+        return ONVIFRecording.CreateRecording(RecordingConfiguration).run(this.config)
     }
 
     /**
@@ -284,7 +284,7 @@ export class Recording {
      *   
      */
     DeleteRecording(RecordingToken: RecordingReference) {
-        return Recording.DeleteRecording(RecordingToken).run(this.config)
+        return ONVIFRecording.DeleteRecording(RecordingToken).run(this.config)
     }
 
     /**
@@ -292,28 +292,28 @@ export class Recording {
      *   shall include a list of all the tracks for each recording.
      */
     GetRecordings() {
-        return Recording.GetRecordings().run(this.config)
+        return ONVIFRecording.GetRecordings().run(this.config)
     }
 
     /**
      * SetRecordingConfiguration shall change the configuration of a recording.
      */
     SetRecordingConfiguration(RecordingToken: RecordingReference, RecordingConfiguration: RecordingConfiguration) {
-        return Recording.SetRecordingConfiguration(RecordingToken,RecordingConfiguration).run(this.config)
+        return ONVIFRecording.SetRecordingConfiguration(RecordingToken,RecordingConfiguration).run(this.config)
     }
 
     /**
      * GetRecordingConfiguration shall retrieve the recording configuration for a recording.
      */
     GetRecordingConfiguration(RecordingToken: RecordingReference) {
-        return Recording.GetRecordingConfiguration(RecordingToken).run(this.config)
+        return ONVIFRecording.GetRecordingConfiguration(RecordingToken).run(this.config)
     }
 
     /**
      * GetRecordingOptions returns information for a recording identified by the RecordingToken. The information includes the number of additonal tracks as well as recording jobs that can be configured.
      */
     GetRecordingOptions(RecordingToken: RecordingReference) {
-        return Recording.GetRecordingOptions(RecordingToken).run(this.config)
+        return ONVIFRecording.GetRecordingOptions(RecordingToken).run(this.config)
     }
 
     /**
@@ -324,7 +324,7 @@ export class Recording {
      *   
      */
     CreateTrack(RecordingToken: RecordingReference, TrackConfiguration: TrackConfiguration) {
-        return Recording.CreateTrack(RecordingToken,TrackConfiguration).run(this.config)
+        return ONVIFRecording.CreateTrack(RecordingToken,TrackConfiguration).run(this.config)
     }
 
     /**
@@ -333,21 +333,21 @@ export class Recording {
      *   TRUE.
      */
     DeleteTrack(RecordingToken: RecordingReference, TrackToken: TrackReference) {
-        return Recording.DeleteTrack(RecordingToken,TrackToken).run(this.config)
+        return ONVIFRecording.DeleteTrack(RecordingToken,TrackToken).run(this.config)
     }
 
     /**
      * GetTrackConfiguration shall retrieve the configuration for a specific track.
      */
     GetTrackConfiguration(RecordingToken: RecordingReference, TrackToken: TrackReference) {
-        return Recording.GetTrackConfiguration(RecordingToken,TrackToken).run(this.config)
+        return ONVIFRecording.GetTrackConfiguration(RecordingToken,TrackToken).run(this.config)
     }
 
     /**
      * SetTrackConfiguration shall change the configuration of a track.
      */
     SetTrackConfiguration(RecordingToken: RecordingReference, TrackToken: TrackReference, TrackConfiguration: TrackConfiguration) {
-        return Recording.SetTrackConfiguration(RecordingToken,TrackToken,TrackConfiguration).run(this.config)
+        return ONVIFRecording.SetTrackConfiguration(RecordingToken,TrackToken,TrackConfiguration).run(this.config)
     }
 
     /**
@@ -359,7 +359,7 @@ export class Recording {
      *   
      */
     CreateRecordingJob(JobConfiguration: RecordingJobConfiguration) {
-        return Recording.CreateRecordingJob(JobConfiguration).run(this.config)
+        return ONVIFRecording.CreateRecordingJob(JobConfiguration).run(this.config)
     }
 
     /**
@@ -369,14 +369,14 @@ export class Recording {
      *   other recording job.
      */
     DeleteRecordingJob(JobToken: RecordingJobReference) {
-        return Recording.DeleteRecordingJob(JobToken).run(this.config)
+        return ONVIFRecording.DeleteRecordingJob(JobToken).run(this.config)
     }
 
     /**
      * GetRecordingJobs shall return a list of all the recording jobs in the device.
      */
     GetRecordingJobs() {
-        return Recording.GetRecordingJobs().run(this.config)
+        return ONVIFRecording.GetRecordingJobs().run(this.config)
     }
 
     /**
@@ -386,14 +386,14 @@ export class Recording {
      *   
      */
     SetRecordingJobConfiguration(JobToken: RecordingJobReference, JobConfiguration: RecordingJobConfiguration) {
-        return Recording.SetRecordingJobConfiguration(JobToken,JobConfiguration).run(this.config)
+        return ONVIFRecording.SetRecordingJobConfiguration(JobToken,JobConfiguration).run(this.config)
     }
 
     /**
      * GetRecordingJobConfiguration shall return the current configuration for a recording job.
      */
     GetRecordingJobConfiguration(JobToken: RecordingJobReference) {
-        return Recording.GetRecordingJobConfiguration(JobToken).run(this.config)
+        return ONVIFRecording.GetRecordingJobConfiguration(JobToken).run(this.config)
     }
 
     /**
@@ -402,7 +402,7 @@ export class Recording {
      *   mode.
      */
     SetRecordingJobMode(JobToken: RecordingJobReference, Mode: RecordingJobMode) {
-        return Recording.SetRecordingJobMode(JobToken,Mode).run(this.config)
+        return ONVIFRecording.SetRecordingJobMode(JobToken,Mode).run(this.config)
     }
 
     /**
@@ -410,7 +410,7 @@ export class Recording {
      *   and state for each track of the recording job.
      */
     GetRecordingJobState(JobToken: RecordingJobReference) {
-        return Recording.GetRecordingJobState(JobToken).run(this.config)
+        return ONVIFRecording.GetRecordingJobState(JobToken).run(this.config)
     }
 
     /**
@@ -419,7 +419,7 @@ export class Recording {
      *   
      */
     ExportRecordedData(SearchScope: SearchScope, FileFormat: string, StorageDestination: StorageReferencePath, StartPoint: string, EndPoint: string) {
-        return Recording.ExportRecordedData(SearchScope,FileFormat,StorageDestination,StartPoint,EndPoint).run(this.config)
+        return ONVIFRecording.ExportRecordedData(SearchScope,FileFormat,StorageDestination,StartPoint,EndPoint).run(this.config)
     }
 
     /**
@@ -428,7 +428,7 @@ export class Recording {
      *   
      */
     StopExportRecordedData(OperationToken: ReferenceToken) {
-        return Recording.StopExportRecordedData(OperationToken).run(this.config)
+        return ONVIFRecording.StopExportRecordedData(OperationToken).run(this.config)
     }
 
     /**
@@ -437,6 +437,6 @@ export class Recording {
      *   
      */
     GetExportRecordedDataState(OperationToken: ReferenceToken) {
-        return Recording.GetExportRecordedDataState(OperationToken).run(this.config)
+        return ONVIFRecording.GetExportRecordedDataState(OperationToken).run(this.config)
     }
 }

--- a/src/api/replay.ts
+++ b/src/api/replay.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { StreamSetup, ReferenceToken, ReplayConfiguration } from "./types";
 
-export class Replay {
+export class ONVIFReplay {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -57,7 +57,7 @@ export class Replay {
      * Returns the capabilities of the replay service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Replay.GetServiceCapabilities().run(this.config)
+        return ONVIFReplay.GetServiceCapabilities().run(this.config)
     }
 
     /**
@@ -69,7 +69,7 @@ export class Replay {
      *   
      */
     GetReplayUri(StreamSetup: StreamSetup, RecordingToken: ReferenceToken) {
-        return Replay.GetReplayUri(StreamSetup,RecordingToken).run(this.config)
+        return ONVIFReplay.GetReplayUri(StreamSetup,RecordingToken).run(this.config)
     }
 
     /**
@@ -79,7 +79,7 @@ export class Replay {
      *   
      */
     GetReplayConfiguration() {
-        return Replay.GetReplayConfiguration().run(this.config)
+        return ONVIFReplay.GetReplayConfiguration().run(this.config)
     }
 
     /**
@@ -89,6 +89,6 @@ export class Replay {
      *   
      */
     SetReplayConfiguration(Configuration: ReplayConfiguration) {
-        return Replay.SetReplayConfiguration(Configuration).run(this.config)
+        return ONVIFReplay.SetReplayConfiguration(Configuration).run(this.config)
     }
 }

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -2,7 +2,7 @@ import { createStandardRequestBodyFromString, mapResponseXmlToJson, generateRequ
 import { IDeviceConfig } from "../config";
 import { RecordingReference, SearchScope, JobToken, EventFilter, PTZPositionFilter, MetadataFilter } from "./types";
 
-export class Search {
+export class ONVIFSearch {
     constructor(private config: IDeviceConfig) {
     }
 
@@ -250,7 +250,7 @@ export class Search {
      * Returns the capabilities of the search service. The result is returned in a typed answer.
      */
     GetServiceCapabilities() {
-        return Search.GetServiceCapabilities().run(this.config)
+        return ONVIFSearch.GetServiceCapabilities().run(this.config)
     }
 
     /**
@@ -258,7 +258,7 @@ export class Search {
      *   operation is mandatory to support for a device implementing the recording search service.
      */
     GetRecordingSummary() {
-        return Search.GetRecordingSummary().run(this.config)
+        return ONVIFSearch.GetRecordingSummary().run(this.config)
     }
 
     /**
@@ -266,7 +266,7 @@ export class Search {
      *   is mandatory to support for a device implementing the recording search service.
      */
     GetRecordingInformation(RecordingToken: RecordingReference) {
-        return Search.GetRecordingInformation(RecordingToken).run(this.config)
+        return ONVIFSearch.GetRecordingInformation(RecordingToken).run(this.config)
     }
 
     /**
@@ -278,7 +278,7 @@ export class Search {
      *   recording search service.
      */
     GetMediaAttributes(Time: string, RecordingTokens: RecordingReference) {
-        return Search.GetMediaAttributes(Time,RecordingTokens).run(this.config)
+        return ONVIFSearch.GetMediaAttributes(Time,RecordingTokens).run(this.config)
     }
 
     /**
@@ -297,7 +297,7 @@ export class Search {
      *   search service.
      */
     FindRecordings(Scope: SearchScope, KeepAliveTime: string, MaxMatches: number) {
-        return Search.FindRecordings(Scope,KeepAliveTime,MaxMatches).run(this.config)
+        return ONVIFSearch.FindRecordings(Scope,KeepAliveTime,MaxMatches).run(this.config)
     }
 
     /**
@@ -316,7 +316,7 @@ export class Search {
      *   This operation is mandatory to support for a device implementing the recording search service.
      */
     GetRecordingSearchResults(SearchToken: JobToken, MinResults: number, MaxResults: number, WaitTime: string) {
-        return Search.GetRecordingSearchResults(SearchToken,MinResults,MaxResults,WaitTime).run(this.config)
+        return ONVIFSearch.GetRecordingSearchResults(SearchToken,MinResults,MaxResults,WaitTime).run(this.config)
     }
 
     /**
@@ -337,7 +337,7 @@ export class Search {
      *   recording search service.
      */
     FindEvents(StartPoint: string, Scope: SearchScope, SearchFilter: EventFilter, IncludeStartState: boolean, KeepAliveTime: string, EndPoint: string, MaxMatches: number) {
-        return Search.FindEvents(StartPoint,Scope,SearchFilter,IncludeStartState,KeepAliveTime,EndPoint,MaxMatches).run(this.config)
+        return ONVIFSearch.FindEvents(StartPoint,Scope,SearchFilter,IncludeStartState,KeepAliveTime,EndPoint,MaxMatches).run(this.config)
     }
 
     /**
@@ -355,7 +355,7 @@ export class Search {
      *   This operation is mandatory to support for a device implementing the recording search service.
      */
     GetEventSearchResults(SearchToken: JobToken, MinResults: number, MaxResults: number, WaitTime: string) {
-        return Search.GetEventSearchResults(SearchToken,MinResults,MaxResults,WaitTime).run(this.config)
+        return ONVIFSearch.GetEventSearchResults(SearchToken,MinResults,MaxResults,WaitTime).run(this.config)
     }
 
     /**
@@ -375,7 +375,7 @@ export class Search {
      *   track in any recording on the device.
      */
     FindPTZPosition(StartPoint: string, Scope: SearchScope, SearchFilter: PTZPositionFilter, KeepAliveTime: string, EndPoint: string, MaxMatches: number) {
-        return Search.FindPTZPosition(StartPoint,Scope,SearchFilter,KeepAliveTime,EndPoint,MaxMatches).run(this.config)
+        return ONVIFSearch.FindPTZPosition(StartPoint,Scope,SearchFilter,KeepAliveTime,EndPoint,MaxMatches).run(this.config)
     }
 
     /**
@@ -394,14 +394,14 @@ export class Search {
      *   track in any recording on the device.
      */
     GetPTZPositionSearchResults(SearchToken: JobToken, MinResults: number, MaxResults: number, WaitTime: string) {
-        return Search.GetPTZPositionSearchResults(SearchToken,MinResults,MaxResults,WaitTime).run(this.config)
+        return ONVIFSearch.GetPTZPositionSearchResults(SearchToken,MinResults,MaxResults,WaitTime).run(this.config)
     }
 
     /**
      * GetSearchState returns the current state of the specified search session. This command is deprecated .
      */
     GetSearchState(SearchToken: JobToken) {
-        return Search.GetSearchState(SearchToken).run(this.config)
+        return ONVIFSearch.GetSearchState(SearchToken).run(this.config)
     }
 
     /**
@@ -416,7 +416,7 @@ export class Search {
      *   
      */
     EndSearch(SearchToken: JobToken) {
-        return Search.EndSearch(SearchToken).run(this.config)
+        return ONVIFSearch.EndSearch(SearchToken).run(this.config)
     }
 
     /**
@@ -436,7 +436,7 @@ export class Search {
      *   SearchCapabilities structure return by the GetCapabilities command in the Device service.
      */
     FindMetadata(StartPoint: string, Scope: SearchScope, MetadataFilter: MetadataFilter, KeepAliveTime: string, EndPoint: string, MaxMatches: number) {
-        return Search.FindMetadata(StartPoint,Scope,MetadataFilter,KeepAliveTime,EndPoint,MaxMatches).run(this.config)
+        return ONVIFSearch.FindMetadata(StartPoint,Scope,MetadataFilter,KeepAliveTime,EndPoint,MaxMatches).run(this.config)
     }
 
     /**
@@ -455,6 +455,6 @@ export class Search {
      *   SearchCapabilities structure return by the GetCapabilities command in the Device service.
      */
     GetMetadataSearchResults(SearchToken: JobToken, MinResults: number, MaxResults: number, WaitTime: string) {
-        return Search.GetMetadataSearchResults(SearchToken,MinResults,MaxResults,WaitTime).run(this.config)
+        return ONVIFSearch.GetMetadataSearchResults(SearchToken,MinResults,MaxResults,WaitTime).run(this.config)
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './manage'
 export * from './api'
+export * from './api/types'


### PR DESCRIPTION
BREAKING CHANGE: in order to generate classes that do not conflict with types, classes are now prefixed with "ONVIF"