### PR TITLE
New Types and Parameter Handling

### DIFF
--- a/scripts/api/ast.ts
+++ b/scripts/api/ast.ts
@@ -149,7 +149,8 @@ generateTypes()
               parameters: action.input.parameters.map(p => {
                 return {
                   name: p.name,
-                  type: p.propertyType
+                  type: p.propertyType,
+                  hasQuestionToken: p.propertyMinOccurs === '0'
                 }
               })
             }

--- a/scripts/api/ast.ts
+++ b/scripts/api/ast.ts
@@ -104,7 +104,7 @@ generateTypes()
             ]
           }, [] as ReadonlyArray<string>)
             .filter((elem, pos, arr) => arr.indexOf(elem) == pos)
-            .filter(a => !['string', 'number', 'any', 'boolean'].some(b => b === a))
+            .filter(a => !['string', 'number', 'any', 'boolean', ''].some(b => b === a))
             .map(name => ({ name }))
         }],
         classes: [{
@@ -123,7 +123,7 @@ generateTypes()
             }, {} as any)
 
             const d = JSON.stringify(ps).replace(/"/g, '')
-            
+
             return {
               isStatic: true,
               docs: [{ description: action.documentation.replace(/\*/g, '') }],

--- a/scripts/api/fetch-wsdl.ts
+++ b/scripts/api/fetch-wsdl.ts
@@ -55,7 +55,9 @@ export const fetchXsd = () =>
     // 'https://www.onvif.org/ver20/analytics/rules.xsd',
     'https://www.onvif.org/ver10/schema/common.xsd',
     'https://www.onvif.org/ver10/schema/onvif.xsd',
-    'http://schemas.xmlsoap.org/soap/envelope/'
+    'http://schemas.xmlsoap.org/soap/envelope/',
+    'https://www.onvif.org/ver10/events/wsdl/event.wsdl',
+    'https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl'
   ]
     .map(url => fetch(url)
       .then(res => res.text())

--- a/scripts/api/parse-onvif-xsd.ts
+++ b/scripts/api/parse-onvif-xsd.ts
@@ -8,15 +8,13 @@ export const typeConvert = (val: string) => {
     case 'token': return 'string'
     case 'hexBinary': return 'string'
     case 'anyURI': return 'string'
+    case 'anyType': return 'any'
     case 'base64Binary': return 'string'
     case 'duration': return 'string'
     case 'IANA-IfTypes': return 'any'
     case 'dateTime': return 'string'
     case 'FilterType': return 'any'
     case 'QName': return 'any'
-    case 'NotificationMessageHolderType': return 'any'
-    case 'StorageConfigurationData': return 'any'
-    case 'StorageConfiguration': return 'any'
     default: return val
   }
 }
@@ -33,7 +31,7 @@ export interface ParsedXsd {
 export const parseOnvifXsdForTypeInfo = (xmlDoc: Document): ParsedXsd => {
   const NS = xmlDoc.documentElement.lookupNamespaceURI('xs') || xmlDoc.documentElement.lookupNamespaceURI('xsd') || ''
   const sts = Array.from(xmlDoc.getElementsByTagNameNS(NS, 'simpleType'))
-  
+
   const enumTypes = sts.filter(s => Array.from(s.getElementsByTagNameNS(NS, 'enumeration')).length)
   const simpleTypes = sts.filter(s => Array.from(s.getElementsByTagNameNS(NS, 'enumeration')).length === 0)
 

--- a/src/soap/request.ts
+++ b/src/soap/request.ts
@@ -118,6 +118,7 @@ export interface IXmlContainer {
 }
 
 export const generateRequestElements = (reqNode: string) => (params: any) => {
+  Object.keys(params).forEach(key => params[key] === undefined ? delete params[key] : {});
   return js2xml({[reqNode.replace(':', '_')]: params}, {
     compact: true,
     elementNameFn: (value) => value.indexOf('_') > 0 ? value.replace('_', ':') : 'tt:' + value

--- a/src/soap/request.ts
+++ b/src/soap/request.ts
@@ -3,7 +3,7 @@ import { IDeviceConfig, ITransportPayoad } from '../config/interfaces'
 import { Observable, from } from 'rxjs'
 import { map, flatMap } from 'rxjs/operators'
 import { createUserToken } from './auth'
-import { xml2json } from 'xml-js'
+import { xml2json, js2xml } from 'xml-js'
 
 export interface IResultStructure<T> {
   readonly json: T
@@ -118,23 +118,14 @@ export interface IXmlContainer {
 }
 
 export const generateRequestElements = (reqNode: string) => (params: any) => {
-  const reducer = (obj: any) => (base: string) => (value?: string): any => Object
-    .keys(obj)
-    .reduce((acc, key) => {
-      const modded = key.includes('_')
-        ? key.replace('_', ':')
-        : `tt:${key}`
-
-      const value = typeof obj[key] === 'string'
-        ? obj[key]
-        : undefined
-
-      return value
-        ? acc.replace('><', `><${modded}>${value}</${modded}><`)
-        : acc.replace('><', '>' + reducer(obj[key])(modded)() + '<')
-    }, value ? `<${base}>${value}</${base}>` : `<${base}></${base}>`)
-
-  return reducer(params)(reqNode)()
+  const result = js2xml({[reqNode.replace(':', '_')]: params}, {
+    compact: true,
+    elementNameFn: (value) => {
+      const res = value.indexOf('_') > 0 ? value.replace('_', ':') : 'tt:' + value
+      return res
+    }
+  })
+  return result
 }
 
 export const createStandardRequestBody =

--- a/src/soap/request.ts
+++ b/src/soap/request.ts
@@ -118,14 +118,10 @@ export interface IXmlContainer {
 }
 
 export const generateRequestElements = (reqNode: string) => (params: any) => {
-  const result = js2xml({[reqNode.replace(':', '_')]: params}, {
+  return js2xml({[reqNode.replace(':', '_')]: params}, {
     compact: true,
-    elementNameFn: (value) => {
-      const res = value.indexOf('_') > 0 ? value.replace('_', ':') : 'tt:' + value
-      return res
-    }
+    elementNameFn: (value) => value.indexOf('_') > 0 ? value.replace('_', ':') : 'tt:' + value
   })
-  return result
 }
 
 export const createStandardRequestBody =


### PR DESCRIPTION
This is a follow up PR to this  #45 .

It tries to address a few issues in generating soap/xml when sending requests to devices by using the same library that parses xml to parse the json from function calls. The revised function fixes two issues:

- Optional parameters that are passed from the calling function are stripped out if they are undefined. Previously, this was an issue because the function could not call `Object.keys` on the undefined properties. Now, it avoid empty nodes in the request like `<tt:ProfileToken/>`.
- Parameters passed in that are complete objects can now have attributes that are properly generated. This results in strings like `<trt:Configuration token="0">`. Attributes are specified just like they are parsed; in a `_attributes` property. This is important for some functions like Media.SetVideoEndocoderConfiguration which expect the 'token' to be passed as an attribute. 

Additionally, it fixes some issues with type definitions by parsing types from the WSDLs. Some of the types used by ONVIF are only defined in the WSDL under schemas and not in the XSDs.