### PR TITLE
fix: cast statusMessage to string and avoid trim error

### DIFF
--- a/src/soap/request.ts
+++ b/src/soap/request.ts
@@ -142,7 +142,7 @@ export const createStandardRequestBody =
             ? ok<IXmlContainer, ITransportPayoad>({ xmlString: response.body, xmlDocument })
             : fail<IXmlContainer, ITransportPayoad>({
               ...response,
-              statusMessage: (reason.valueOrUndefined() || subcode.valueOr(response.statusMessage)).trim()
+              statusMessage: (reason.valueOrUndefined() || subcode.valueOr(JSON.stringify(response.statusMessage))).trim()
             })
         }))
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19707386/147421140-02cdb13f-57c3-4e8f-94e3-935926435531.png)
